### PR TITLE
Add thread safety tests and Linux shims

### DIFF
--- a/Sources/StateGraph/Counter.swift
+++ b/Sources/StateGraph/Counter.swift
@@ -1,5 +1,7 @@
 import Synchronization
+#if canImport(os.lock)
 import os.lock
+#endif
 
 private let count_old: OSAllocatedUnfairLock<UInt64> = .init(
   uncheckedState: 0

--- a/Sources/StateGraph/Logger.swift
+++ b/Sources/StateGraph/Logger.swift
@@ -1,4 +1,15 @@
+#if canImport(os.log)
 import os.log
+#else
+struct Logger {
+  init(_ log: OSLog) {}
+  func debug(_ message: String) {}
+}
+struct OSLog {
+  static let disabled = OSLog()
+  init(subsystem: String = "", category: String = "") {}
+}
+#endif
 
 enum Log {
   
@@ -6,8 +17,9 @@ enum Log {
   
 }
 
+#if canImport(os.log)
 extension OSLog {
-  
+
   @inline(__always)
   fileprivate static func makeOSLogInDebug(isEnabled: Bool = true, _ factory: () -> OSLog) -> OSLog {
 #if DEBUG
@@ -16,5 +28,12 @@ extension OSLog {
     return .disabled
 #endif
   }
-  
+
 }
+#else
+extension OSLog {
+  static func makeOSLogInDebug(isEnabled: Bool = true, _ factory: () -> OSLog) -> OSLog {
+    return OSLog()
+  }
+}
+#endif

--- a/Sources/StateGraph/Macro.swift
+++ b/Sources/StateGraph/Macro.swift
@@ -15,11 +15,16 @@ public macro GraphComputed() = #externalMacro(module: "StateGraphMacro", type: "
 @attached(peer)
 public macro GraphIgnored() = #externalMacro(module: "StateGraphMacro", type: "IgnoredMacro")
 
+import Foundation
+
+#if canImport(os.lock)
 @_exported import os.lock
+#endif
 
 #if DEBUG
-
+#if canImport(os.lock)
 import os.lock
+#endif
 
 final class ImplicitInitializers {
   @GraphStored

--- a/Sources/StateGraph/Node+Observe.swift
+++ b/Sources/StateGraph/Node+Observe.swift
@@ -180,7 +180,29 @@ extension Node {
 
 // MARK: - Internals
 
+#if canImport(Combine)
 @_exported @preconcurrency import class Combine.AnyCancellable
+#else
+public final class AnyCancellable: @unchecked Sendable, Hashable {
+  private let onCancel: () -> Void
+
+  public init(_ onCancel: @escaping () -> Void = {}) {
+    self.onCancel = onCancel
+  }
+
+  public func cancel() {
+    onCancel()
+  }
+
+  public static func == (lhs: AnyCancellable, rhs: AnyCancellable) -> Bool {
+    return lhs === rhs
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
+  }
+}
+#endif
 
 final class Subscriptions: Sendable, Hashable {
   

--- a/Sources/StateGraph/OSLockShim.swift
+++ b/Sources/StateGraph/OSLockShim.swift
@@ -1,0 +1,30 @@
+#if !canImport(os.lock)
+import Foundation
+
+public final class OSAllocatedUnfairLock<State>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var state: State
+
+  public init(initialState: State) {
+    self.state = initialState
+  }
+
+  public init(uncheckedState: State) {
+    self.state = uncheckedState
+  }
+
+  @discardableResult
+  public func withLock<R>(_ body: (inout State) -> R) -> R {
+    lock.lock()
+    defer { lock.unlock() }
+    return body(&state)
+  }
+
+  @discardableResult
+  public func withLockUnchecked<R>(_ body: (inout State) -> R) -> R {
+    lock.lock()
+    defer { lock.unlock() }
+    return body(&state)
+  }
+}
+#endif

--- a/Sources/StateGraph/StateGraph.swift
+++ b/Sources/StateGraph/StateGraph.swift
@@ -1,4 +1,4 @@
-import Foundation.NSLock
+import Foundation
 
 #if canImport(Observation)
   import Observation

--- a/Tests/StateGraphTests/ConcurrencyTests.swift
+++ b/Tests/StateGraphTests/ConcurrencyTests.swift
@@ -1,5 +1,7 @@
 import XCTest
+#if canImport(os.lock)
 import os.lock
+#endif
 
 @testable import StateGraph
 

--- a/Tests/StateGraphTests/ThreadSafetyTests.swift
+++ b/Tests/StateGraphTests/ThreadSafetyTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+#if canImport(os.lock)
+import os.lock
+#endif
+
+@testable import StateGraph
+
+final class ThreadSafetyTests: XCTestCase {
+
+  func testConcurrentDynamicDependencyChange() async throws {
+    let toggle = Stored(name: "toggle", wrappedValue: false)
+    let a = Stored(name: "a", wrappedValue: 0)
+    let b = Stored(name: "b", wrappedValue: 0)
+
+    let computed = Computed(name: "computed") { _ in
+      toggle.wrappedValue ? a.wrappedValue : b.wrappedValue
+    }
+
+    await withTaskGroup(of: Void.self) { group in
+      for i in 0..<200 {
+        group.addTask {
+          if i % 3 == 0 {
+            toggle.wrappedValue.toggle()
+          } else if i % 3 == 1 {
+            a.wrappedValue += 1
+          } else {
+            b.wrappedValue += 1
+          }
+          _ = computed.wrappedValue
+        }
+      }
+    }
+
+    let expected = toggle.wrappedValue ? a.wrappedValue : b.wrappedValue
+    XCTAssertEqual(computed.wrappedValue, expected)
+  }
+
+  func testMassiveParallelGraphUpdates() async throws {
+    let sources = (0..<20).map { Stored(name: "s\($0)", wrappedValue: 0) }
+    let computed = Computed(name: "sum") { _ in
+      sources.reduce(0) { $0 + $1.wrappedValue }
+    }
+
+    await withTaskGroup(of: Void.self) { group in
+      for _ in 0..<1000 {
+        group.addTask {
+          let idx = Int.random(in: 0..<sources.count)
+          sources[idx].wrappedValue += 1
+          if Bool.random() {
+            _ = computed.wrappedValue
+          }
+        }
+      }
+    }
+
+    let expectedSum = sources.reduce(0) { $0 + $1.wrappedValue }
+    XCTAssertEqual(computed.wrappedValue, expectedSum)
+  }
+}


### PR DESCRIPTION
## Summary
- add a shim for `OSAllocatedUnfairLock` when `os.lock` is unavailable
- stub out `AnyCancellable` when `Combine` is missing
- fix imports so the package builds on Linux
- add complex thread‑safety tests exercising dynamic dependencies and high concurrency

## Testing
- `swift test -l`
- `swift test`