### PR TITLE
Add build check for Development project

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,3 +16,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run Test
         run: swift test
+
+  build-development:
+    runs-on: macos-15
+
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1.1
+        with:
+          xcode-version: "16.2"
+      - uses: actions/checkout@v4
+      - name: Build Development project
+        run: |
+          xcodebuild \
+            -project Development/Development.xcodeproj \
+            -scheme Development \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO build


### PR DESCRIPTION
## Summary
- enhance workflow with job to build the `Development` app

## Testing
- `swift test` *(fails: no such module 'os.lock')*