### PR TITLE
Refactor macro helper

### DIFF
--- a/Sources/StateGraphMacro/Extension.swift
+++ b/Sources/StateGraphMacro/Extension.swift
@@ -96,9 +96,7 @@ extension VariableDeclSyntax {
       return binding
     }
         
-    return self.with(\.bindings, .init(self.bindings.map {
-      $0.with(\.initializer, initializer)
-    }))
+    return self.with(\.bindings, .init(newBindings))
     
   }
 

--- a/Sources/StateGraphMacro/Plugin.swift
+++ b/Sources/StateGraphMacro/Plugin.swift
@@ -10,6 +10,5 @@ struct Plugin: CompilerPlugin {
     StoredMacro.self,
     ComputedMacro.self,
     IgnoredMacro.self,
-    ComputedMacro.self,
   ]
 }


### PR DESCRIPTION
## Summary
- fix `providingMacros` in macro plugin
- return new initializer bindings in helper method

## Testing
- `swift test` *(fails: no such module 'os.lock')*