### PR TITLE
Add SPI manifest

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,11 @@
+# This is manifest file for the Swift Package Index for it to auto-generate and
+# host DocC documentation.
+#
+# For reference see https://swiftpackageindex.com/swiftpackageindex/spimanifest/documentation/spimanifest/commonusecases#Host-DocC-documentation-in-the-Swift-Package-Index
+version: 1
+builder:
+  configs:
+    - documentation_targets:
+      # First item in the list is the "landing" (default) target
+      - StateGraph
+      - StateGraphNormalization


### PR DESCRIPTION
## Summary
- add `.spi.yml` so Swift Package Index can host DocC documentation

## Testing
- `swift test` *(fails: no such module 'os.lock')*