### PR TITLE
Add build check for Development project

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,9 +15,7 @@ jobs:
           xcode-version: "16.2"
       - uses: actions/checkout@v4
       - name: Run Test
-        env:
-          SWIFTPM_ENABLE_PLUGINS: 1
-        run: swift test --enable-all-traits
+        run: swift test
 
   build-development:
     runs-on: macos-15
@@ -28,8 +26,6 @@ jobs:
           xcode-version: "16.2"
       - uses: actions/checkout@v4
       - name: Build Development project
-        env:
-          SWIFTPM_ENABLE_PLUGINS: 1
         run: |
           xcodebuild \
             -skipMacroValidation \

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,4 +15,26 @@ jobs:
           xcode-version: "16.2"
       - uses: actions/checkout@v4
       - name: Run Test
-        run: swift test
+        env:
+          SWIFTPM_ENABLE_PLUGINS: 1
+        run: swift test --enable-all-traits
+
+  build-development:
+    runs-on: macos-15
+
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1.1
+        with:
+          xcode-version: "16.2"
+      - uses: actions/checkout@v4
+      - name: Build Development project
+        env:
+          SWIFTPM_ENABLE_PLUGINS: 1
+        run: |
+          xcodebuild \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            -project Development/Development.xcodeproj \
+            -scheme Development \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO build


### PR DESCRIPTION
## Summary
- enhance workflow with job to build the `Development` app
- enable macros in CI and skip plugin validation when building the Xcode project

## Testing
- `swift test --enable-all-traits` *(fails: no such module 'os.lock')*