### PR TITLE
Bump TypedIdentifier

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/VergeGroup/swift-typed-identifier.git",
       "state" : {
-        "revision" : "284340409ba47858a1b3c353dcef9c21303953db",
-        "version" : "2.0.3"
+        "revision" : "ea7afa2ce943c6bf3ef87d385c8a6e9f67fea4f3",
+        "version" : "2.0.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/VergeGroup/swift-typed-identifier.git", from: "2.0.3"),
+    .package(url: "https://github.com/VergeGroup/swift-typed-identifier.git", from: "2.0.4"),
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"602.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.5.2"),
   ],


### PR DESCRIPTION
## Summary
- update TypedIdentifier dependency to version 2.0.4

## Testing
- `swift test -c release` *(fails: Couldn't connect to server)*