### PR TITLE
Refactor UnifiedStoredMacro and fix private(set) handling

### DIFF
--- a/Tests/StateGraphMacroTests/UnifiedStoredMacroTests.swift
+++ b/Tests/StateGraphMacroTests/UnifiedStoredMacroTests.swift
@@ -5,6 +5,17 @@ import XCTest
 @testable import StateGraphMacro
 
 final class UnifiedStoredMacroTests: XCTestCase {
+    
+  override func invokeTest() {
+    withMacroTesting(
+      record: false,
+      macros: [
+        "GraphStored": UnifiedStoredMacro.self,
+      ]
+    ) {
+      super.invokeTest()
+    }
+  }
   
   func test_private_set_modifier() {
     assertMacro {
@@ -31,7 +42,9 @@ final class UnifiedStoredMacroTests: XCTestCase {
             $value.wrappedValue = newValue
           }
         }
-        @GraphIgnored private let $value: Stored<Int> = .init(name: "value", wrappedValue: 0)
+
+        @GraphIgnored
+          private let $value: Stored<Int> = .init(name: "value", wrappedValue: 0)
       }
       """
     }
@@ -62,20 +75,11 @@ final class UnifiedStoredMacroTests: XCTestCase {
             $value.wrappedValue = newValue
           }
         }
-        @GraphIgnored private let $value: Stored<Int> = .init(name: "value", wrappedValue: 0)
+
+        @GraphIgnored
+          private let $value: Stored<Int> = .init(name: "value", wrappedValue: 0)
       }
       """
-    }
-  }
-  
-  override func invokeTest() {
-    withMacroTesting(
-      record: false,
-      macros: [
-        "GraphStored": UnifiedStoredMacro.self,
-      ]
-    ) {
-      super.invokeTest()
     }
   }
 

--- a/Tests/StateGraphMacroTests/UnifiedStoredMacroTests.swift
+++ b/Tests/StateGraphMacroTests/UnifiedStoredMacroTests.swift
@@ -6,6 +6,68 @@ import XCTest
 
 final class UnifiedStoredMacroTests: XCTestCase {
   
+  func test_private_set_modifier() {
+    assertMacro {
+      """
+      final class Model {
+        @GraphStored
+        private(set) var value: Int = 0
+      }
+      """
+    } expansion: {
+      """
+      final class Model {
+        private(set) var value: Int {
+          @storageRestrictions(
+            accesses: $value
+          )
+          init(initialValue) {
+            $value.wrappedValue = initialValue
+          }
+          get {
+            return $value.wrappedValue
+          }
+          set {
+            $value.wrappedValue = newValue
+          }
+        }
+        @GraphIgnored private let $value: Stored<Int> = .init(name: "value", wrappedValue: 0)
+      }
+      """
+    }
+  }
+  
+  func test_private_modifier() {
+    assertMacro {
+      """
+      final class Model {
+        @GraphStored
+        private var value: Int = 0
+      }
+      """
+    } expansion: {
+      """
+      final class Model {
+        private var value: Int {
+          @storageRestrictions(
+            accesses: $value
+          )
+          init(initialValue) {
+            $value.wrappedValue = initialValue
+          }
+          get {
+            return $value.wrappedValue
+          }
+          set {
+            $value.wrappedValue = newValue
+          }
+        }
+        @GraphIgnored private let $value: Stored<Int> = .init(name: "value", wrappedValue: 0)
+      }
+      """
+    }
+  }
+  
   override func invokeTest() {
     withMacroTesting(
       record: false,

--- a/Tests/StateGraphTests/Syntax.swift
+++ b/Tests/StateGraphTests/Syntax.swift
@@ -24,6 +24,16 @@ final class UserDefaultsModel {
   
 }
 
+final class PrivateExample {
+  
+  @GraphStored 
+  private var private_value: Int = 0
+  
+  @GraphStored 
+  private(set) var _private_set_value: Int = 0
+  
+}
+
 // MARK: - Unified Syntax Demo
 
 final class UnifiedSyntaxDemo {


### PR DESCRIPTION
## Summary
- Refactored UnifiedStoredMacro for better code organization and maintainability
- Fixed issue where `private(set)` modifier was incorrectly applied to generated storage properties

## Changes

### Bug Fix
- Fixed `private(set)` modifier handling in `inheritAccessControl` method
- Now correctly strips the `(set)` detail from access modifiers when generating the storage property
- Example: `private(set) var value` now generates `private let $value` instead of `private(set) let $value`

### Refactoring
1. **Extracted common weak/unowned handling**:
   - Added `needsValueAccess()` helper
   - Added `createWrapperInitExpression()` helper
   - Added `createValueAccessExpression()` helper
   - Eliminated duplicate code across multiple accessor methods

2. **Created reusable accessor generation helpers**:
   - `createStorageRestrictionsInitAccessor()`
   - `createSimpleGetAccessor()`
   - `createSimpleSetAccessor()`

3. **Added InitializerBuilder**:
   - New struct for building storage initializer expressions
   - Cleaner and more declarative initializer generation

4. **Simplified type annotation logic**:
   - Extracted `createMemoryTypeAnnotation()` method
   - More readable conditional logic for different storage types

5. **Reduced nesting in argument parsing**:
   - Extracted `parseBackingExpression()` method
   - Flattened the control flow

## Impact
- No breaking changes to the public API
- Improved code maintainability and readability
- Fixed compilation errors for properties with `private(set)` modifier

🤖 Generated with [Claude Code](https://claude.ai/code)