### PR TITLE
Add actor isolation tests for withGraphTrackingGroup and onChange

### DIFF
--- a/Tests/StateGraphTests/ActorIsolationTests.swift
+++ b/Tests/StateGraphTests/ActorIsolationTests.swift
@@ -1,0 +1,108 @@
+import Testing
+@preconcurrency import StateGraph
+import Foundation
+
+@Suite("Actor Isolation Tests")
+struct ActorIsolationTests {
+  
+  final class ThreadTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _callsOnMainActor: Int = 0
+    private var _callsOnBackground: Int = 0
+    
+    var callsOnMainActor: Int {
+      lock.lock()
+      defer { lock.unlock() }
+      return _callsOnMainActor
+    }
+    
+    var callsOnBackground: Int {
+      lock.lock()
+      defer { lock.unlock() }
+      return _callsOnBackground
+    }
+    
+    func recordCall() {
+      lock.lock()
+      defer { lock.unlock() }
+      
+      if Thread.isMainThread {
+        _callsOnMainActor += 1
+      } else {
+        _callsOnBackground += 1
+      }
+    }
+    
+    func reset() {
+      lock.lock()
+      defer { lock.unlock() }
+      _callsOnMainActor = 0
+      _callsOnBackground = 0
+    }
+  }
+  
+  @Test @MainActor
+  func withGraphTrackingGroupPreservesMainActorIsolation() async throws {
+    let node = Stored(wrappedValue: 0)
+    let tracker = ThreadTracker()
+    
+    // Start withGraphTrackingGroup on MainActor
+    let cancellable = withGraphTracking {
+      withGraphTrackingGroup {
+        tracker.recordCall()
+        print("=== withGraphTrackingGroup called, value: \(node.wrappedValue), isMainThread: \(Thread.isMainThread) ===")
+        _ = node.wrappedValue // Track the node
+      }
+    }
+    
+    // Initial call should be on MainActor
+    #expect(tracker.callsOnMainActor == 1)
+    #expect(tracker.callsOnBackground == 0)
+    
+    // Update from background thread
+    await Task.detached {
+      node.wrappedValue = 1
+    }.value
+    
+    try await Task.sleep(nanoseconds: 200_000_000)
+    
+    // The handler should still be called on MainActor even though update came from background
+    #expect(tracker.callsOnMainActor == 2)
+    #expect(tracker.callsOnBackground == 0)
+    
+    cancellable.cancel()
+  }
+  
+  @Test @MainActor
+  func onChangePreservesMainActorIsolation() async throws {
+    let node = Stored(wrappedValue: 0)
+    let tracker = ThreadTracker()
+    
+    // Start onChange on MainActor
+    let cancellable = withGraphTracking {
+      node.onChange { value in
+        tracker.recordCall()
+        print("=== onChange called, value: \(value), isMainThread: \(Thread.isMainThread) ===")
+      }
+    }
+    
+    try await Task.sleep(nanoseconds: 100_000_000)
+    
+    // Initial call should be on MainActor
+    #expect(tracker.callsOnMainActor == 1)
+    #expect(tracker.callsOnBackground == 0)
+    
+    // Update from background thread
+    await Task.detached {
+      node.wrappedValue = 1
+    }.value
+    
+    try await Task.sleep(nanoseconds: 200_000_000)
+    
+    // The onChange callback should still be called on MainActor
+    #expect(tracker.callsOnMainActor == 2)
+    #expect(tracker.callsOnBackground == 0)
+    
+    cancellable.cancel()
+  }
+}


### PR DESCRIPTION
## Summary
- Added comprehensive actor isolation tests to verify MainActor context preservation
- Ensures `withGraphTrackingGroup` and `onChange` callbacks execute on MainActor when started from MainActor
- Validates that background thread updates don't break actor isolation guarantees

## Test Coverage
- `withGraphTrackingGroupPreservesMainActorIsolation`: Verifies group tracking maintains MainActor context
- `onChangePreservesMainActorIsolation`: Verifies onChange callbacks maintain MainActor context
- Both tests validate behavior when node updates come from background threads

## Technical Details
- Uses `Thread.isMainThread` to verify execution context
- Tests critical path for UI safety in SwiftUI applications
- Minimal test suite focused on essential actor isolation guarantees

## Test Results
```
✔ Test withGraphTrackingGroupPreservesMainActorIsolation() passed
✔ Test onChangePreservesMainActorIsolation() passed
```

🤖 Generated with [Claude Code](https://claude.ai/code)