### PR TITLE
Include property name in @GraphStored init accessor

### DIFF
--- a/Sources/StateGraphMacro/UnifiedStoredMacro.swift
+++ b/Sources/StateGraphMacro/UnifiedStoredMacro.swift
@@ -693,7 +693,7 @@ extension UnifiedStoredMacro: AccessorMacro {
         initializes: $\(raw: propertyName)
       )
       init(initialValue) {
-        $\(raw: propertyName) = .init(wrappedValue: \(raw: wrappedValue))
+        $\(raw: propertyName) = .init(name: "\(raw: propertyName)", wrappedValue: \(raw: wrappedValue))
       }
       """
     )

--- a/Tests/StateGraphMacroTests/UnifiedStoredMacroTests.swift
+++ b/Tests/StateGraphMacroTests/UnifiedStoredMacroTests.swift
@@ -854,7 +854,7 @@ final class UnifiedStoredMacroTests: XCTestCase {
             initializes: $unowned_variable
           )
           init(initialValue) {
-            $unowned_variable = .init(wrappedValue: .init(initialValue))
+            $unowned_variable = .init(name: "unowned_variable", wrappedValue: .init(initialValue))
           }
           get {
             return $unowned_variable.wrappedValue.value

--- a/Tests/StateGraphTests/StaticPropertyTests.swift
+++ b/Tests/StateGraphTests/StaticPropertyTests.swift
@@ -11,8 +11,8 @@ struct StaticPropertyTests {
     @GraphStored
     var instanceValue: Int = 0
   }
-  
-  @Test func static_property_compilation() {
+    
+  @Test @MainActor func static_property_compilation() {
     // Test if static @GraphStored properties compile and work correctly
     ModelWithStatic.sharedValue = 10
     #expect(ModelWithStatic.sharedValue == 10)
@@ -26,7 +26,7 @@ struct StaticPropertyTests {
     #expect(instance.instanceValue == 5)
   }
   
-  @Test func static_property_reactivity() async {
+  @Test @MainActor func static_property_reactivity() async {
     // Reset static value
     ModelWithStatic.sharedValue = 0
     


### PR DESCRIPTION
## Summary
- Updates the `@GraphStored` macro to include property names when generating init accessors
- Improves debugging and diagnostics by ensuring node names are properly set during initialization

## Changes
The macro now generates:
```swift
init(initialValue) {
  $propertyName = .init(name: "propertyName", wrappedValue: initialValue)
}
```

Instead of:
```swift
init(initialValue) {
  $propertyName = .init(wrappedValue: initialValue)
}
```

## Test plan
- [x] Updated existing test expectations to match the new generated code
- [x] All tests pass
- [x] Verified the generated code includes property names in init accessors

🤖 Generated with [Claude Code](https://claude.ai/code)