### PR TITLE
Add shouldNotifyObservers optimization for Equatable types

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1.1
         with:
-          xcode-version: "26.0"
+          xcode-version: "26.4"
       - uses: actions/checkout@v4
       - name: Run Test
         run: swift test
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1.1
         with:
-          xcode-version: "26.0"
+          xcode-version: "26.4"
       - uses: actions/checkout@v4
       - name: Build Development project
         run: |

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -20,7 +20,7 @@ import Foundation.NSLock
 public typealias Stored<Value> = _Stored<Value, InMemoryStorage<Value>>
 
 extension _Stored where S == InMemoryStorage<Value> {
-  /// 便利な初期化メソッド（wrappedValue指定）
+  /// Convenience initializer with wrappedValue (non-Equatable types)
   public convenience init(
     _ file: StaticString = #fileID,
     _ line: UInt = #line,
@@ -35,6 +35,70 @@ extension _Stored where S == InMemoryStorage<Value> {
       column,
       name: name,
       storage: storage
+    )
+  }
+}
+
+extension _Stored where S == InMemoryStorage<Value>, Value: Equatable {
+  /// Convenience initializer with wrappedValue for Equatable types
+  /// Automatically skips notifications when the value hasn't changed.
+  public convenience init(
+    _ file: StaticString = #fileID,
+    _ line: UInt = #line,
+    _ column: UInt = #column,
+    name: StaticString? = nil,
+    wrappedValue: Value
+  ) {
+    let storage = InMemoryStorage(initialValue: wrappedValue)
+    self.init(
+      file,
+      line,
+      column,
+      name: name,
+      storage: storage
+    )
+  }
+}
+
+extension _Stored where S == InMemoryStorage<Value>, Value: AnyObject {
+  /// Convenience initializer with wrappedValue for reference types
+  /// Automatically skips notifications when the reference identity hasn't changed.
+  public convenience init(
+    _ file: StaticString = #fileID,
+    _ line: UInt = #line,
+    _ column: UInt = #column,
+    name: StaticString? = nil,
+    wrappedValue: Value
+  ) {
+    let storage = InMemoryStorage(initialValue: wrappedValue)
+    self.init(
+      file,
+      line,
+      column,
+      name: name,
+      storage: storage
+    )
+  }
+}
+
+extension _Stored where S == InMemoryStorage<Value>, Value: Equatable & AnyObject {
+  /// Convenience initializer with wrappedValue for Equatable reference types
+  /// Uses value equality (Equatable) rather than reference identity.
+  public convenience init(
+    _ file: StaticString = #fileID,
+    _ line: UInt = #line,
+    _ column: UInt = #column,
+    name: StaticString? = nil,
+    wrappedValue: Value
+  ) {
+    let storage = InMemoryStorage(initialValue: wrappedValue)
+    self.init(
+      file,
+      line,
+      column,
+      name: name,
+      storage: storage,
+      shouldNotify: { $0 != $1 }
     )
   }
 }

--- a/Sources/StateGraph/StorageAbstraction.swift
+++ b/Sources/StateGraph/StorageAbstraction.swift
@@ -133,19 +133,21 @@ public final class UserDefaultsStorage<Value: UserDefaultsStorable>: Storage, Se
 // MARK: - Base Stored Node
 
 public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDebugStringConvertible {
-  
+
   public let lock: NodeLock
-  
+
   nonisolated(unsafe)
   private var storage: S
-  
+
+  private let shouldNotify: @Sendable (Value, Value) -> Bool
+
 #if canImport(Observation)
   @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
   private var observationRegistrar: ObservationRegistrar {
     return .shared
   }
 #endif
-  
+
   public var potentiallyDirty: Bool {
     get {
       return false
@@ -154,18 +156,18 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
       fatalError()
     }
   }
-  
+
   public let info: NodeInfo
-  
+
   public var wrappedValue: Value {
     get {
-      
+
 #if canImport(Observation)
       if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-        observationRegistrar.access(PointerKeyPathRoot.shared, keyPath: _keyPath(self))        
+        observationRegistrar.access(PointerKeyPathRoot.shared, keyPath: _keyPath(self))
       }
 #endif
-      
+
       lock.lock()
       defer { lock.unlock() }
 
@@ -183,6 +185,18 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
       return storage.value
     }
     set {
+      lock.lock()
+
+      let oldValue = storage.value
+
+      // Skip notification if value hasn't changed (like Observation.framework)
+      guard shouldNotify(oldValue, newValue) else {
+        storage.value = newValue
+        let _didSetHandler = didSetHandler
+        lock.unlock()
+        _didSetHandler?(oldValue, newValue)
+        return
+      }
 
 #if canImport(Observation)
       if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
@@ -200,9 +214,6 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
       }
 #endif
 
-      lock.lock()
-
-      let oldValue = storage.value
       storage.value = newValue
 
       let _outgoingEdges = outgoingEdges
@@ -278,7 +289,8 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
     _ line: UInt = #line,
     _ column: UInt = #column,
     name: StaticString? = nil,
-    storage: consuming S
+    storage: consuming S,
+    shouldNotify: @Sendable @escaping (Value, Value) -> Bool = { _, _ in true }
   ) {
     self.info = .init(
       name: name,
@@ -286,11 +298,12 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
     )
     self.lock = .init()
     self.storage = storage
-           
-    self.storage.loaded(context: .init(onStorageUpdated: { [weak self] in      
-      self?.notifyStorageUpdated()      
+    self.shouldNotify = shouldNotify
+
+    self.storage.loaded(context: .init(onStorageUpdated: { [weak self] in
+      self?.notifyStorageUpdated()
     }))
-    
+
 #if DEBUG
     Task {
       await NodeStore.shared.register(node: self)
@@ -341,4 +354,58 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
     self.didSetHandler = handler
   }
 
-} 
+}
+
+// MARK: - Equatable convenience initializer
+
+extension _Stored where Value: Equatable {
+
+  /// Convenience initializer for Equatable types that automatically skips
+  /// notifications when the value hasn't changed.
+  public convenience init(
+    _ file: StaticString = #fileID,
+    _ line: UInt = #line,
+    _ column: UInt = #column,
+    name: StaticString? = nil,
+    storage: consuming S
+  ) {
+    self.init(file, line, column, name: name, storage: storage, shouldNotify: { $0 != $1 })
+  }
+
+}
+
+// MARK: - AnyObject convenience initializer (for non-Equatable reference types)
+
+extension _Stored where Value: AnyObject {
+
+  /// Convenience initializer for reference types that automatically skips
+  /// notifications when the reference identity hasn't changed.
+  public convenience init(
+    _ file: StaticString = #fileID,
+    _ line: UInt = #line,
+    _ column: UInt = #column,
+    name: StaticString? = nil,
+    storage: consuming S
+  ) {
+    self.init(file, line, column, name: name, storage: storage, shouldNotify: { $0 !== $1 })
+  }
+
+}
+
+// MARK: - Equatable & AnyObject convenience initializer (resolve ambiguity)
+
+extension _Stored where Value: Equatable & AnyObject {
+
+  /// Convenience initializer for Equatable reference types.
+  /// Uses value equality (Equatable) rather than reference identity.
+  public convenience init(
+    _ file: StaticString = #fileID,
+    _ line: UInt = #line,
+    _ column: UInt = #column,
+    name: StaticString? = nil,
+    storage: consuming S
+  ) {
+    self.init(file, line, column, name: name, storage: storage, shouldNotify: { $0 != $1 })
+  }
+
+}

--- a/Sources/StateGraph/util.swift
+++ b/Sources/StateGraph/util.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - withMainActor
+
 func withMainActor(_ closure: sending @escaping @MainActor () -> Void) {
   
   if #available(iOS 26, macOS 26, watchOS 26, tvOS 26, *) {

--- a/Tests/StateGraphTests/GraphTrackingMapTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingMapTests.swift
@@ -271,7 +271,9 @@ struct GraphTrackingMapTests {
     let value = Stored(wrappedValue: 10)
     var receivedValues: [Int] = []
 
-    await confirmation(expectedCount: 3) { confirm in
+    // Note: Stored skips notification for same Equatable value,
+    // so even with PassthroughFilter, same value won't trigger notification
+    await confirmation(expectedCount: 2) { confirm in
       let cancellable = withGraphTracking {
         withGraphTrackingMap(
           { value.wrappedValue },
@@ -291,7 +293,7 @@ struct GraphTrackingMapTests {
       }
       try? await Task.sleep(nanoseconds: 100_000_000)
 
-      // Change to same value (PassthroughFilter allows duplicates)
+      // Change to same value - Stored skips notification for Equatable types
       Task {
         value.wrappedValue = 20
       }
@@ -300,7 +302,7 @@ struct GraphTrackingMapTests {
       cancellable.cancel()
     }
 
-    #expect(receivedValues == [10, 20, 20])
+    #expect(receivedValues == [10, 20])
   }
 
 }

--- a/Tests/StateGraphTests/NodeObserveTests.swift
+++ b/Tests/StateGraphTests/NodeObserveTests.swift
@@ -3,14 +3,14 @@ import Testing
 
 @Suite("Stored.observe()")
 struct NodeObserveTests {
-  
+
   @Test
   func basic() async throws {
     let node = Stored(wrappedValue: 0)
     let stream = node.observe()
-          
+
     await confirmation(expectedCount: 2) { c in
-      Task { 
+      Task {
         for try await _ in stream {
           c.confirm()
         }
@@ -20,14 +20,14 @@ struct NodeObserveTests {
       try? await Task.sleep(for: .milliseconds(100))
 
     }
-    
+
   }
-    
+
   @Test("Can observe value changes")
   func testObserveValueChanges() async throws {
     let node = Stored(wrappedValue: 0)
     let stream = node.observe()
-    
+
     let results = OSAllocatedUnfairLock.init(initialState: [Int]())
     let task = Task {
       for try await value in stream {
@@ -35,40 +35,40 @@ struct NodeObserveTests {
         results.withLock { $0.append(value) }
       }
     }
-    
+
     try await Task.sleep(for: .milliseconds(100))
-    
+
     // Initial value is included
     #expect(results.withLock { $0 == [0] })
 
-    
+
     // Change value
     node.wrappedValue = 1
     try await Task.sleep(for: .milliseconds(100))
     #expect(results.withLock { $0 == [0, 1] })
-    
+
     // Change value again
     node.wrappedValue = 2
     try await Task.sleep(for: .milliseconds(100))
     #expect(results.withLock { $0 == [0, 1, 2] })
-    
-    // Even with the same value, change notification is sent
+
+    // Same value should NOT trigger notification (Equatable optimization)
     node.wrappedValue = 2
     try await Task.sleep(for: .milliseconds(100))
-    #expect(results.withLock { $0 == [0, 1, 2, 2] })
-    
+    #expect(results.withLock { $0 == [0, 1, 2] })
+
     task.cancel()
   }
-  
+
   @Test("Can observe complex type value changes")
   func testObserveWithComplexType() async throws {
     struct TestStruct: Equatable {
       var value: Int
     }
-    
+
     let node = Stored(wrappedValue: TestStruct(value: 0))
     let stream = node.observe()
-    
+
     let results = OSAllocatedUnfairLock.init(initialState: [TestStruct]())
     let task = Task {
       for try await value in stream {
@@ -76,74 +76,186 @@ struct NodeObserveTests {
       }
     }
     try await Task.sleep(for: .milliseconds(100))
-    
+
     // Initial value is included
     #expect(results.withLock { $0 == [TestStruct(value: 0)] })
-    
+
     // Change value
     node.wrappedValue = TestStruct(value: 1)
     try await Task.sleep(for: .milliseconds(100))
     #expect(results.withLock { $0 == [TestStruct(value: 0), TestStruct(value: 1)] })
-    
+
     // Change value again
     node.wrappedValue = TestStruct(value: 2)
     try await Task.sleep(for: .milliseconds(100))
     #expect(results.withLock { $0 == [TestStruct(value: 0), TestStruct(value: 1), TestStruct(value: 2)] })
-    
-    // Even with the same value, change notification is sent
+
+    // Same value should NOT trigger notification (Equatable optimization)
     node.wrappedValue = TestStruct(value: 2)
     try await Task.sleep(for: .milliseconds(100))
-    
-    #expect(results.withLock { $0 == [TestStruct(value: 0), TestStruct(value: 1), TestStruct(value: 2), TestStruct(value: 2)] })
-    
+    #expect(results.withLock { $0 == [TestStruct(value: 0), TestStruct(value: 1), TestStruct(value: 2)] })
+
     task.cancel()
   }
-  
+
   @Test("Multiple subscribers can exist simultaneously")
   func testObserveWithMultipleSubscribers() async throws {
     let node = Stored(wrappedValue: 0)
-    
+
     let results1 = OSAllocatedUnfairLock.init(initialState: [Int]())
     let results2 = OSAllocatedUnfairLock.init(initialState: [Int]())
-    
+
     let task1 = Task {
       for try await value in node.observe() {
         results1.withLock { $0.append(value) }
       }
     }
-    
+
     let task2 = Task {
       for try await value in node.observe() {
         results2.withLock { $0.append(value) }
       }
     }
-    
+
     try await Task.sleep(for: .milliseconds(100))
-    
+
     // Initial value is included
     #expect(results1.withLock { $0 == [0] })
     #expect(results2.withLock { $0 == [0] })
-    
+
     // Change value
     node.wrappedValue = 1
     try await Task.sleep(for: .milliseconds(100))
     #expect(results1.withLock { $0 == [0, 1] })
     #expect(results2.withLock { $0 == [0, 1] })
-    
+
     // Change value again
     node.wrappedValue = 2
     try await Task.sleep(for: .milliseconds(100))
     #expect(results1.withLock { $0 == [0, 1, 2] })
     #expect(results2.withLock { $0 == [0, 1, 2] })
-    
-    // Even with the same value, change notification is sent
+
+    // Same value should NOT trigger notification (Equatable optimization)
     node.wrappedValue = 2
     try await Task.sleep(for: .milliseconds(100))
-    #expect(results1.withLock { $0 == [0, 1, 2, 2] })
-    #expect(results2.withLock { $0 == [0, 1, 2, 2] })
-    
+    #expect(results1.withLock { $0 == [0, 1, 2] })
+    #expect(results2.withLock { $0 == [0, 1, 2] })
+
     task1.cancel()
     task2.cancel()
+  }
+
+  @Test("Non-Equatable types always notify on assignment")
+  func testNonEquatableAlwaysNotifies() async throws {
+    // Non-Equatable struct
+    struct NonEquatableStruct: Sendable {
+      var value: Int
+    }
+
+    let node = Stored(wrappedValue: NonEquatableStruct(value: 0))
+    let stream = node.observe()
+
+    let results = OSAllocatedUnfairLock.init(initialState: [Int]())
+    let task = Task {
+      for try await value in stream {
+        results.withLock { $0.append(value.value) }
+      }
+    }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    // Initial value
+    #expect(results.withLock { $0 == [0] })
+
+    // Change value
+    node.wrappedValue = NonEquatableStruct(value: 1)
+    try await Task.sleep(for: .milliseconds(100))
+    #expect(results.withLock { $0 == [0, 1] })
+
+    // Same value - but non-Equatable always notifies
+    node.wrappedValue = NonEquatableStruct(value: 1)
+    try await Task.sleep(for: .milliseconds(100))
+    #expect(results.withLock { $0 == [0, 1, 1] })
+
+    task.cancel()
+  }
+
+  @Test("Reference types skip notification for same reference")
+  func testReferenceTypesSameReference() async throws {
+    final class RefType: @unchecked Sendable {
+      var value: Int
+      init(value: Int) { self.value = value }
+    }
+
+    let obj = RefType(value: 0)
+    let node = Stored(wrappedValue: obj)
+    let stream = node.observe()
+
+    let results = OSAllocatedUnfairLock.init(initialState: [Int]())
+    let task = Task {
+      for try await value in stream {
+        results.withLock { $0.append(value.value) }
+      }
+    }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    // Initial value included
+    #expect(results.withLock { $0 == [0] })
+
+    // Different reference - should notify
+    let obj2 = RefType(value: 1)
+    node.wrappedValue = obj2
+    try await Task.sleep(for: .milliseconds(100))
+    #expect(results.withLock { $0 == [0, 1] })
+
+    // Same reference - should NOT notify
+    node.wrappedValue = obj2
+    try await Task.sleep(for: .milliseconds(100))
+    #expect(results.withLock { $0 == [0, 1] })
+
+    task.cancel()
+  }
+
+  @Test("Equatable reference types use value equality")
+  func testEquatableReferenceTypes() async throws {
+    final class EquatableRefType: Equatable, @unchecked Sendable {
+      var value: Int
+      init(value: Int) { self.value = value }
+      static func == (lhs: EquatableRefType, rhs: EquatableRefType) -> Bool {
+        lhs.value == rhs.value
+      }
+    }
+
+    let obj1 = EquatableRefType(value: 0)
+    let node = Stored(wrappedValue: obj1)
+    let stream = node.observe()
+
+    let results = OSAllocatedUnfairLock.init(initialState: [Int]())
+    let task = Task {
+      for try await value in stream {
+        results.withLock { $0.append(value.value) }
+      }
+    }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    // Initial value included
+    #expect(results.withLock { $0 == [0] })
+
+    // Different reference but equal value - should NOT notify
+    let obj2 = EquatableRefType(value: 0)
+    node.wrappedValue = obj2
+    try await Task.sleep(for: .milliseconds(100))
+    #expect(results.withLock { $0 == [0] })
+
+    // Different value - should notify
+    let obj3 = EquatableRefType(value: 1)
+    node.wrappedValue = obj3
+    try await Task.sleep(for: .milliseconds(100))
+    #expect(results.withLock { $0 == [0, 1] })
+
+    task.cancel()
   }
 
 }
@@ -220,4 +332,4 @@ struct StoredDidSetTests {
     #expect(secondHandlerCalled == true)
   }
 
-} 
+}

--- a/Tests/StateGraphTests/StoredComparatorTests.swift
+++ b/Tests/StateGraphTests/StoredComparatorTests.swift
@@ -1,0 +1,200 @@
+import Observation
+import Testing
+
+@testable import StateGraph
+
+@Suite
+struct StoredComparatorTests {
+
+  @Test
+  func observation_willSet_didSet_not_called_for_same_value() async {
+    // Given: A model with GraphStored property
+    final class Model: Sendable {
+      @GraphStored var count: Int = 0
+    }
+
+    let model = Model()
+
+    // When: Observing changes and setting the same value
+    await confirmation(expectedCount: 0) { c in
+      withObservationTracking {
+        _ = model.count
+      } onChange: {
+        c.confirm()
+      }
+
+      model.count = 0  // Same value - should NOT trigger onChange
+
+      try? await Task.sleep(for: .milliseconds(50))
+    }
+  }
+
+  @Test
+  func observation_willSet_didSet_called_for_different_value() async {
+    // Given: A model with GraphStored property
+    final class Model: Sendable {
+      @GraphStored var count: Int = 0
+    }
+
+    let model = Model()
+
+    // When: Observing changes and setting a different value
+    await confirmation(expectedCount: 1) { c in
+      withObservationTracking {
+        _ = model.count
+      } onChange: {
+        Task {
+          #expect(model.count == 1)
+          c.confirm()
+        }
+      }
+
+      model.count = 1  // Different value - should trigger onChange
+
+      try? await Task.sleep(for: .milliseconds(50))
+    }
+  }
+
+  @Test
+  func multiple_same_value_updates_no_notifications() async {
+    // Given: A model with GraphStored property
+    final class Model: Sendable {
+      @GraphStored var value: String = "initial"
+    }
+
+    let model = Model()
+
+    // When: Setting same value multiple times
+    await confirmation(expectedCount: 0) { c in
+      withObservationTracking {
+        _ = model.value
+      } onChange: {
+        c.confirm()
+      }
+
+      model.value = "initial"
+      model.value = "initial"
+      model.value = "initial"
+
+      try? await Task.sleep(for: .milliseconds(50))
+    }
+  }
+
+  @Test
+  func state_graph_tracking_no_notification_for_same_value() async {
+    // Given: A model with GraphStored property
+    final class Model: Sendable {
+      @GraphStored var count: Int = 10
+    }
+
+    let model = Model()
+
+    // When: Using StateGraph's tracking and setting same value
+    await confirmation(expectedCount: 0) { c in
+      withStateGraphTracking {
+        _ = model.count
+      } didChange: {
+        c.confirm()
+      }
+
+      model.count = 10  // Same value - should NOT trigger
+
+      try? await Task.sleep(for: .milliseconds(100))
+    }
+  }
+
+  @Test
+  func computed_node_not_invalidated_for_same_stored_value() async {
+    // Given: Stored node and computed node
+    let stored = Stored(name: "stored", wrappedValue: 5)
+
+    let computeCount = OSAllocatedUnfairLock(initialState: 0)
+    let computed = Computed(name: "computed") { _ in
+      computeCount.withLock { $0 += 1 }
+      return stored.wrappedValue * 2
+    }
+
+    // Trigger initial computation
+    #expect(computed.wrappedValue == 10)
+    #expect(computeCount.withLock { $0 } == 1)
+
+    // When: Set the same value
+    stored.wrappedValue = 5
+
+    // Then: Computed should not be marked as dirty and not recompute
+    #expect(computed.wrappedValue == 10)
+    #expect(computeCount.withLock { $0 } == 1, "Computed node should not recompute for same stored value")
+  }
+
+  @Test
+  func onChange_callback_not_invoked_for_same_value() async {
+    // Given: Stored node with onChange callback
+    let stored = Stored(name: "stored", wrappedValue: 100)
+
+    var changeCount = 0
+
+    let cancellable = withGraphTracking {
+      withGraphTrackingMap { stored.wrappedValue } onChange: { newValue in
+        changeCount += 1
+      }
+    }
+
+    // Initial state
+    #expect(changeCount == 1)
+
+    // When: Set the same value multiple times
+    stored.wrappedValue = 100
+    stored.wrappedValue = 100
+
+    try? await Task.sleep(for: .milliseconds(50))
+
+    // Then: onChange should not be invoked
+    #expect(changeCount == 1, "onChange should not be called for same value")
+
+    // When: Set a different value
+    stored.wrappedValue = 200
+
+    try? await Task.sleep(for: .milliseconds(50))
+
+    // Then: onChange should be invoked
+    #expect(changeCount == 2, "onChange should be called once for different value")
+
+    withExtendedLifetime(cancellable, {})
+  }
+
+  @Test
+  func equatable_custom_struct_comparison() async {
+    // Given: Custom Equatable struct
+    struct Point: Equatable {
+      let x: Int
+      let y: Int
+    }
+
+    let stored = Stored(name: "point", wrappedValue: Point(x: 10, y: 20))
+
+    let computeCount = OSAllocatedUnfairLock(initialState: 0)
+    let computed = Computed(name: "computed") { _ in
+      computeCount.withLock { $0 += 1 }
+      return stored.wrappedValue.x + stored.wrappedValue.y
+    }
+
+    // Trigger initial computation
+    #expect(computed.wrappedValue == 30)
+    #expect(computeCount.withLock { $0 } == 1)
+
+    // When: Set equivalent struct (same values)
+    stored.wrappedValue = Point(x: 10, y: 20)
+
+    // Then: Should not recompute
+    #expect(computed.wrappedValue == 30)
+    #expect(computeCount.withLock { $0 } == 1, "Same struct values should not trigger recomputation")
+
+    // When: Set different struct
+    stored.wrappedValue = Point(x: 15, y: 25)
+
+    // Then: Should recompute
+    #expect(computed.wrappedValue == 40)
+    #expect(computeCount.withLock { $0 } == 2, "Different struct values should trigger recomputation")
+  }
+
+}


### PR DESCRIPTION
## Summary

- Implement the Observable macro's `shouldNotifyObservers` pattern using compile-time resolved closures
- Skip notifications for Equatable types when values haven't changed
- Skip notifications for reference types when identity hasn't changed
- Prefer value equality over identity for Equatable reference types

## Changes

| Value Type | Notification Behavior |
|------------|----------------------|
| Equatable | Notifies only when value changes (`==`) |
| AnyObject (non-Equatable) | Notifies only when reference changes (`===`) |
| Equatable & AnyObject | Notifies only when value changes (`==`) |
| Non-Equatable struct | Always notifies (unchanged) |

## Breaking Change

This changes behavior: Equatable types will now only notify when values actually change, matching `Observation.framework` behavior.

## Test plan

- [x] All `NodeObserveTests` pass (7 tests)
- [x] All `GraphTrackingMapTests` pass (6 tests)
- [x] 88/89 total tests pass (1 flaky test is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)