### PR TITLE
Add generic ClosureBox to fix thunk stack growing

### DIFF
--- a/Sources/StateGraph/Observation/withGraphTrackingGroup.swift
+++ b/Sources/StateGraph/Observation/withGraphTrackingGroup.swift
@@ -95,8 +95,8 @@ public func withGraphTrackingGroup(
     return
   }
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox?>(
-    uncheckedState: .init(handler: handler)
+  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
+    uncheckedState: ClosureBox(handler)
   )
 
   // Create a cancellable for this scope that manages nested tracking
@@ -113,7 +113,7 @@ public func withGraphTrackingGroup(
       // Nested groups/maps will register with this parent via addChild()
       ThreadLocal.currentCancellable.withValue(scopeCancellable) {
         _handlerBox.withLock {
-          $0?.handler()
+          $0?()
         }
       }
     },
@@ -131,12 +131,4 @@ public func withGraphTrackingGroup(
     subscriptions!.append(AnyCancellable(scopeCancellable))
   }
 
-}
-
-private struct ClosureBox {
-  let handler: () -> Void
-  
-  init(handler: @escaping () -> Void) {
-    self.handler = handler
-  }
 }

--- a/Sources/StateGraph/Observation/withGraphTrackingMap.swift
+++ b/Sources/StateGraph/Observation/withGraphTrackingMap.swift
@@ -137,8 +137,8 @@ public func withGraphTrackingMap<Projection>(
 
   var filter = filter
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox?>(
-    uncheckedState: .init(handler: {
+  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
+    uncheckedState: ClosureBox({
       let result = applier()
       let filtered = filter.send(value: result)
       if let filtered {
@@ -160,7 +160,7 @@ public func withGraphTrackingMap<Projection>(
       // Set this scope's cancellable as the current parent for nested tracking
       // Nested groups/maps will register with this parent via addChild()
       ThreadLocal.currentCancellable.withValue(scopeCancellable) {
-        _handlerBox.withLock { $0?.handler() }
+        _handlerBox.withLock { $0?() }
       }
     },
     didChange: {
@@ -305,8 +305,8 @@ public func withGraphTrackingMap<Dependency: AnyObject, Projection>(
 
   var filter = filter
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox?>(
-    uncheckedState: .init(handler: {
+  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
+    uncheckedState: ClosureBox({
       guard let dependency = weakDependency else {
         return
       }
@@ -335,7 +335,7 @@ public func withGraphTrackingMap<Dependency: AnyObject, Projection>(
       // Set this scope's cancellable as the current parent for nested tracking
       // Nested groups/maps will register with this parent via addChild()
       ThreadLocal.currentCancellable.withValue(scopeCancellable) {
-        _handlerBox.withLock { $0?.handler() }
+        _handlerBox.withLock { $0?() }
       }
     },
     didChange: {
@@ -351,13 +351,5 @@ public func withGraphTrackingMap<Dependency: AnyObject, Projection>(
     parent.addChild(scopeCancellable)
   } else {
     subscriptions!.append(AnyCancellable(scopeCancellable))
-  }
-}
-
-private struct ClosureBox {
-  let handler: () -> Void
-
-  init(handler: @escaping () -> Void) {
-    self.handler = handler
   }
 }


### PR DESCRIPTION
## Summary

- Create generic `ClosureBox<R>` in `withTracking.swift` to eliminate code duplication
- Fix thunk stack growing for `didChange` closure in `withContinuousStateGraphTracking` by wrapping closures once at entry point and passing them directly in recursive calls
- Remove duplicate private `ClosureBox` definitions from `withGraphTrackingGroup.swift` and `withGraphTrackingMap.swift`
- Add `callAsFunction` support for cleaner invocation syntax

## Background

PR #88 fixed thunk stack growing issue for handler closures by wrapping them in `ClosureBox`. However:
1. `ClosureBox` was duplicated in two files
2. `didChange` closure in `withContinuousStateGraphTracking` still had the same thunk stack growing issue due to recursive wrapping/unwrapping via `UnsafeSendable`

## Changes

| File | Changes |
|------|---------|
| `withTracking.swift` | Add generic `ClosureBox<R>` with `callAsFunction`, add private `_withContinuousStateGraphTracking` |
| `withGraphTrackingGroup.swift` | Remove private `ClosureBox`, use shared one |
| `withGraphTrackingMap.swift` | Remove private `ClosureBox`, use shared one |

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (99 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)