### PR TITLE
[codex] Improve observation key path readability

### DIFF
--- a/Sources/StateGraph/Primitives/KeyPath.swift
+++ b/Sources/StateGraph/Primitives/KeyPath.swift
@@ -1,8 +1,10 @@
 import Observation
 
-struct PointerKeyPathRoot: Observable, Sendable {
+struct PointerKeyPathRoot<Object: AnyObject>: Observable, Sendable {
   
-  static let shared = PointerKeyPathRoot()
+  static var shared: PointerKeyPathRoot<Object> {
+    PointerKeyPathRoot<Object>()
+  }
   
   subscript(pointer pointer: UnsafeMutableRawPointer) -> Never {
     fatalError()
@@ -11,9 +13,11 @@ struct PointerKeyPathRoot: Observable, Sendable {
 }
 
 @inline(__always) 
-func _keyPath(_ object: AnyObject) -> any KeyPath<PointerKeyPathRoot, Never> & Sendable {
+func _keyPath<Object: AnyObject>(
+  _ object: Object
+) -> any KeyPath<PointerKeyPathRoot<Object>, Never> & Sendable {
   let p = Unmanaged.passUnretained(object).toOpaque()
-  let keyPath = \PointerKeyPathRoot[pointer: p]
+  let keyPath = \PointerKeyPathRoot<Object>[pointer: p]
   return keyPath
 }
 

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -231,7 +231,7 @@ public final class Computed<Value>: Node, Observable, CustomDebugStringConvertib
 #if canImport(Observation)
       if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
         withMainActor { [observationRegistrar, keyPath = _keyPath(self)] in   
-          observationRegistrar.willSet(PointerKeyPathRoot.shared, keyPath: keyPath)
+          observationRegistrar.willSet(PointerKeyPathRoot<Computed<Value>>.shared, keyPath: keyPath)
         }
       }
 #endif
@@ -256,7 +256,7 @@ public final class Computed<Value>: Node, Observable, CustomDebugStringConvertib
     get {
       #if canImport(Observation)
         if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-          observationRegistrar.access(PointerKeyPathRoot.shared, keyPath: _keyPath(self))   
+          observationRegistrar.access(PointerKeyPathRoot<Computed<Value>>.shared, keyPath: _keyPath(self))   
         }
       #endif
       recomputeIfNeeded()

--- a/Sources/StateGraph/StorageAbstraction.swift
+++ b/Sources/StateGraph/StorageAbstraction.swift
@@ -162,7 +162,7 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
       
 #if canImport(Observation)
       if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-        observationRegistrar.access(PointerKeyPathRoot.shared, keyPath: _keyPath(self))        
+        observationRegistrar.access(PointerKeyPathRoot<_Stored<Value, S>>.shared, keyPath: _keyPath(self))        
       }
 #endif
       
@@ -187,14 +187,14 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
 #if canImport(Observation)
       if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
         withMainActor { [observationRegistrar, keyPath = _keyPath(self)] in
-          observationRegistrar.willSet(PointerKeyPathRoot.shared, keyPath: keyPath)
+          observationRegistrar.willSet(PointerKeyPathRoot<_Stored<Value, S>>.shared, keyPath: keyPath)
         }
       }
 
       defer {
         if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
           withMainActor { [observationRegistrar, keyPath = _keyPath(self)] in
-            observationRegistrar.didSet(PointerKeyPathRoot.shared, keyPath: keyPath)
+            observationRegistrar.didSet(PointerKeyPathRoot<_Stored<Value, S>>.shared, keyPath: keyPath)
           }
         }
       }
@@ -231,8 +231,8 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
       // Workaround: SwiftUI will not trigger update if we call only didSet.
       // as here is where the value already updated.
       withMainActor { [observationRegistrar, keyPath = _keyPath(self)] in   
-        observationRegistrar.willSet(PointerKeyPathRoot.shared, keyPath: keyPath)
-        observationRegistrar.didSet(PointerKeyPathRoot.shared, keyPath: keyPath)  
+        observationRegistrar.willSet(PointerKeyPathRoot<_Stored<Value, S>>.shared, keyPath: keyPath)
+        observationRegistrar.didSet(PointerKeyPathRoot<_Stored<Value, S>>.shared, keyPath: keyPath)  
       }
     }
 #endif

--- a/Tests/StateGraphTests/KeyPathTests.swift
+++ b/Tests/StateGraphTests/KeyPathTests.swift
@@ -1,244 +1,135 @@
-@preconcurrency import Testing
 @preconcurrency import Foundation
+@preconcurrency import Testing
 @testable import StateGraph
 
-@Suite("KeyPath Uniqueness Tests")
+@Suite("KeyPath Tests")
 struct KeyPathTests {
-  
-  @Test("Different objects generate different KeyPaths")
-  func keyPathUniqueness() {
-    // Verify that different objects generate different KeyPaths
-    let object1 = NSObject()
-    let object2 = NSObject()
-    
-    let keyPath1 = _keyPath(object1)
-    let keyPath2 = _keyPath(object2)
-    
-    // Different objects should produce different KeyPaths
-    #expect(keyPath1 != keyPath2, "Different objects should produce different KeyPaths")
-  }
-  
+
   @Test("Same object generates consistent KeyPaths")
-  func keyPathConsistency() {
-    // Verify that the same object generates consistent KeyPaths
+  func sameObjectKeyPathConsistency() {
     let object = NSObject()
-    
+
     let keyPath1 = _keyPath(object)
     let keyPath2 = _keyPath(object)
-    
-    // Same object should produce identical KeyPaths
-    #expect(keyPath1 == keyPath2, "Same object should produce identical KeyPaths")
+
+    #expect(keyPath1 == keyPath2)
   }
-  
-  @Test("KeyPath uniqueness with multiple objects")
-  func keyPathUniquenessWithMultipleObjects() {
-    // Verify KeyPath uniqueness with multiple objects
+
+  @Test("Same-type different objects generate different KeyPaths")
+  func sameTypeDifferentObjectsGenerateDifferentKeyPaths() {
+    let object1 = NSObject()
+    let object2 = NSObject()
+
+    let keyPath1 = _keyPath(object1)
+    let keyPath2 = _keyPath(object2)
+
+    #expect(keyPath1 != keyPath2)
+  }
+
+  @Test("Same-type KeyPaths remain unique across many live objects")
+  func sameTypeKeyPathsRemainUniqueAcrossManyLiveObjects() {
     let objects = (0..<100).map { _ in NSObject() }
     let keyPaths = objects.map { _keyPath($0) }
-    
-    // All KeyPaths should be unique
+
     for i in 0..<keyPaths.count {
-      for j in (i+1)..<keyPaths.count {
-        #expect(keyPaths[i] != keyPaths[j], "KeyPath \(i) and \(j) should be different")
+      for j in (i + 1)..<keyPaths.count {
+        #expect(keyPaths[i] != keyPaths[j])
       }
     }
   }
-  
-  @Test("KeyPath uniqueness with different object types")
-  func keyPathWithDifferentObjectTypes() {
-    // Verify that KeyPaths are unique even for different object types
-    let nsObject = NSObject()
-    let nsString = NSString(string: "test")
-    let nsArray = NSArray()
-    
-    let keyPath1 = _keyPath(nsObject)
-    let keyPath2 = _keyPath(nsString)
-    let keyPath3 = _keyPath(nsArray)
-    
-    #expect(keyPath1 != keyPath2, "NSObject and NSString should have different KeyPaths")
-    #expect(keyPath2 != keyPath3, "NSString and NSArray should have different KeyPaths")
-    #expect(keyPath1 != keyPath3, "NSObject and NSArray should have different KeyPaths")
-  }
-  
-  @Test("KeyPath stability")
-  func keyPathStability() {
-    // Verify that KeyPaths remain stable while the object is alive
+
+  @Test("KeyPath remains stable while object is alive")
+  func keyPathRemainsStableWhileObjectIsAlive() {
     let object = NSObject()
     let initialKeyPath = _keyPath(object)
-    
-    // Multiple calls should return the same KeyPath
+
     for _ in 0..<10 {
-      let currentKeyPath = _keyPath(object)
-      #expect(initialKeyPath == currentKeyPath, "KeyPath should be stable for the same object")
+      #expect(_keyPath(object) == initialKeyPath)
     }
   }
-  
-  @Test("Weak references and object lifecycle")
-  func keyPathWithWeakReferences() {
-    // Verify the relationship between object lifecycle and KeyPath using weak references
-    var keyPath: (any KeyPath<PointerKeyPathRoot, Never> & Sendable)?
-    
+
+  @Test("KeyPath remains valid after object is released")
+  func keyPathRemainsValidAfterObjectIsReleased() {
+    var keyPath: (any KeyPath<PointerKeyPathRoot<NSObject>, Never> & Sendable)?
+
     autoreleasepool {
       let object = NSObject()
       keyPath = _keyPath(object)
-      
-      // KeyPath should be valid while the object is alive
-      #expect(keyPath != nil)
     }
-    
-    // KeyPath itself should be retained even after the object is deallocated
+
     #expect(keyPath != nil)
   }
-  
-  @Test("Sendable protocol conformance")
+
+  @Test("KeyPath is Sendable")
   func keyPathSendableConformance() {
-    // Verify that KeyPath conforms to Sendable protocol
     let object = NSObject()
     let keyPath = _keyPath(object)
-    
-    // Verify conformance to Sendable protocol at type level
-    let sendableKeyPath: any KeyPath<PointerKeyPathRoot, Never> & Sendable = keyPath
-    #expect(sendableKeyPath != nil)
+
+    let sendableKeyPath: any KeyPath<PointerKeyPathRoot<NSObject>, Never> & Sendable = keyPath
+
+    #expect(sendableKeyPath == keyPath)
   }
-  
+
   @Test("Concurrent KeyPath generation")
   func concurrentKeyPathGeneration() async {
-    // Verify safety of KeyPath generation in concurrent environments
-    let keyPaths = OSAllocatedUnfairLock<[any KeyPath<PointerKeyPathRoot, Never> & Sendable]>(initialState: [])
+    let keyPaths = OSAllocatedUnfairLock<
+      [any KeyPath<PointerKeyPathRoot<NSObject>, Never> & Sendable]
+    >(initialState: [])
     let objects = OSAllocatedUnfairLock<[NSObject]>(initialState: [])
-    
+
     await withTaskGroup(of: Void.self) { group in
       for _ in 0..<10 {
         group.addTask {
-          // Create objects within each task to avoid data races
           let object = NSObject()
           let keyPath = _keyPath(object)
-          
-          // Retain objects to prevent memory address reuse
+
           objects.withLock { objects in
             objects.append(object)
           }
-          
+
           keyPaths.withLock { keyPaths in
             keyPaths.append(keyPath)
           }
         }
       }
     }
-    
-    // Verify the count of concurrently generated KeyPaths
+
     let finalKeyPaths = keyPaths.withLock { $0 }
     let finalObjects = objects.withLock { $0 }
-    
-    #expect(finalKeyPaths.count == 10, "Should have generated 10 KeyPaths")
-    #expect(finalObjects.count == 10, "Should have created 10 objects")
-    
-    // Verify that KeyPaths are unique while objects are alive
+
+    #expect(finalKeyPaths.count == 10)
+    #expect(finalObjects.count == 10)
+
     for i in 0..<finalKeyPaths.count {
-      for j in (i+1)..<finalKeyPaths.count {
-        #expect(finalKeyPaths[i] != finalKeyPaths[j], "Concurrently generated KeyPath \(i) and \(j) should be different while objects are alive")
+      for j in (i + 1)..<finalKeyPaths.count {
+        #expect(finalKeyPaths[i] != finalKeyPaths[j])
       }
     }
   }
-  
-  @Test("Hash value uniqueness")
-  func keyPathHashUniqueness() {
-    // Verify uniqueness of KeyPath hash values
-    let objects = (0..<50).map { _ in NSObject() }
-    let keyPaths = objects.map { _keyPath($0) }
-    let hashValues = keyPaths.map { $0.hashValue }
-    
-    // Check for hash value duplicates (should be unique but collisions are possible)
-    let uniqueHashes = Set(hashValues)
-    let collisionRate = Double(hashValues.count - uniqueHashes.count) / Double(hashValues.count)
-    
-    // Verify collision rate is below 10% (hash function quality check)
-    #expect(collisionRate < 0.1, "Hash collision rate should be low")
+
+  @Test("KeyPath description includes generic root type")
+  func keyPathDescriptionIncludesGenericRootType() {
+    let stored = Stored(wrappedValue: 1)
+    let computed = Computed<Int>(constant: 1)
+
+    let storedDescription = String(describing: _keyPath(stored))
+    let computedDescription = String(describing: _keyPath(computed))
+
+    #expect(storedDescription.contains("PointerKeyPathRoot"))
+    #expect(storedDescription.contains("_Stored<Int, InMemoryStorage<Int>>"))
+    #expect(computedDescription.contains("PointerKeyPathRoot"))
+    #expect(computedDescription.contains("Computed<Int>"))
+    #expect(storedDescription != computedDescription)
   }
-  
-  @Test("Memory address reflection")
-  func keyPathMemoryAddress() {
-    // Verify that KeyPath actually reflects object memory addresses
-    let object1 = NSObject()
-    let object2 = NSObject()
-    
-    let keyPath1 = _keyPath(object1)
-    let keyPath2 = _keyPath(object2)
-    
-    // Verify that KeyPath string representations contain memory addresses
-    let keyPathString1 = keyPath1._kvcKeyPathString
-    let keyPathString2 = keyPath2._kvcKeyPathString
-    
-    if let string1 = keyPathString1, let string2 = keyPathString2 {
-      #expect(string1 != string2, "KeyPath strings should be different for different objects")
-      #expect(string1.contains("pointer"), "KeyPath string should contain 'pointer'")
-      #expect(string2.contains("pointer"), "KeyPath string should contain 'pointer'")
-    }
-  }
-  
-  @Test("Memory address reuse behavior")
-  func keyPathMemoryAddressReuse() {
-    // Verify behavior related to memory address reuse
-    var firstKeyPath: (any KeyPath<PointerKeyPathRoot, Never> & Sendable)?
-    var firstAddress: String?
-    
-    // Create first object and get its KeyPath
-    autoreleasepool {
-      let object1 = NSObject()
-      firstKeyPath = _keyPath(object1)
-      firstAddress = firstKeyPath?._kvcKeyPathString
-    }
-    
-    // Promote garbage collection
-    for _ in 0..<100 {
-      autoreleasepool {
-        _ = NSObject()
-      }
-    }
-    
-    // Create new object with KeyPath
-    let object2 = NSObject()
-    let secondKeyPath = _keyPath(object2)
-    let secondAddress = secondKeyPath._kvcKeyPathString
-    
-    // Compare KeyPath objects themselves
-    if let firstKeyPath = firstKeyPath {
-      // When memory addresses are reused, KeyPaths may become the same
-      // This is an implementation detail and may not always be different
-      let keyPathsAreDifferent = !(firstKeyPath == secondKeyPath)
-      
-      // Compare address strings to verify actual behavior
-      if let firstAddr = firstAddress, let secondAddr = secondAddress {
-        print("First address: \(firstAddr)")
-        print("Second address: \(secondAddr)")
-        
-        if firstAddr == secondAddr {
-          // When memory addresses are reused, KeyPaths should be equal
-          #expect(!keyPathsAreDifferent, "When memory addresses are reused, KeyPaths should be equal")
-        } else {
-          // When memory addresses are different, KeyPaths should be different
-          #expect(keyPathsAreDifferent, "When memory addresses are different, KeyPaths should be different")
-        }
-      }
-    }
-  }
-  
-  @Test("Implementation details verification")
-  func keyPathImplementationDetails() {
-    // Verify KeyPath implementation details
+
+  @Test("Expected pointer KeyPath matches generated KeyPath")
+  func expectedPointerKeyPathMatchesGeneratedKeyPath() {
     let object = NSObject()
-    let keyPath = _keyPath(object)
-    
-    // Verify that KeyPath string representation has appropriate format
-    if let keyPathString = keyPath._kvcKeyPathString {
-      #expect(keyPathString.hasPrefix("pointer:"), "KeyPath string should start with 'pointer:'")
-    }
-    
-    // Verify relationship between object memory address and KeyPath
     let objectPointer = Unmanaged.passUnretained(object).toOpaque()
-    let expectedKeyPath = \PointerKeyPathRoot[pointer: objectPointer]
-    
-    // KeyPaths created from the same pointer should be equal
-    #expect(keyPath == expectedKeyPath, "KeyPath should match expected KeyPath from same pointer")
+
+    let keyPath = _keyPath(object)
+    let expectedKeyPath = \PointerKeyPathRoot<NSObject>[pointer: objectPointer]
+
+    #expect(keyPath == expectedKeyPath)
   }
-} 
+}

--- a/Tests/StateGraphTests/ObservationKeyPathTests.swift
+++ b/Tests/StateGraphTests/ObservationKeyPathTests.swift
@@ -1,0 +1,63 @@
+import Observation
+@preconcurrency import Testing
+@testable import StateGraph
+
+@Suite("Observation KeyPath Tests")
+@MainActor
+struct ObservationKeyPathTests {
+
+  @Test("Direct Stored observation ignores another same-type instance")
+  func directStoredObservationIgnoresAnotherSameTypeInstance() async {
+    let observed = Stored(wrappedValue: 0)
+    let other = Stored(wrappedValue: 0)
+
+    await confirmation(expectedCount: 1) { confirmation in
+      withObservationTracking {
+        _ = observed.wrappedValue
+      } onChange: {
+        confirmation.confirm()
+      }
+
+      other.wrappedValue = 1
+      try? await Task.sleep(for: .milliseconds(10))
+
+      observed.wrappedValue = 1
+      try? await Task.sleep(for: .milliseconds(10))
+    }
+  }
+
+  @Test("Direct Stored observation invalidates when the observed node changes")
+  func directStoredObservationInvalidatesWhenObservedNodeChanges() async {
+    let node = Stored(wrappedValue: 0)
+
+    await confirmation(expectedCount: 1) { confirmation in
+      withObservationTracking {
+        _ = node.wrappedValue
+      } onChange: {
+        confirmation.confirm()
+      }
+
+      node.wrappedValue = 1
+      try? await Task.sleep(for: .milliseconds(10))
+    }
+  }
+
+  @Test("Computed observation invalidates when a dependency changes")
+  func computedObservationInvalidatesWhenDependencyChanges() async {
+    let source = Stored(wrappedValue: 1)
+    let computed = Computed<Int> { _ in
+      source.wrappedValue * 2
+    }
+
+    await confirmation(expectedCount: 1) { confirmation in
+      withObservationTracking {
+        _ = computed.wrappedValue
+      } onChange: {
+        confirmation.confirm()
+      }
+
+      source.wrappedValue = 2
+      try? await Task.sleep(for: .milliseconds(10))
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Make `PointerKeyPathRoot` generic so Observation key path descriptions include the observed node type.
- Keep pointer-based key path identity so same-type different node instances remain distinct.
- Update `Stored` and `Computed` Observation calls to use typed roots, and refresh key path coverage around identity, stability, Sendable conformance, and descriptions.

## Impact
This improves SwiftUI `_printChanges()` readability by replacing the untyped pointer root with a typed root while preserving the existing shared `ObservationRegistrar` and pointer identity model.

## Validation
- `swift test --filter KeyPathTests`
- `swift test`