### PR TITLE
[codex] Document computed dependency captures

### DIFF
--- a/Sources/StateGraph/Documentation.docc/Core-Concepts.md
+++ b/Sources/StateGraph/Documentation.docc/Core-Concepts.md
@@ -172,6 +172,22 @@ self.$computed = .init { _ in
 }
 ```
 
+Capture the node itself, not the current wrapped value. Dependency edges are recorded
+when the computation reads another node's `wrappedValue`; a capture list that reads
+`self.property` captures only the value available at that moment.
+
+```swift
+// ✅ Correct: capture the stored node and read it inside the computation
+self.$displayValue = .init { [items = self.$items] _ in
+  makeDisplayValue(from: items.wrappedValue)
+}
+
+// ❌ Incorrect: captures a snapshot of the current value, so later changes are not tracked
+self.$displayValue = .init { [items = self.items] _ in
+  makeDisplayValue(from: items)
+}
+```
+
 ### Cascade Updates
 
 Dependencies form a graph, and changes cascade through it automatically:
@@ -333,4 +349,4 @@ Now that you understand the core concepts:
 
 - <doc:Describing-Models> - Learn to build complex reactive models
 - <doc:Advanced-Patterns> - Explore advanced usage patterns
-- <doc:Performance-Optimization> - Optimize your state graphs for performance 
+- <doc:Performance-Optimization> - Optimize your state graphs for performance

--- a/Tests/StateGraphTests/CaptureDependencyTrackingTests.swift
+++ b/Tests/StateGraphTests/CaptureDependencyTrackingTests.swift
@@ -1,0 +1,77 @@
+import Testing
+
+@testable import StateGraph
+
+@Suite
+struct CaptureDependencyTrackingTests {
+
+  final class CapturesStoredValue {
+    @GraphStored
+    var personalities: [String] = ["calm"]
+
+    var personalityDisplayValueNode = Computed<String>(constant: "")
+
+    var personalityDisplayValue: String {
+      personalityDisplayValueNode.wrappedValue
+    }
+
+    init() {
+      self.personalityDisplayValueNode = .init { [personalities = self.personalities] _ in
+        Self.makeMultipleSelectionDisplayValue(from: personalities)
+      }
+    }
+
+    static func makeMultipleSelectionDisplayValue(from personalities: [String]) -> String {
+      personalities.joined(separator: ",")
+    }
+  }
+
+  final class CapturesStoredNode {
+    @GraphStored
+    var personalities: [String] = ["calm"]
+
+    var personalityDisplayValueNode = Computed<String>(constant: "")
+
+    var personalityDisplayValue: String {
+      personalityDisplayValueNode.wrappedValue
+    }
+
+    init() {
+      self.personalityDisplayValueNode = .init { [personalities = self.$personalities] _ in
+        Self.makeMultipleSelectionDisplayValue(from: personalities.wrappedValue)
+      }
+    }
+
+    static func makeMultipleSelectionDisplayValue(from personalities: [String]) -> String {
+      personalities.joined(separator: ",")
+    }
+  }
+
+  @Test
+  func capturingStoredValueDoesNotBecomeComputedDependency() {
+    let model = CapturesStoredValue()
+
+    #expect(model.personalityDisplayValue == "calm")
+    #expect(model.personalityDisplayValueNode.incomingEdges.isEmpty)
+
+    model.personalities = ["active"]
+
+    // Capturing the wrapped value is a snapshot. It does not create a dependency edge.
+    #expect(model.personalityDisplayValue == "calm")
+    #expect(model.personalityDisplayValueNode.incomingEdges.isEmpty)
+  }
+
+  @Test
+  func capturingStoredNodeAndReadingItInsideRuleBecomesComputedDependency() {
+    let model = CapturesStoredNode()
+
+    #expect(model.personalityDisplayValue == "calm")
+    #expect(model.personalityDisplayValueNode.incomingEdges.count == 1)
+
+    model.personalities = ["active"]
+
+    // Capturing the node and reading wrappedValue during the rule creates a dependency edge.
+    #expect(model.personalityDisplayValue == "active")
+    #expect(model.personalityDisplayValueNode.incomingEdges.count == 1)
+  }
+}


### PR DESCRIPTION
## Summary

- Add specification tests for computed dependency capture behavior.
- Document that computed rules should capture nodes and read `wrappedValue` inside the computation.
- Clarify that capturing `self.property` captures a snapshot value and does not create a dependency edge.

## Validation

- `swift test --filter CaptureDependencyTrackingTests`
- `swift test`
- `git diff --check`