### PR TITLE
[codex] Add GraphStored property observer support

### DIFF
--- a/Sources/StateGraphMacro/Extension.swift
+++ b/Sources/StateGraphMacro/Extension.swift
@@ -213,12 +213,30 @@ extension VariableDeclSyntax {
               return accessor.body
             }
           }
-        case .getter(let _):
+        case .getter:
           return nil
         }
       }
     }
     return nil
+  }
+
+  var didSetParameterName: String {
+    for binding in self.bindings {
+      if let accessorBlock = binding.accessorBlock {
+        switch accessorBlock.accessors {
+        case .accessors(let accessors):
+          for accessor in accessors {
+            if accessor.accessorSpecifier.tokenKind == .keyword(.didSet) {
+              return accessor.parameters?.name.text ?? "oldValue"
+            }
+          }
+        case .getter:
+          return "oldValue"
+        }
+      }
+    }
+    return "oldValue"
   }
 
   var willSetBlock: CodeBlockSyntax? {
@@ -231,12 +249,30 @@ extension VariableDeclSyntax {
               return accessor.body
             }
           }
-        case .getter(let _):
+        case .getter:
           return nil
         }
       }
     }
     return nil
+  }
+
+  var willSetParameterName: String {
+    for binding in self.bindings {
+      if let accessorBlock = binding.accessorBlock {
+        switch accessorBlock.accessors {
+        case .accessors(let accessors):
+          for accessor in accessors {
+            if accessor.accessorSpecifier.tokenKind == .keyword(.willSet) {
+              return accessor.parameters?.name.text ?? "newValue"
+            }
+          }
+        case .getter:
+          return "newValue"
+        }
+      }
+    }
+    return "newValue"
   }
 
   var isComputed: Bool {

--- a/Sources/StateGraphMacro/UnifiedStoredMacro.swift
+++ b/Sources/StateGraphMacro/UnifiedStoredMacro.swift
@@ -9,8 +9,6 @@ public struct UnifiedStoredMacro {
     case constantVariableIsNotSupported
     case computedVariableIsNotSupported
     case needsTypeAnnotation
-    case didSetNotSupported
-    case willSetNotSupported
     case userDefaultsRequiresDefaultValue
     case invalidBackingArgument
     case weakVariableNotSupported
@@ -51,10 +49,6 @@ extension UnifiedStoredMacro.Error: DiagnosticMessage {
       return "Computed variables are not supported with @GraphStored"
     case .needsTypeAnnotation:
       return "@GraphStored requires explicit type annotation"
-    case .didSetNotSupported:
-      return "didSet is not supported with @GraphStored"
-    case .willSetNotSupported:
-      return "willSet is not supported with @GraphStored"
     case .userDefaultsRequiresDefaultValue:
       return "@GraphStored with UserDefaults backing requires a default value"
     case .invalidBackingArgument:
@@ -92,17 +86,6 @@ extension UnifiedStoredMacro {
       return false
     }
 
-    // Check didSet/willSet
-    if variableDecl.didSetBlock != nil {
-      context.addDiagnostics(from: Error.didSetNotSupported, node: node)
-      return false
-    }
-
-    if variableDecl.willSetBlock != nil {
-      context.addDiagnostics(from: Error.willSetNotSupported, node: node)
-      return false
-    }
-
     // UserDefaults specific validation
     if case .userDefaults = backingType {
       if !variableDecl.hasInitializer {
@@ -128,9 +111,7 @@ extension UnifiedStoredMacro {
 
   /// Checks if any binding has computed property accessors
   private static func hasComputedProperties(_ variableDecl: VariableDeclSyntax) -> Bool {
-    return variableDecl.bindings.contains { binding in
-      binding.accessorBlock != nil
-    }
+    return variableDecl.isComputed
   }
 }
 
@@ -578,7 +559,7 @@ extension UnifiedStoredMacro: AccessorMacro {
 
     // Add getter and setter
     accessors.append(createSimpleGetAccessor(propertyName: propertyName))
-    accessors.append(createSimpleSetAccessor(propertyName: propertyName))
+    accessors.append(createSimpleSetAccessor(propertyName: propertyName, variableDecl: variableDecl))
 
     return accessors
   }
@@ -614,14 +595,12 @@ extension UnifiedStoredMacro: AccessorMacro {
   }
   
   private static func createSimpleSetAccessor(
-    propertyName: String
+    propertyName: String,
+    variableDecl: VariableDeclSyntax
   ) -> AccessorDeclSyntax {
-    return AccessorDeclSyntax(
-      """
-      set { 
-        $\(raw: propertyName).wrappedValue = newValue
-      }
-      """
+    createSetAccessor(
+      assignmentTarget: "$\(propertyName).wrappedValue",
+      variableDecl: variableDecl
     )
   }
 
@@ -744,13 +723,78 @@ extension UnifiedStoredMacro: AccessorMacro {
     propertyName: String, variableDecl: VariableDeclSyntax
   ) -> AccessorDeclSyntax {
     let assignmentTarget = "$\(propertyName).wrappedValue"
-    
+    return createSetAccessor(assignmentTarget: assignmentTarget, variableDecl: variableDecl)
+  }
+
+  private static func createSetAccessor(
+    assignmentTarget: String,
+    variableDecl: VariableDeclSyntax
+  ) -> AccessorDeclSyntax {
+    guard variableDecl.willSetBlock != nil || variableDecl.didSetBlock != nil else {
+      return AccessorDeclSyntax(
+        """
+        set {
+          \(raw: assignmentTarget) = newValue
+        }
+        """
+      )
+    }
+
+    let typeAnnotation = variableDecl.typeSyntax.map { ": \($0.trimmed)" } ?? ""
+    var statements: [String] = []
+
+    if let willSetBlock = variableDecl.willSetBlock {
+      let newValueName = variableDecl.willSetParameterName
+      let observerStatements = makeObserverStatements(from: willSetBlock)
+      statements.append(
+        """
+        do {
+        \(indent("let \(newValueName)\(typeAnnotation) = __graphStoredNewValue\n\(observerStatements)", by: 2))
+        }
+        """
+      )
+    }
+
+    if variableDecl.didSetBlock != nil {
+      let oldValueName = variableDecl.didSetParameterName
+      statements.append("let \(oldValueName)\(typeAnnotation) = \(assignmentTarget)")
+    }
+
+    statements.append("\(assignmentTarget) = __graphStoredNewValue")
+
+    if let didSetBlock = variableDecl.didSetBlock {
+      let observerStatements = makeObserverStatements(from: didSetBlock)
+      statements.append(
+        """
+        do {
+        \(indent(observerStatements, by: 2))
+        }
+        """
+      )
+    }
+
     return AccessorDeclSyntax(
       """
-      set { 
-        \(raw: assignmentTarget) = newValue
+      set(__graphStoredNewValue) {
+      \(raw: indent(statements.joined(separator: "\n"), by: 2))
       }
       """
     )
+  }
+
+  private static func makeObserverStatements(from block: CodeBlockSyntax) -> String {
+    block.trimmed.statements
+      .map { $0.trimmed.description }
+      .joined(separator: "\n")
+  }
+
+  private static func indent(_ string: String, by spaces: Int) -> String {
+    let indentation = String(repeating: " ", count: spaces)
+    return string
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .map { line in
+        line.isEmpty ? "" : "\(indentation)\(line)"
+      }
+      .joined(separator: "\n")
   }
 }

--- a/Tests/StateGraphMacroTests/UnifiedStoredMacroTests.swift
+++ b/Tests/StateGraphMacroTests/UnifiedStoredMacroTests.swift
@@ -1,4 +1,7 @@
 import MacroTesting
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
@@ -119,7 +122,238 @@ final class UnifiedStoredMacroTests: XCTestCase {
       """
     }
   }
-  
+
+  func test_memory_storage_didSet_accessor_expansion() throws {
+    let accessors = try expandGraphStoredAccessors(
+      from: parseVariableDecl(
+        """
+        @GraphStored
+        var count: Int = 0 {
+          didSet {
+            history.append((oldValue, count))
+          }
+        }
+        """
+      )
+    )
+
+    XCTAssertEqual(
+      accessors.map(\.trimmed.description).joined(separator: "\n\n"),
+      """
+      get {
+        return $count.wrappedValue
+      }
+
+      set(__graphStoredNewValue) {
+        let oldValue: Int = $count.wrappedValue
+        $count.wrappedValue = __graphStoredNewValue
+        do {
+          history.append((oldValue, count))
+        }
+      }
+      """
+    )
+  }
+
+  func test_memory_storage_willSet_accessor_expansion() throws {
+    let accessors = try expandGraphStoredAccessors(
+      from: parseVariableDecl(
+        """
+        @GraphStored
+        var count: Int = 0 {
+          willSet {
+            history.append((count, newValue))
+          }
+        }
+        """
+      )
+    )
+
+    XCTAssertEqual(
+      accessors.map(\.trimmed.description).joined(separator: "\n\n"),
+      """
+      get {
+        return $count.wrappedValue
+      }
+
+      set(__graphStoredNewValue) {
+        do {
+          let newValue: Int = __graphStoredNewValue
+          history.append((count, newValue))
+        }
+        $count.wrappedValue = __graphStoredNewValue
+      }
+      """
+    )
+  }
+
+  func test_memory_storage_willSet_accessor_expansion_with_custom_new_value_name() throws {
+    let accessors = try expandGraphStoredAccessors(
+      from: parseVariableDecl(
+        """
+        @GraphStored
+        var count: Int = 0 {
+          willSet(nextValue) {
+            history.append((count, nextValue))
+          }
+        }
+        """
+      )
+    )
+
+    XCTAssertEqual(
+      accessors.map(\.trimmed.description).joined(separator: "\n\n"),
+      """
+      get {
+        return $count.wrappedValue
+      }
+
+      set(__graphStoredNewValue) {
+        do {
+          let nextValue: Int = __graphStoredNewValue
+          history.append((count, nextValue))
+        }
+        $count.wrappedValue = __graphStoredNewValue
+      }
+      """
+    )
+  }
+
+  func test_memory_storage_willSet_and_didSet_accessor_expansion() throws {
+    let accessors = try expandGraphStoredAccessors(
+      from: parseVariableDecl(
+        """
+        @GraphStored
+        var count: Int = 0 {
+          willSet {
+            history.append(("will", count, newValue))
+          }
+          didSet {
+            history.append(("did", oldValue, count))
+          }
+        }
+        """
+      )
+    )
+
+    XCTAssertEqual(
+      accessors.map(\.trimmed.description).joined(separator: "\n\n"),
+      """
+      get {
+        return $count.wrappedValue
+      }
+
+      set(__graphStoredNewValue) {
+        do {
+          let newValue: Int = __graphStoredNewValue
+          history.append(("will", count, newValue))
+        }
+        let oldValue: Int = $count.wrappedValue
+        $count.wrappedValue = __graphStoredNewValue
+        do {
+          history.append(("did", oldValue, count))
+        }
+      }
+      """
+    )
+  }
+
+  func test_memory_storage_didSet_accessor_expansion_with_custom_old_value_name() throws {
+    let accessors = try expandGraphStoredAccessors(
+      from: parseVariableDecl(
+        """
+        @GraphStored
+        var count: Int = 0 {
+          didSet(previousValue) {
+            history.append((previousValue, count))
+          }
+        }
+        """
+      )
+    )
+
+    XCTAssertEqual(
+      accessors.map(\.trimmed.description).joined(separator: "\n\n"),
+      """
+      get {
+        return $count.wrappedValue
+      }
+
+      set(__graphStoredNewValue) {
+        let previousValue: Int = $count.wrappedValue
+        $count.wrappedValue = __graphStoredNewValue
+        do {
+          history.append((previousValue, count))
+        }
+      }
+      """
+    )
+  }
+
+  func test_userdefaults_storage_didSet_accessor_expansion() throws {
+    let accessors = try expandGraphStoredAccessors(
+      from: parseVariableDecl(
+        #"""
+        @GraphStored(backed: .userDefaults(key: "username"))
+        var username: String = "anonymous" {
+          didSet {
+            history.append((oldValue, username))
+          }
+        }
+        """#
+      )
+    )
+
+    XCTAssertEqual(
+      accessors.map(\.trimmed.description).joined(separator: "\n\n"),
+      """
+      get {
+        return $username.wrappedValue
+      }
+
+      set(__graphStoredNewValue) {
+        let oldValue: String = $username.wrappedValue
+        $username.wrappedValue = __graphStoredNewValue
+        do {
+          history.append((oldValue, username))
+        }
+      }
+      """
+    )
+  }
+
+  func test_userdefaults_storage_willSet_accessor_expansion() throws {
+    let accessors = try expandGraphStoredAccessors(
+      from: parseVariableDecl(
+        #"""
+        @GraphStored(backed: .userDefaults(key: "username"))
+        var username: String = "anonymous" {
+          willSet {
+            history.append((username, newValue))
+          }
+        }
+        """#
+      )
+    )
+
+    XCTAssertEqual(
+      accessors.map(\.trimmed.description).joined(separator: "\n\n"),
+      """
+      get {
+        return $username.wrappedValue
+      }
+
+      set(__graphStoredNewValue) {
+        do {
+          let newValue: String = __graphStoredNewValue
+          history.append((username, newValue))
+        }
+        $username.wrappedValue = __graphStoredNewValue
+      }
+      """
+    )
+  }
+
   func test_memory_storage_explicit() {
     assertMacro {
       """
@@ -220,7 +454,7 @@ final class UnifiedStoredMacroTests: XCTestCase {
       """
     }
   }
-  
+
   func test_userdefaults_storage_with_suite() {
     assertMacro {
       """
@@ -808,5 +1042,34 @@ final class UnifiedStoredMacroTests: XCTestCase {
       }
       """
     } 
+  }
+
+  private func expandGraphStoredAccessors(
+    from variableDecl: VariableDeclSyntax
+  ) throws -> [AccessorDeclSyntax] {
+    let attribute = try XCTUnwrap(
+      variableDecl.attributes.compactMap { attribute -> AttributeSyntax? in
+        guard case .attribute(let attributeSyntax) = attribute else {
+          return nil
+        }
+        return attributeSyntax
+      }.first
+    )
+
+    return try UnifiedStoredMacro.expansion(
+      of: attribute,
+      providingAccessorsOf: variableDecl,
+      in: BasicMacroExpansionContext(lexicalContext: [])
+    )
+  }
+
+  private func parseVariableDecl(_ source: String) throws -> VariableDeclSyntax {
+    let sourceFile = Parser.parse(source: source)
+
+    return try XCTUnwrap(
+      sourceFile.statements.compactMap { statement in
+        statement.item.as(VariableDeclSyntax.self)
+      }.first
+    )
   }
 } 

--- a/Tests/StateGraphTests/GraphStoredDidSetTests.swift
+++ b/Tests/StateGraphTests/GraphStoredDidSetTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+@testable import StateGraph
+
+@Suite("@GraphStored property observers")
+struct GraphStoredDidSetTests {
+
+  @Test func didSet_runs_after_assignment_with_old_value() {
+    final class Model {
+      @GraphStored
+      var count: Int = 0 {
+        didSet {
+          history.append((oldValue, count))
+        }
+      }
+
+      var history: [(Int, Int)] = []
+    }
+
+    let model = Model()
+
+    model.count = 1
+    model.count = 3
+
+    #expect(model.history.count == 2)
+    #expect(model.history[0].0 == 0)
+    #expect(model.history[0].1 == 1)
+    #expect(model.history[1].0 == 1)
+    #expect(model.history[1].1 == 3)
+  }
+
+  @Test func didSet_uses_custom_old_value_name() {
+    final class Model {
+      @GraphStored
+      var count: Int = 10 {
+        didSet(previousValue) {
+          history.append((previousValue, count))
+        }
+      }
+
+      var history: [(Int, Int)] = []
+    }
+
+    let model = Model()
+
+    model.count = 12
+
+    #expect(model.history.count == 1)
+    #expect(model.history[0].0 == 10)
+    #expect(model.history[0].1 == 12)
+  }
+
+  @Test func didSet_runs_with_userDefaults_backing() {
+    let key = "GraphStoredDidSetTests.username"
+    UserDefaults.standard.removeObject(forKey: key)
+
+    final class Settings {
+      @GraphStored(backed: .userDefaults(key: "GraphStoredDidSetTests.username"))
+      var username: String = "anonymous" {
+        didSet {
+          history.append((oldValue, username))
+        }
+      }
+
+      var history: [(String, String)] = []
+    }
+
+    let settings = Settings()
+
+    settings.username = "blob"
+
+    #expect(settings.history.count == 1)
+    #expect(settings.history[0].0 == "anonymous")
+    #expect(settings.history[0].1 == "blob")
+
+    UserDefaults.standard.removeObject(forKey: key)
+  }
+
+  @Test func willSet_runs_before_assignment_with_new_value() {
+    final class Model {
+      @GraphStored
+      var count: Int = 0 {
+        willSet {
+          history.append((count, newValue))
+        }
+      }
+
+      var history: [(Int, Int)] = []
+    }
+
+    let model = Model()
+
+    model.count = 2
+
+    #expect(model.history.count == 1)
+    #expect(model.history[0].0 == 0)
+    #expect(model.history[0].1 == 2)
+    #expect(model.count == 2)
+  }
+
+  @Test func willSet_uses_custom_new_value_name() {
+    final class Model {
+      @GraphStored
+      var count: Int = 5 {
+        willSet(nextValue) {
+          history.append((count, nextValue))
+        }
+      }
+
+      var history: [(Int, Int)] = []
+    }
+
+    let model = Model()
+
+    model.count = 8
+
+    #expect(model.history.count == 1)
+    #expect(model.history[0].0 == 5)
+    #expect(model.history[0].1 == 8)
+    #expect(model.count == 8)
+  }
+
+  @Test func willSet_and_didSet_run_in_observer_order() {
+    final class Model {
+      @GraphStored
+      var count: Int = 0 {
+        willSet {
+          history.append(("will", count, newValue))
+        }
+        didSet {
+          history.append(("did", oldValue, count))
+        }
+      }
+
+      var history: [(String, Int, Int)] = []
+    }
+
+    let model = Model()
+
+    model.count = 4
+
+    #expect(model.history.count == 2)
+    #expect(model.history[0].0 == "will")
+    #expect(model.history[0].1 == 0)
+    #expect(model.history[0].2 == 4)
+    #expect(model.history[1].0 == "did")
+    #expect(model.history[1].1 == 0)
+    #expect(model.history[1].2 == 4)
+  }
+
+  @Test func willSet_runs_with_userDefaults_backing() {
+    let key = "GraphStoredWillSetTests.username"
+    UserDefaults.standard.removeObject(forKey: key)
+
+    final class Settings {
+      @GraphStored(backed: .userDefaults(key: "GraphStoredWillSetTests.username"))
+      var username: String = "anonymous" {
+        willSet {
+          history.append((username, newValue))
+        }
+      }
+
+      var history: [(String, String)] = []
+    }
+
+    let settings = Settings()
+
+    settings.username = "blob"
+
+    #expect(settings.history.count == 1)
+    #expect(settings.history[0].0 == "anonymous")
+    #expect(settings.history[0].1 == "blob")
+
+    UserDefaults.standard.removeObject(forKey: key)
+  }
+}

--- a/implementation-notes.html
+++ b/implementation-notes.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>Implementation Notes</title>
+</head>
+<body>
+  <h1>Implementation Notes</h1>
+
+  <section>
+    <h2>2026-05-23: @GraphStored didSet support</h2>
+    <h3>Design Decisions</h3>
+    <ul>
+      <li><code>@GraphStored</code> already expands into explicit <code>get</code>/<code>set</code> accessors backed by the generated <code>$property</code> node. Supporting <code>didSet</code> is therefore being interpreted as preserving the user's observer body and running it from the generated setter after assigning <code>newValue</code>.</li>
+      <li><code>willSet</code> support is being implemented in the same generated setter. The observer body runs before writing to <code>$property.wrappedValue</code>, with Swift's default <code>newValue</code> binding or the custom <code>willSet(customName)</code> binding.</li>
+      <li>When both observers are present, generated code should run <code>willSet</code>, capture <code>oldValue</code>, assign the new value, then run <code>didSet</code>.</li>
+      <li>The generated setter should capture the old value before assignment and expose it as Swift's normal <code>oldValue</code> name, or as the custom observer parameter name when the source uses <code>didSet(customName)</code>.</li>
+      <li>Initialization accessors remain observer-free, matching Swift's stored-property behavior where <code>didSet</code> is not called during initialization.</li>
+      <li>Macro expansion coverage is kept at the accessor-expansion level by calling <code>UnifiedStoredMacro.expansion(...providingAccessorsOf:)</code> directly. This verifies generated <code>get</code>/<code>set</code> accessors without snapshotting an invalid-looking full property body.</li>
+    </ul>
+    <h3>Deviations</h3>
+    <ul>
+      <li>No intentional deviations for <code>willSet</code> are planned. External storage notifications from UserDefaults still follow the existing storage update path and do not synthesize property observer calls.</li>
+    </ul>
+    <h3>Trade-offs</h3>
+    <ul>
+      <li>Using the generated setter keeps behavior local to macro expansion and avoids adding a new runtime hook just for property observer syntax.</li>
+      <li>The lower-level <code>Stored.onDidSet</code> remains available, but macro-level <code>didSet</code> gives source compatibility with normal Swift property observers.</li>
+      <li>Swift accessor macro expansion keeps the original <code>didSet</code> observer syntax visible in macro snapshots. The implementation does not rely on that observer being invoked; it explicitly runs the observer body from the generated setter so runtime behavior is covered by tests.</li>
+      <li>Because handwritten Swift does not allow <code>didSet</code> and <code>get</code> to coexist in the same accessor block, macro snapshot tests should not assert that invalid-looking expanded form. The meaningful coverage is compile/runtime behavior for memory and UserDefaults backed properties.</li>
+    </ul>
+    <h3>Open Questions</h3>
+    <ul>
+      <li>Confirm whether property observers should ever run for external storage updates, such as UserDefaults changes made outside the generated setter.</li>
+    </ul>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `@GraphStored` support for Swift-style `didSet` and `willSet` property observers.
- Generates observer-aware setters for both memory and UserDefaults-backed storage.
- Supports default `oldValue` / `newValue` bindings and custom observer parameter names.
- Adds accessor-level macro expansion tests to avoid asserting invalid-looking full property snapshots where observer syntax appears beside generated accessors.
- Adds runtime tests covering memory storage, UserDefaults storage, custom observer names, and combined `willSet` / `didSet` order.

## Validation

- `git diff --check --cached`
- `swift test`