### PR TITLE
[codex] Add SwiftUI graph tracking modifier

### DIFF
--- a/Development/Development/ContentView.swift
+++ b/Development/Development/ContentView.swift
@@ -132,7 +132,6 @@ struct Observe_specific: View {
 private struct Book_StateView: View {
     
   let model: Model
-  @State var subscription: AnyCancellable?
   
   init(entity: Model) {
     self.model = entity
@@ -158,32 +157,24 @@ private struct Book_StateView: View {
         model.count2 += 1
       }
     }
-    .onAppear {
-      
+    .graphTracking {
       print("onAppear")
-                
-      subscription = withGraphTracking {
 
-        withGraphTrackingGroup {
-          print("☁️", model.count1, model.count2)
-        }
-
-        withGraphTrackingMap {
-          model.count1 + model.count2
-        } onChange: { value in
-          print("computed", value)
-        }
-
-        withGraphTrackingMap {
-          model.$count1.wrappedValue
-        } onChange: { value in
-          print("count", value)
-        }
+      withGraphTrackingGroup {
+        print("☁️", model.count1, model.count2)
       }
-      
-    }
-    .onDisappear {
-      subscription?.cancel()      
+
+      withGraphTrackingMap {
+        model.count1 + model.count2
+      } onChange: { value in
+        print("computed", value)
+      }
+
+      withGraphTrackingMap {
+        model.$count1.wrappedValue
+      } onChange: { value in
+        print("count", value)
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -172,6 +172,32 @@ struct ItemListView: View {
 }
 ```
 
+### Lifecycle Tracking
+
+Use `.graphTracking` when a SwiftUI view needs to keep a `withGraphTracking`
+subscription alive only while the view is visible:
+
+```swift
+struct AutoRefreshView: View {
+  let model: RefreshModel
+
+  var body: some View {
+    Toggle("Auto Refresh", isOn: model.$isEnabled.binding)
+      .graphTracking {
+        withGraphTrackingMap {
+          model.isEnabled
+        } onChange: { isEnabled in
+          if isEnabled {
+            model.start()
+          } else {
+            model.stop()
+          }
+        }
+      }
+  }
+}
+```
+
 ### Environment Integration
 
 Use `GraphObject` protocol for environment propagation:

--- a/Sources/StateGraph/Documentation.docc/SwiftUI-Integration.md
+++ b/Sources/StateGraph/Documentation.docc/SwiftUI-Integration.md
@@ -115,6 +115,45 @@ struct FormView: View {
 }
 ```
 
+## Lifecycle Tracking
+
+Use `.graphTracking` when a SwiftUI view needs to host a StateGraph subscription
+for side effects. The modifier starts the tracking scope when the view appears
+and cancels it when the view disappears.
+
+```swift
+struct AutoRefreshView: View {
+  let viewModel: AutoRefreshViewModel
+
+  var body: some View {
+    Toggle("Auto Refresh", isOn: viewModel.$isEnabled.binding)
+      .graphTracking {
+        withGraphTrackingMap {
+          viewModel.isEnabled
+        } onChange: { isEnabled in
+          if isEnabled {
+            viewModel.start()
+          } else {
+            viewModel.stop()
+          }
+        }
+      }
+  }
+}
+```
+
+When the tracking closure captures a replaceable dependency, pass an identity so
+the subscription is rebuilt only when that dependency changes:
+
+```swift
+content
+  .graphTracking(id: ObjectIdentifier(viewModel)) {
+    withGraphTrackingGroup {
+      syncExternalState(viewModel.status)
+    }
+  }
+```
+
 ## Observable Conformance
 
 Swift State Graph nodes automatically conform to SwiftUI's `Observable` protocol when available, enabling direct use with SwiftUI's observation system:
@@ -511,4 +550,4 @@ enum ViewState {
 }
 ```
 
-Swift State Graph provides a natural, reactive approach to SwiftUI development, eliminating boilerplate while maintaining full type safety and performance. 
+Swift State Graph provides a natural, reactive approach to SwiftUI development, eliminating boilerplate while maintaining full type safety and performance.

--- a/Sources/StateGraph/SwiftUI+GraphTracking.swift
+++ b/Sources/StateGraph/SwiftUI+GraphTracking.swift
@@ -1,0 +1,163 @@
+#if canImport(SwiftUI)
+
+@preconcurrency import Combine
+import SwiftUI
+
+extension View {
+
+  /// Starts a StateGraph tracking scope while this view is visible.
+  ///
+  /// Use this modifier when a SwiftUI view needs to host side effects that depend on
+  /// StateGraph values, such as starting a service, logging derived state, or synchronizing
+  /// external UI. The tracking scope starts when the view appears and is cancelled when the
+  /// view disappears.
+  ///
+  /// The closure can call ``withGraphTrackingGroup(_:)`` and ``withGraphTrackingMap(_:onChange:isolation:)``
+  /// just like a manually retained ``withGraphTracking(_:)`` subscription.
+  ///
+  /// ```swift
+  /// content
+  ///   .graphTracking {
+  ///     withGraphTrackingGroup {
+  ///       print(model.count)
+  ///     }
+  ///   }
+  /// ```
+  ///
+  /// - Parameter scope: A closure that registers StateGraph tracking operations.
+  /// - Returns: A view that keeps the tracking subscription alive while it is visible.
+  public func graphTracking(
+    _ scope: @MainActor @escaping () -> Void
+  ) -> some View {
+    modifier(
+      GraphTrackingViewModifier(
+        id: GraphTrackingStableID(),
+        scope: scope
+      )
+    )
+  }
+
+  /// Starts a StateGraph tracking scope while this view is visible, restarting when an identity changes.
+  ///
+  /// Use this overload when the tracking closure captures a value that can be replaced while the
+  /// view remains mounted. When `id` changes, the current subscription is cancelled and a new
+  /// tracking scope is created with the latest closure.
+  ///
+  /// ```swift
+  /// content
+  ///   .graphTracking(id: model.id) {
+  ///     withGraphTrackingMap {
+  ///       model.count
+  ///     } onChange: { count in
+  ///       print(count)
+  ///     }
+  ///   }
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - id: A value that identifies the dependencies captured by `scope`.
+  ///   - scope: A closure that registers StateGraph tracking operations.
+  /// - Returns: A view that keeps the tracking subscription alive while it is visible.
+  public func graphTracking<ID: Equatable>(
+    id: ID,
+    _ scope: @MainActor @escaping () -> Void
+  ) -> some View {
+    modifier(
+      GraphTrackingViewModifier(
+        id: id,
+        scope: scope
+      )
+    )
+  }
+}
+
+private struct GraphTrackingStableID: Equatable {}
+
+private struct GraphTrackingViewModifier<ID: Equatable>: ViewModifier {
+
+  let id: ID
+  let scope: @MainActor () -> Void
+
+  func body(content: Content) -> some View {
+    content
+      .task(id: id) { @MainActor in
+        let taskState = GraphTrackingTaskState()
+
+        await withTaskCancellationHandler {
+          let cancellable = withGraphTracking {
+            scope()
+          }
+          taskState.setCancellable(cancellable)
+          await taskState.waitUntilCancelled()
+        } onCancel: {
+          taskState.cancel()
+        }
+      }
+  }
+}
+
+/// Holds a graph tracking subscription until its SwiftUI task is cancelled.
+///
+/// `withGraphTracking` returns a synchronous `AnyCancellable`, so the SwiftUI task must stay
+/// alive to retain that cancellable until the view disappears or the task identity changes.
+/// This state object keeps the subscription and the waiting continuation behind a lock so
+/// cancellation can safely arrive before or after the subscription is created.
+private final class GraphTrackingTaskState: @unchecked Sendable {
+
+  private struct State {
+    var cancellable: AnyCancellable?
+    var continuation: CheckedContinuation<Void, Never>?
+    var isCancelled = false
+  }
+
+  private let state = OSAllocatedUnfairLock(uncheckedState: State())
+
+  func setCancellable(_ cancellable: AnyCancellable) {
+    let shouldCancelImmediately = state.withLock { state in
+      if state.isCancelled {
+        return true
+      }
+      state.cancellable = cancellable
+      return false
+    }
+
+    if shouldCancelImmediately {
+      cancellable.cancel()
+    }
+  }
+
+  func waitUntilCancelled() async {
+    await withCheckedContinuation { continuation in
+      let shouldResumeImmediately = state.withLock { state in
+        if state.isCancelled {
+          return true
+        }
+        state.continuation = continuation
+        return false
+      }
+
+      if shouldResumeImmediately {
+        continuation.resume()
+      }
+    }
+  }
+
+  func cancel() {
+    let cancellation = state.withLock { state -> (AnyCancellable?, CheckedContinuation<Void, Never>?) in
+      guard !state.isCancelled else {
+        return (nil, nil)
+      }
+      state.isCancelled = true
+      defer {
+        state.cancellable = nil
+        state.continuation = nil
+      }
+      return (state.cancellable, state.continuation)
+    }
+
+    cancellation.0?.cancel()
+    cancellation.1?.resume()
+  }
+}
+
+#endif

--- a/Tests/StateGraphTests/SwiftUIGraphTrackingTests.swift
+++ b/Tests/StateGraphTests/SwiftUIGraphTrackingTests.swift
@@ -1,0 +1,48 @@
+#if canImport(SwiftUI)
+
+import SwiftUI
+import Testing
+
+@testable import StateGraph
+
+@Suite("SwiftUI GraphTracking Tests")
+struct SwiftUIGraphTrackingTests {
+
+  @Test
+  @MainActor
+  func graphTrackingModifierBuildsView() {
+    let model = GraphTrackingModifierModel()
+
+    let view = Text("Count")
+      .graphTracking {
+        withGraphTrackingGroup {
+          _ = model.count
+        }
+      }
+
+    _ = view
+  }
+
+  @Test
+  @MainActor
+  func graphTrackingIDModifierBuildsView() {
+    let model = GraphTrackingModifierModel()
+
+    let view = Text("Count")
+      .graphTracking(id: ObjectIdentifier(model)) {
+        withGraphTrackingMap {
+          model.count
+        } onChange: { _ in
+        }
+      }
+
+    _ = view
+  }
+}
+
+private final class GraphTrackingModifierModel {
+
+  @GraphStored var count: Int = 0
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds a SwiftUI `.graphTracking` modifier that hosts a `withGraphTracking` subscription for the lifetime of the view task. It also adds an `id:` overload so captured dependencies can restart tracking when their identity changes.

## Details

- Adds `View.graphTracking { ... }` and `View.graphTracking(id:) { ... }`.
- Keeps the synchronous `AnyCancellable` alive through SwiftUI's `task(id:)` lifecycle using a lock-backed cancellation state.
- Updates the Development sample to use the modifier instead of a hand-retained `AnyCancellable`.
- Documents lifecycle tracking in README and DocC.
- Adds SwiftUI compile coverage for both modifier overloads.

## Validation

- `swift test --filter SwiftUIGraphTrackingTests`
- `swift test`
- XcodeBuildMCP `build_sim` for the `Development` scheme