### PR TITLE
Run graph tracking handlers outside locks

### DIFF
--- a/Sources/StateGraph/Observation/withGraphTrackingGroup.swift
+++ b/Sources/StateGraph/Observation/withGraphTrackingGroup.swift
@@ -95,13 +95,11 @@ public func withGraphTrackingGroup(
     return
   }
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
-    uncheckedState: ClosureBox(handler)
-  )
+  let trackingHandler = GraphTrackingHandler(handler)
 
   // Create a cancellable for this scope that manages nested tracking
   let scopeCancellable = GraphTrackingCancellable {
-    _handlerBox.withLock { $0 = nil }
+    trackingHandler.cancel()
   }
 
   withContinuousStateGraphTracking(
@@ -112,13 +110,11 @@ public func withGraphTrackingGroup(
       // Set this scope's cancellable as the current parent for nested tracking
       // Nested groups/maps will register with this parent via addChild()
       ThreadLocal.currentCancellable.withValue(scopeCancellable) {
-        _handlerBox.withLock {
-          $0?()
-        }
+        trackingHandler.invoke()
       }
     },
     didChange: {
-      guard !_handlerBox.withLock({ $0 == nil }) else { return .stop }
+      guard !trackingHandler.isCancelled else { return .stop }
       return .next
     },
     isolation: isolation

--- a/Sources/StateGraph/Observation/withGraphTrackingMap.swift
+++ b/Sources/StateGraph/Observation/withGraphTrackingMap.swift
@@ -137,19 +137,17 @@ public func withGraphTrackingMap<Projection>(
 
   var filter = filter
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
-    uncheckedState: ClosureBox({
-      let result = applier()
-      let filtered = filter.send(value: result)
-      if let filtered {
-        onChange(filtered)
-      }
-    })
-  )
+  let trackingHandler = GraphTrackingHandler {
+    let result = applier()
+    let filtered = filter.send(value: result)
+    if let filtered {
+      onChange(filtered)
+    }
+  }
 
   // Create a cancellable for this scope that manages nested tracking
   let scopeCancellable = GraphTrackingCancellable {
-    _handlerBox.withLock { $0 = nil }
+    trackingHandler.cancel()
   }
 
   withContinuousStateGraphTracking(
@@ -160,11 +158,11 @@ public func withGraphTrackingMap<Projection>(
       // Set this scope's cancellable as the current parent for nested tracking
       // Nested groups/maps will register with this parent via addChild()
       ThreadLocal.currentCancellable.withValue(scopeCancellable) {
-        _handlerBox.withLock { $0?() }
+        trackingHandler.invoke()
       }
     },
     didChange: {
-      guard !_handlerBox.withLock({ $0 == nil }) else { return .stop }
+      guard !trackingHandler.isCancelled else { return .stop }
       return .next
     },
     isolation: isolation
@@ -301,32 +299,30 @@ public func withGraphTrackingMap<Dependency: AnyObject, Projection>(
     return
   }
 
-  weak var weakDependency = from
+  weak let weakDependency = from
 
   var filter = filter
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
-    uncheckedState: ClosureBox({
-      guard let dependency = weakDependency else {
-        return
-      }
-      let result = map(dependency)
-      let filtered = filter.send(value: result)
-      if let filtered {
-        onChange(filtered)
-      }
-    })
-  )
+  let trackingHandler = GraphTrackingHandler {
+    guard let dependency = weakDependency else {
+      return
+    }
+    let result = map(dependency)
+    let filtered = filter.send(value: result)
+    if let filtered {
+      onChange(filtered)
+    }
+  }
 
   // Create a cancellable for this scope that manages nested tracking
   let scopeCancellable = GraphTrackingCancellable {
-    _handlerBox.withLock { $0 = nil }
+    trackingHandler.cancel()
   }
 
   withContinuousStateGraphTracking(
     apply: {
       guard weakDependency != nil else {
-        _handlerBox.withLock { $0 = nil }
+        trackingHandler.cancel()
         return
       }
       // Cancel all children before re-executing (cleans up nested subscriptions)
@@ -335,11 +331,11 @@ public func withGraphTrackingMap<Dependency: AnyObject, Projection>(
       // Set this scope's cancellable as the current parent for nested tracking
       // Nested groups/maps will register with this parent via addChild()
       ThreadLocal.currentCancellable.withValue(scopeCancellable) {
-        _handlerBox.withLock { $0?() }
+        trackingHandler.invoke()
       }
     },
     didChange: {
-      guard !_handlerBox.withLock({ $0 == nil }) else { return .stop }
+      guard !trackingHandler.isCancelled else { return .stop }
       guard weakDependency != nil else { return .stop }
       return .next
     },

--- a/Sources/StateGraph/Observation/withTracking.swift
+++ b/Sources/StateGraph/Observation/withTracking.swift
@@ -59,6 +59,77 @@ struct ClosureBox<R> {
   }
 }
 
+/// Owns a tracking handler's lifetime and serializes its execution.
+///
+/// The state lock is held only while updating invocation state. The handler runs
+/// after the lock is released so it may cancel its own tracking scope safely.
+final class GraphTrackingHandler: @unchecked Sendable {
+
+  /// Immutable closure storage whose execution is serialized by the owning state machine.
+  private struct Handler: @unchecked Sendable {
+    let closure: () -> Void
+
+    func callAsFunction() {
+      closure()
+    }
+  }
+
+  private struct State {
+    var handler: Handler?
+    var isInvoking = false
+    var needsInvocation = false
+  }
+
+  private let state: OSAllocatedUnfairLock<State>
+
+  init(_ handler: @escaping () -> Void) {
+    self.state = .init(
+      uncheckedState: .init(handler: .init(closure: handler))
+    )
+  }
+
+  var isCancelled: Bool {
+    state.withLock { $0.handler == nil }
+  }
+
+  func invoke() {
+    let shouldDrain = state.withLock { state in
+      guard state.handler != nil else { return false }
+
+      state.needsInvocation = true
+      guard !state.isInvoking else { return false }
+
+      state.isInvoking = true
+      return true
+    }
+
+    guard shouldDrain else { return }
+
+    while let handler = takeNextHandler() {
+      handler()
+    }
+  }
+
+  func cancel() {
+    state.withLock { state in
+      state.handler = nil
+      state.needsInvocation = false
+    }
+  }
+
+  private func takeNextHandler() -> Handler? {
+    state.withLock { state in
+      guard state.needsInvocation, let handler = state.handler else {
+        state.isInvoking = false
+        return nil
+      }
+
+      state.needsInvocation = false
+      return handler
+    }
+  }
+}
+
 func perform<Return>(
   _ closure: () -> Return,
   isolation: isolated (any Actor)? = #isolation

--- a/Tests/StateGraphTests/GraphTrackingHandlerTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingHandlerTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+
+@testable import StateGraph
+
+@Suite("GraphTrackingHandler Tests")
+struct GraphTrackingHandlerTests {
+
+  private final class Counter: @unchecked Sendable {
+    private let value = OSAllocatedUnfairLock(initialState: 0)
+
+    var current: Int {
+      value.withLock { $0 }
+    }
+
+    @discardableResult
+    func increment() -> Int {
+      value.withLock {
+        $0 += 1
+        return $0
+      }
+    }
+  }
+
+  private final class HandlerHolder: @unchecked Sendable {
+    private let handler = OSAllocatedUnfairLock<GraphTrackingHandler?>(initialState: nil)
+
+    func store(_ handler: GraphTrackingHandler) {
+      self.handler.withLock { $0 = handler }
+    }
+
+    func invoke() {
+      handler.withLock { $0 }?.invoke()
+    }
+
+    func cancel() {
+      handler.withLock { $0 }?.cancel()
+    }
+  }
+
+  private final class InvocationProbe: @unchecked Sendable {
+    private struct State {
+      var activeCount = 0
+      var maximumActiveCount = 0
+      var invocationCount = 0
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    let firstInvocationStarted = DispatchSemaphore(value: 0)
+    let resumeFirstInvocation = DispatchSemaphore(value: 0)
+
+    var result: (invocationCount: Int, maximumActiveCount: Int) {
+      state.withLock { ($0.invocationCount, $0.maximumActiveCount) }
+    }
+
+    func invoke() {
+      let invocationCount = state.withLock { state in
+        state.activeCount += 1
+        state.maximumActiveCount = max(state.maximumActiveCount, state.activeCount)
+        state.invocationCount += 1
+        return state.invocationCount
+      }
+
+      if invocationCount == 1 {
+        firstInvocationStarted.signal()
+        resumeFirstInvocation.wait()
+      }
+
+      state.withLock { $0.activeCount -= 1 }
+    }
+  }
+
+  @Test
+  func trackingHandlerCanCancelItself() {
+    let holder = HandlerHolder()
+    let invocationCount = Counter()
+    let handler = GraphTrackingHandler {
+      invocationCount.increment()
+      holder.cancel()
+    }
+    holder.store(handler)
+
+    handler.invoke()
+    handler.invoke()
+
+    #expect(invocationCount.current == 1)
+  }
+
+  @Test
+  func reentrantInvocationsCoalesceIntoOneRerun() {
+    let holder = HandlerHolder()
+    let invocationCount = Counter()
+    let handler = GraphTrackingHandler {
+      if invocationCount.increment() == 1 {
+        holder.invoke()
+        holder.invoke()
+      }
+    }
+    holder.store(handler)
+
+    handler.invoke()
+
+    #expect(invocationCount.current == 2)
+  }
+
+  @Test
+  func concurrentInvocationsAreSerializedAndCoalesced() {
+    let probe = InvocationProbe()
+    let handler = GraphTrackingHandler {
+      probe.invoke()
+    }
+    let firstInvocationFinished = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global().async {
+      handler.invoke()
+      firstInvocationFinished.signal()
+    }
+
+    #expect(probe.firstInvocationStarted.wait(timeout: .now() + 1) == .success)
+
+    let pendingInvocations = DispatchGroup()
+    for _ in 0..<10 {
+      pendingInvocations.enter()
+      DispatchQueue.global().async {
+        handler.invoke()
+        pendingInvocations.leave()
+      }
+    }
+
+    #expect(pendingInvocations.wait(timeout: .now() + 1) == .success)
+    probe.resumeFirstInvocation.signal()
+    #expect(firstInvocationFinished.wait(timeout: .now() + 1) == .success)
+
+    let result = probe.result
+    #expect(result.invocationCount == 2)
+    #expect(result.maximumActiveCount == 1)
+  }
+}


### PR DESCRIPTION
## Summary

- introduce a small state machine for tracking-handler lifetime and execution
- invoke group/map user handlers after releasing the unfair lock
- serialize concurrent execution and coalesce pending invalidations into one rerun

## Root cause

Group and map tracking invoked user closures while `_handlerBox` was exclusively borrowed by an unfair lock. Cancelling the same scope from inside a handler attempted to reacquire that lock and could deadlock. Copying the closure out without additional state would avoid that deadlock but allow concurrent handlers to race over filter state.

## Invocation drain

The active invoker owns a drain loop. An invocation arriving while the handler is running sets `needsInvocation` and returns. After the current handler finishes, the owner consumes that flag and performs one latest-state rerun. If no work remains, it clears `isInvoking` and exits. This prevents lost wakeups without recursively growing the stack.

## Impact

Handlers may cancel their own tracking scope safely. Reentrant and concurrent invalidations do not execute the handler concurrently, and repeated pending requests are aggregated according to the existing continuous-tracking contract.

## Validation

- `swift test --filter GraphTrackingHandlerTests` (3 tests passed)
- Full `swift test` (38 XCTest tests and 125 Swift Testing tests passed)
- `git diff --check`
