### PR TITLE
Make node edge lifetimes safe

### DIFF
--- a/Sources/StateGraph/NodeStore.swift
+++ b/Sources/StateGraph/NodeStore.swift
@@ -41,8 +41,10 @@ public actor NodeStore {
 
     // edges
     let edges = allNodes
-      .flatMap(\.outgoingEdges).map {
-        "\(name($0.from)) -> \(name($0.to))\($0.isPending ? " [style=dashed]" : "")"
+      .flatMap { $0.outgoingEdgesSnapshot() }
+      .compactMap { edge -> String? in
+        guard let from = edge.from, let to = edge.to else { return nil }
+        return "\(name(from)) -> \(name(to))\(edge.isPending ? " [style=dashed]" : "")"
       }.joined(separator: "\n")
 
     return """

--- a/Sources/StateGraph/Primitives/Node.swift
+++ b/Sources/StateGraph/Primitives/Node.swift
@@ -17,6 +17,30 @@ public protocol TypeErasedNode: Hashable, AnyObject, Sendable, CustomDebugString
   func recomputeIfNeeded()
 }
 
+extension TypeErasedNode {
+
+  /// Returns an independent snapshot of the node's outgoing dependency edges.
+  func outgoingEdgesSnapshot() -> ContiguousArray<Edge> {
+    lock.lock()
+    defer { lock.unlock() }
+    return outgoingEdges
+  }
+
+  /// Removes an outgoing edge while holding the owning node's lock.
+  func removeOutgoingEdge(_ edge: Edge) {
+    lock.lock()
+    outgoingEdges.removeAll(where: { $0 === edge })
+    lock.unlock()
+  }
+
+  /// Removes an incoming edge while holding the owning node's lock.
+  func removeIncomingEdge(_ edge: Edge) {
+    lock.lock()
+    incomingEdges.removeAll(where: { $0 === edge })
+    lock.unlock()
+  }
+}
+
 public protocol Node: TypeErasedNode {
   
   associatedtype Value

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -301,7 +301,7 @@ public final class Computed<Value>: Node, Observable, CustomDebugStringConvertib
 #endif
 
       for edge in _outgoingEdges {
-        edge.to.potentiallyDirty = true
+        edge.to?.potentiallyDirty = true
       }
 
       for registration in _trackingRegistrations {
@@ -368,7 +368,8 @@ public final class Computed<Value>: Node, Observable, CustomDebugStringConvertib
     self.lock = .init()
 
 #if DEBUG
-    Task {
+    Task { [weak self] in
+      guard let self else { return }
       await NodeStore.shared.register(node: self)
     }
 #endif
@@ -400,7 +401,8 @@ public final class Computed<Value>: Node, Observable, CustomDebugStringConvertib
     self.lock = .init()
 
 #if DEBUG
-    Task {
+    Task { [weak self] in
+      guard let self else { return }
       await NodeStore.shared.register(node: self)
     }
 #endif
@@ -432,18 +434,30 @@ public final class Computed<Value>: Node, Observable, CustomDebugStringConvertib
     self.lock = .init()
    
 #if DEBUG
-    Task {
+    Task { [weak self] in
+      guard let self else { return }
       await NodeStore.shared.register(node: self)
     }
 #endif
   }
   
-    deinit {
-//      Log.generic.debug("Deinit Computed: \(self.info.name.map(String.init) ?? "noname")")
-      for edge in incomingEdges {
-        edge.from.outgoingEdges.removeAll(where: { $0 === edge })
-      }
+  deinit {
+//    Log.generic.debug("Deinit Computed: \(self.info.name.map(String.init) ?? "noname")")
+    lock.lock()
+    let incomingEdges = self.incomingEdges
+    let outgoingEdges = self.outgoingEdges
+    self.incomingEdges.removeAll()
+    self.outgoingEdges.removeAll()
+    lock.unlock()
+
+    for edge in incomingEdges {
+      edge.from?.removeOutgoingEdge(edge)
     }
+
+    for edge in outgoingEdges {
+      edge.to?.removeIncomingEdge(edge)
+    }
+  }
 
   public func recomputeIfNeeded() {
 
@@ -464,11 +478,15 @@ public final class Computed<Value>: Node, Observable, CustomDebugStringConvertib
 
     if !_potentiallyDirty && _cachedValue != nil { return }
 
+    incomingEdges.removeAll(where: { $0.from == nil })
+
     for edge in incomingEdges {
-      edge.from.recomputeIfNeeded()
+      edge.from?.recomputeIfNeeded()
     }
 
-    let hasPendingIncomingEdge = incomingEdges.contains(where: \.isPending)
+    let hasPendingIncomingEdge = incomingEdges.contains {
+      $0.from != nil && $0.isPending
+    }
 
     if hasPendingIncomingEdge || _cachedValue == nil {
 
@@ -506,16 +524,20 @@ public final class Computed<Value>: Node, Observable, CustomDebugStringConvertib
   }
 
   private func removeIncomingEdges() {
+    let incomingEdges = self.incomingEdges
+    self.incomingEdges.removeAll()
+
     for edge in incomingEdges {
-      edge.from.lock.lock()
-      edge.from.outgoingEdges.removeAll(where: { $0 === edge })
-      edge.from.lock.unlock()
+      edge.from?.removeOutgoingEdge(edge)
     }
-    incomingEdges.removeAll()
   }
    
   public var debugDescription: String {
-    "Computed<\(Value.self)>(name=\(info.name.map(String.init) ?? "noname"), value=\(String(describing: _cachedValue)))"
+    lock.lock()
+    let cachedValue = _cachedValue
+    lock.unlock()
+
+    return "Computed<\(Value.self)>(name=\(info.name.map(String.init) ?? "noname"), value=\(String(describing: cachedValue)))"
   }
   
 }
@@ -567,11 +589,11 @@ extension Computed {
   
 }
 
-@DebugDescription
+/// A dependency link whose lifetime does not keep either endpoint alive.
 public final class Edge: CustomDebugStringConvertible {
 
-  unowned let from: any TypeErasedNode
-  unowned let to: any TypeErasedNode
+  weak var from: (any TypeErasedNode)?
+  weak var to: (any TypeErasedNode)?
   
   private let lock: OSAllocatedUnfairLock<Void> = .init()
   
@@ -596,7 +618,11 @@ public final class Edge: CustomDebugStringConvertible {
   }
 
   public var debugDescription: String {
-    "\(from.debugDescription) -> \(to.debugDescription)"
+    guard let from, let to else {
+      return "Edge(deallocated endpoint)"
+    }
+
+    return "\(from.debugDescription) -> \(to.debugDescription)"
   }
 
   deinit {

--- a/Sources/StateGraph/StorageAbstraction.swift
+++ b/Sources/StateGraph/StorageAbstraction.swift
@@ -229,7 +229,7 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
 
       for edge in _outgoingEdges {
         edge.isPending = true
-        edge.to.potentiallyDirty = true
+        edge.to?.potentiallyDirty = true
       }
 
       _didSetHandler?(oldValue, newValue)
@@ -262,7 +262,7 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
 
     for edge in _outgoingEdges {
       edge.isPending = true
-      edge.to.potentiallyDirty = true
+      edge.to?.potentiallyDirty = true
     }
   }
   
@@ -305,7 +305,8 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
     }))
 
 #if DEBUG
-    Task {
+    Task { [weak self] in
+      guard let self else { return }
       await NodeStore.shared.register(node: self)
     }
 #endif
@@ -313,10 +314,15 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
   
   deinit {
 //    Log.generic.debug("Deinit StoredNode: \(self.info.name.map(String.init) ?? "noname")")
+    lock.lock()
+    let outgoingEdges = self.outgoingEdges
+    self.outgoingEdges.removeAll()
+    lock.unlock()
+
     for edge in outgoingEdges {
-      edge.to.incomingEdges.removeAll(where: { $0 === edge })
+      edge.to?.removeIncomingEdge(edge)
     }
-    outgoingEdges.removeAll()
+
     storage.unloaded()
   }
   
@@ -325,7 +331,10 @@ public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDe
   }
   
   public var debugDescription: String {
+    lock.lock()
     let value = storage.value
+    lock.unlock()
+
     let typeName = _typeName(type(of: self))    
     return "\(typeName)(name=\(info.name.map(String.init) ?? "noname"), value=\(String(describing: value)))"
   }

--- a/Tests/StateGraphTests/NodeLifecycleTests.swift
+++ b/Tests/StateGraphTests/NodeLifecycleTests.swift
@@ -1,0 +1,29 @@
+import StateGraph
+import Testing
+
+@Suite("Node Lifecycle Tests")
+struct NodeLifecycleTests {
+
+  @Test
+  func releasingUpstreamComputedRemovesDownstreamEdge() async {
+    let trigger = Stored(wrappedValue: 0)
+    var upstream: Computed<Int>? = Computed { _ in 10 }
+    weak let weakUpstream = upstream
+    let downstream = Computed { [weak upstream] _ in
+      (upstream?.wrappedValue ?? 0) + trigger.wrappedValue
+    }
+
+    #expect(downstream.wrappedValue == 10)
+
+    upstream = nil
+
+    for _ in 0..<100 where weakUpstream != nil {
+      try? await Task.sleep(for: .milliseconds(1))
+    }
+
+    #expect(weakUpstream == nil)
+
+    trigger.wrappedValue = 1
+    #expect(downstream.wrappedValue == 1)
+  }
+}


### PR DESCRIPTION
## Summary

- make dependency-edge endpoints weak so an edge never outlives an endpoint through ownership
- detach both incoming and outgoing edges without holding two node locks at once
- snapshot debug and topology state under the owning node's lock
- prevent debug registration tasks from unnecessarily extending node lifetime

## Root cause

`Computed.deinit` removed only its incoming edges. Its outgoing edges could remain in downstream nodes while retaining unowned endpoint references, so a later downstream recomputation could dereference a released upstream node. Debug-only graph registration and graph rendering also accessed node lifetime or edge collections without a consistent ownership boundary.

## Behavior

After an upstream computed node is released, downstream nodes treat the missing endpoint as an absent dependency and remain valid. Node teardown first snapshots and clears the node-owned edge collection, releases that node's lock, and then removes each edge from the opposite endpoint.

## Scope

This PR does not redesign the public mutable topology surface exposed by `TypeErasedNode`. It limits the change to endpoint lifetime, teardown, propagation, and debug snapshots.

## Validation

- `swift test --filter NodeLifecycleTests` (1 test passed)
- `swift test` (38 XCTest tests and 123 Swift Testing tests passed)
- `git diff --check`
