### PR TITLE
Adopt SendableMetatype for graph values

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import CompilerPluginSupport

--- a/Sources/StateGraph/Primitives/Node.swift
+++ b/Sources/StateGraph/Primitives/Node.swift
@@ -48,7 +48,7 @@ extension Node {
     }
     ```
   */
-  public func map<ComputedValue>(
+  public func map<ComputedValue: SendableMetatype>(
     _ project: @escaping @Sendable (Computed<ComputedValue>.Context, Self.Value) -> ComputedValue
   ) -> Computed<ComputedValue> {
     return Computed { context in

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -17,7 +17,10 @@ import Foundation.NSLock
 ///
 /// - When value changes: Changes propagate to all dependent nodes, triggering recalculations
 /// - When value is accessed: Dependencies are recorded, automatically building the graph structure
-public typealias Stored<Value> = _Stored<Value, InMemoryStorage<Value>>
+///
+/// `Value` itself does not need to conform to `Sendable`. `SendableMetatype` allows the
+/// node's isolated closures to use generic conformances safely.
+public typealias Stored<Value: SendableMetatype> = _Stored<Value, InMemoryStorage<Value>>
 
 extension _Stored where S == InMemoryStorage<Value> {
   /// Convenience initializer with wrappedValue (non-Equatable types)
@@ -103,9 +106,13 @@ extension _Stored where S == InMemoryStorage<Value>, Value: Equatable & AnyObjec
   }
 }
 
+/// Describes how a computed node produces and compares values.
+///
+/// `Value` itself does not need to conform to `Sendable`. `SendableMetatype` allows the
+/// descriptor's sendable closures to use generic conformances safely.
 public protocol ComputedDescriptor<Value>: Sendable {
   
-  associatedtype Value
+  associatedtype Value: SendableMetatype
   
   func compute(context: inout Computed<Value>.Context) -> Value
   
@@ -115,14 +122,14 @@ public protocol ComputedDescriptor<Value>: Sendable {
 extension ComputedDescriptor {
   
   @Sendable
-  public static func any<Value>(
+  public static func any<Value: SendableMetatype>(
     _ compute: @Sendable @escaping (inout Computed<Value>.Context) -> Value
   ) -> Self where Self == AnyComputedDescriptor<Value> {
     AnyComputedDescriptor(compute: compute, isEqual: { _, _ in false })
   }
   
   @Sendable
-  public static func any<Value>(
+  public static func any<Value: SendableMetatype>(
     _ compute: @Sendable @escaping (
       inout Computed<Value>.Context
     ) -> Value
@@ -132,7 +139,7 @@ extension ComputedDescriptor {
   
 }
 
-public struct AnyComputedDescriptor<Value>: ComputedDescriptor {
+public struct AnyComputedDescriptor<Value: SendableMetatype>: ComputedDescriptor {
 
   private let computeClosure: @Sendable (inout Computed<Value>.Context) -> Value
   private let isEqualClosure: @Sendable (Value, Value) -> Bool
@@ -147,7 +154,7 @@ public struct AnyComputedDescriptor<Value>: ComputedDescriptor {
   
   public init(
     compute: @escaping @Sendable (inout Computed<Value>.Context) -> Value
-  ) where Value : Equatable {
+  ) where Value: Equatable {
     self.computeClosure = compute  
     self.isEqualClosure = { $0 == $1 }
   }
@@ -209,8 +216,10 @@ public enum StateGraphGlobal {
 /// - Value is lazily computed: Calculations only occur when the value is accessed
 /// - Dependencies are tracked: The node automatically tracks which nodes it depends on
 /// - Changes propagate: When this node's value changes, downstream nodes are notified
-/// ```
-public final class Computed<Value>: Node, Observable, CustomDebugStringConvertible {
+///
+/// `Value` itself does not need to conform to `Sendable`. `SendableMetatype` allows the
+/// node's isolated closures to use generic conformances safely.
+public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDebugStringConvertible {
     
   public struct Context {
     

--- a/Sources/StateGraph/Primitives/UserDefaultsStored.swift
+++ b/Sources/StateGraph/Primitives/UserDefaultsStored.swift
@@ -181,7 +181,11 @@ extension Optional: UserDefaultsStorable where Wrapped: UserDefaultsStorable {
 ///
 /// - When value changes: Changes propagate to all dependent nodes and are persisted to UserDefaults
 /// - When value is accessed: Dependencies are recorded and the value is loaded from UserDefaults if needed
-public typealias UserDefaultsStored<Value: UserDefaultsStorable> = _Stored<Value, UserDefaultsStorage<Value>>
+///
+/// `Value` itself does not need to conform to `Sendable`; only its metatype must be sendable.
+public typealias UserDefaultsStored<
+  Value: UserDefaultsStorable & SendableMetatype
+> = _Stored<Value, UserDefaultsStorage<Value>>
   
 extension _Stored where S == UserDefaultsStorage<Value> {
   /// Initializes a UserDefaultsStored node with standard UserDefaults.

--- a/Sources/StateGraph/StorageAbstraction.swift
+++ b/Sources/StateGraph/StorageAbstraction.swift
@@ -132,7 +132,14 @@ public final class UserDefaultsStorage<Value: UserDefaultsStorable>: Storage, Se
 
 // MARK: - Base Stored Node
 
-public final class _Stored<Value, S: Storage<Value>>: Node, Observable, CustomDebugStringConvertible {
+/// A graph node backed by a pluggable storage implementation.
+///
+/// `Value` itself does not need to conform to `Sendable`. `SendableMetatype` allows the
+/// node's isolated closures to use generic conformances safely.
+public final class _Stored<
+  Value: SendableMetatype,
+  S: Storage<Value>
+>: Node, Observable, CustomDebugStringConvertible {
 
   public let lock: NodeLock
 

--- a/Tests/StateGraphTests/SendableMetatypeTests.swift
+++ b/Tests/StateGraphTests/SendableMetatypeTests.swift
@@ -1,0 +1,43 @@
+import Testing
+
+@testable import StateGraph
+
+/// A reference value that intentionally does not conform to `Sendable`.
+private final class NonSendableEquatableValue: Equatable {
+
+  let rawValue: Int
+
+  init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+
+  static func == (lhs: NonSendableEquatableValue, rhs: NonSendableEquatableValue) -> Bool {
+    lhs.rawValue == rhs.rawValue
+  }
+}
+
+private func makeEquatableStored<Value: Equatable & SendableMetatype>(
+  _ value: Value
+) -> Stored<Value> {
+  Stored(wrappedValue: value)
+}
+
+private func makeEquatableComputed<Value: Equatable & SendableMetatype>(
+  _ rule: @escaping @Sendable (inout Computed<Value>.Context) -> Value
+) -> Computed<Value> {
+  Computed(rule: rule)
+}
+
+@Suite
+struct SendableMetatypeTests {
+
+  @Test
+  func equatableNodesAcceptNonSendableValues() {
+    let stored = makeEquatableStored(NonSendableEquatableValue(rawValue: 1))
+    let computed = makeEquatableComputed { _ in
+      NonSendableEquatableValue(rawValue: stored.wrappedValue.rawValue + 1)
+    }
+
+    #expect(computed.wrappedValue.rawValue == 2)
+  }
+}


### PR DESCRIPTION
## Summary

- raise the package tools version to Swift 6.3
- require `SendableMetatype` at graph-node generic boundaries that move type metadata and protocol conformances through isolated closures
- preserve support for non-`Sendable` values and cover it with a focused regression test

## Root cause

Swift 6.3 closure-isolation checking diagnoses captures of generic `Value.Type` in StateGraph's isolated closures. In particular, the `@Sendable` equality closure uses the generic `Equatable` conformance, and debug registration tasks capture the surrounding generic context. Without a `SendableMetatype` requirement, those conformances could theoretically be global-actor isolated and therefore unsafe to use from another isolation domain.

`SendableMetatype` is narrower than `Sendable`: it permits the metatype and nonisolated conformances to cross isolation boundaries without requiring `Value` instances themselves to be sendable.

## API impact

Concrete structs, enums, classes, and actors implicitly conform to `SendableMetatype`, so ordinary call sites remain unchanged. Generic wrappers around `Stored`, `Computed`, or `ComputedDescriptor` may need to propagate a `SendableMetatype` constraint.

## Scope

This PR does not change locking, storage behavior, graph topology, or node/edge lifecycle. It is intentionally separate from #111.

## Validation

- `swift build --target StateGraph -Xswiftc -enable-experimental-feature -Xswiftc ClosureIsolation -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency`
- `swift test --filter SendableMetatypeTests` (1 test passed)
- `swift test --no-parallel` (38 XCTest tests and 125 Swift Testing tests passed)
- `git diff --check`

The strict-concurrency build no longer emits the four `Value.Type` warnings. Existing warnings in `GraphTracking` and weak-variable tests remain unchanged.