### PR TITLE
Stabilize parallel package tests

### DIFF
--- a/Tests/StateGraphNormalizationTests/NormalizationTests.swift
+++ b/Tests/StateGraphNormalizationTests/NormalizationTests.swift
@@ -196,6 +196,58 @@ private actor ConcurrentStartGate {
   }
 }
 
+/// A one-shot signal that lets synchronous store callbacks resume async test code.
+///
+/// Waiting suspends the test task, which avoids exhausting cooperative-executor threads
+/// when synchronization tests run in parallel with the rest of the package.
+private final class TestSignal: @unchecked Sendable {
+
+  private struct State {
+    var isSignaled = false
+    var waiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+  }
+
+  private let state = OSAllocatedUnfairLock(initialState: State())
+
+  func signal() {
+    let waiters = state.withLock { state in
+      guard !state.isSignaled else { return [CheckedContinuation<Bool, Never>]() }
+
+      state.isSignaled = true
+      let waiters = Array(state.waiters.values)
+      state.waiters.removeAll()
+      return waiters
+    }
+
+    waiters.forEach { $0.resume(returning: true) }
+  }
+
+  func wait(for timeout: Duration) async -> Bool {
+    let id = UUID()
+
+    return await withCheckedContinuation { continuation in
+      let isAlreadySignaled = state.withLock { state in
+        guard !state.isSignaled else { return true }
+        state.waiters[id] = continuation
+        return false
+      }
+
+      guard !isAlreadySignaled else {
+        continuation.resume(returning: true)
+        return
+      }
+
+      Task.detached { [self] in
+        try? await Task.sleep(for: timeout)
+        let waiter = state.withLock { state in
+          state.waiters.removeValue(forKey: id)
+        }
+        waiter?.resume(returning: false)
+      }
+    }
+  }
+}
+
 @Suite
 struct NormalizationTests {
 
@@ -321,17 +373,18 @@ struct NormalizationTests {
     #expect(childStore.contains(.init(2)))
   }
 
-  @Test func readWaitsForCoordinatedMutation() {
+  @Test func readWaitsForCoordinatedMutation() async {
     let coordinator = EntityStoreCoordinator()
     let store = EntityStore<ValueEntity>(
       entities: [.init(1): .init(id: 1, value: 1)],
       coordinator: coordinator
     )
-    let mutationStarted = DispatchSemaphore(value: 0)
+    let mutationStarted = TestSignal()
     let allowMutationToFinish = DispatchSemaphore(value: 0)
-    let readStarted = DispatchSemaphore(value: 0)
-    let readFinished = DispatchSemaphore(value: 0)
+    let readStarted = TestSignal()
+    let readFinished = TestSignal()
     let work = DispatchGroup()
+    let workFinished = TestSignal()
     let readValue = OSAllocatedUnfairLock<Int?>(initialState: nil)
 
     work.enter()
@@ -348,7 +401,7 @@ struct NormalizationTests {
       work.leave()
     }
 
-    #expect(mutationStarted.wait(timeout: .now() + .seconds(5)) == .success)
+    #expect(await mutationStarted.wait(for: .seconds(5)))
 
     work.enter()
     DispatchQueue.global().async {
@@ -358,17 +411,21 @@ struct NormalizationTests {
       work.leave()
     }
 
-    #expect(readStarted.wait(timeout: .now() + .seconds(5)) == .success)
-    #expect(readFinished.wait(timeout: .now() + .milliseconds(100)) == .timedOut)
+    work.notify(queue: .global()) {
+      workFinished.signal()
+    }
+
+    #expect(await readStarted.wait(for: .seconds(5)))
+    #expect(await !readFinished.wait(for: .milliseconds(100)))
 
     allowMutationToFinish.signal()
 
-    #expect(readFinished.wait(timeout: .now() + .seconds(5)) == .success)
-    #expect(work.wait(timeout: .now() + .seconds(5)) == .success)
+    #expect(await readFinished.wait(for: .seconds(5)))
+    #expect(await workFinished.wait(for: .seconds(5)))
     #expect(readValue.withLock { $0 } == 2)
   }
 
-  @Test func sharedCoordinatorBlocksReadsAcrossStores() {
+  @Test func sharedCoordinatorBlocksReadsAcrossStores() async {
     let coordinator = EntityStoreCoordinator()
     let mutatingStore = EntityStore<ValueEntity>(
       entities: [.init(1): .init(id: 1, value: 1)],
@@ -378,11 +435,12 @@ struct NormalizationTests {
       entities: [.init(2): .init(id: 2, value: 2)],
       coordinator: coordinator
     )
-    let mutationStarted = DispatchSemaphore(value: 0)
+    let mutationStarted = TestSignal()
     let allowMutationToFinish = DispatchSemaphore(value: 0)
-    let readStarted = DispatchSemaphore(value: 0)
-    let readFinished = DispatchSemaphore(value: 0)
+    let readStarted = TestSignal()
+    let readFinished = TestSignal()
     let work = DispatchGroup()
+    let workFinished = TestSignal()
 
     work.enter()
     DispatchQueue.global().async {
@@ -397,7 +455,7 @@ struct NormalizationTests {
       work.leave()
     }
 
-    #expect(mutationStarted.wait(timeout: .now() + .seconds(5)) == .success)
+    #expect(await mutationStarted.wait(for: .seconds(5)))
 
     work.enter()
     DispatchQueue.global().async {
@@ -407,13 +465,17 @@ struct NormalizationTests {
       work.leave()
     }
 
-    #expect(readStarted.wait(timeout: .now() + .seconds(5)) == .success)
-    #expect(readFinished.wait(timeout: .now() + .milliseconds(100)) == .timedOut)
+    work.notify(queue: .global()) {
+      workFinished.signal()
+    }
+
+    #expect(await readStarted.wait(for: .seconds(5)))
+    #expect(await !readFinished.wait(for: .milliseconds(100)))
 
     allowMutationToFinish.signal()
 
-    #expect(readFinished.wait(timeout: .now() + .seconds(5)) == .success)
-    #expect(work.wait(timeout: .now() + .seconds(5)) == .success)
+    #expect(await readFinished.wait(for: .seconds(5)))
+    #expect(await workFinished.wait(for: .seconds(5)))
   }
 
   @Test func getAllReturnsIndependentSnapshot() {

--- a/Tests/StateGraphTests/GraphTrackingGroupTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingGroupTests.swift
@@ -692,7 +692,9 @@ struct ContinuousTrackingTests {
 
 }
 
-@Suite
+// These tests intentionally suspend a synchronous tracking handler. Running both at once can
+// occupy every cooperative-executor worker on small CI machines before either test can resume it.
+@Suite(.serialized)
 struct IssuesTrackingOnHeavyOperation {
 
   final class Model: Sendable {
@@ -706,7 +708,11 @@ struct IssuesTrackingOnHeavyOperation {
   func stuck() async {
 
     let model = Model()
-
+    let handlerStarted = DispatchSemaphore(value: 0)
+    let handlerFinished = TestSignal()
+    let resumeHandler = DispatchSemaphore(value: 0)
+    let coordinatorFinished = TestSignal()
+    let coordinatorObservedHandler = OSAllocatedUnfairLock(initialState: false)
     var cancellable: AnyCancellable?
 
     await confirmation(expectedCount: 1) { c in
@@ -716,26 +722,32 @@ struct IssuesTrackingOnHeavyOperation {
 
           if model.count2 == 2 {
             c.confirm()
+            handlerFinished.signal()
           }
 
-          if model.count1 == 1 {
-            Thread.sleep(forTimeInterval: 2)
+          if model.count1 == 1, model.count2 != 2 {
+            handlerStarted.signal()
+            resumeHandler.wait()
           }
 
         }
       }
-      Task.detached {
-        print("Update count1")
-        model.count1 = 1
-        Task.detached {
-          try? await Task.sleep(for: .milliseconds(100))
-          print("Update count2")
+
+      DispatchQueue.global().async {
+        let didObserveHandler = handlerStarted.wait(timeout: .now() + .seconds(5)) == .success
+        coordinatorObservedHandler.withLock { $0 = didObserveHandler }
+        if didObserveHandler {
           model.count2 = 2
         }
+        resumeHandler.signal()
+        coordinatorFinished.signal()
       }
 
-      try? await Task.sleep(for: .seconds(3))
+      model.count1 = 1
 
+      #expect(await handlerFinished.wait(for: .seconds(5)))
+      #expect(await coordinatorFinished.wait(for: .seconds(5)))
+      #expect(coordinatorObservedHandler.withLock { $0 })
       #expect(model.count2 == 2)
     }
 
@@ -747,6 +759,12 @@ struct IssuesTrackingOnHeavyOperation {
   func stuckMain() async {
 
     let model = Model()
+    let trackingStarted = TestSignal()
+    let handlerStarted = DispatchSemaphore(value: 0)
+    let handlerFinished = TestSignal()
+    let resumeHandler = DispatchSemaphore(value: 0)
+    let coordinatorFinished = TestSignal()
+    let coordinatorObservedHandler = OSAllocatedUnfairLock(initialState: false)
 
     await confirmation(expectedCount: 1) { c in
 
@@ -758,18 +776,16 @@ struct IssuesTrackingOnHeavyOperation {
         
         let _cancellable = withGraphTracking {
           withGraphTrackingGroup {
-            print("💥 In")
             #expect(Thread.isMainThread)
             if model.count2 == 2 {
-              print("✨ confirm")
               c.confirm()
+              handlerFinished.signal()
             }
             
-            if model.count1 == 1 {
-              print("😪 sleep")
-              Thread.sleep(forTimeInterval: 2)
+            if model.count1 == 1, model.count2 != 2 {
+              handlerStarted.signal()
+              resumeHandler.wait()
             }
-            print("💥 out")
             
           }
         }
@@ -777,24 +793,28 @@ struct IssuesTrackingOnHeavyOperation {
         cancellable.withLockUnchecked {
           $0 = _cancellable
         }
+        trackingStarted.signal()
       }
 
-      Task {        
-        try? await Task.sleep(for: .milliseconds(100))
-        print("Update count1")
-        model.count1 = 1
-        Task {
-          try? await Task.sleep(for: .milliseconds(100))
-          print("Update count2")
+      #expect(await trackingStarted.wait(for: .seconds(5)))
+
+      DispatchQueue.global().async {
+        let didObserveHandler = handlerStarted.wait(timeout: .now() + .seconds(5)) == .success
+        coordinatorObservedHandler.withLock { $0 = didObserveHandler }
+        if didObserveHandler {
           model.count2 = 2
         }
-
-        withExtendedLifetime(cancellable) {}
+        resumeHandler.signal()
+        coordinatorFinished.signal()
       }
 
-      try? await Task.sleep(for: .seconds(4))
+      model.count1 = 1
+      #expect(await handlerFinished.wait(for: .seconds(5)))
+      #expect(await coordinatorFinished.wait(for: .seconds(5)))
+      #expect(coordinatorObservedHandler.withLock { $0 })
       #expect(model.count2 == 2)
 
+      withExtendedLifetime(cancellable) {}
     }
 
   }

--- a/Tests/StateGraphTests/GraphTrackingHandlerTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingHandlerTests.swift
@@ -46,7 +46,7 @@ struct GraphTrackingHandlerTests {
     }
 
     private let state = OSAllocatedUnfairLock(initialState: State())
-    let firstInvocationStarted = DispatchSemaphore(value: 0)
+    let firstInvocationStarted = TestSignal()
     let resumeFirstInvocation = DispatchSemaphore(value: 0)
 
     var result: (invocationCount: Int, maximumActiveCount: Int) {
@@ -104,21 +104,22 @@ struct GraphTrackingHandlerTests {
   }
 
   @Test
-  func concurrentInvocationsAreSerializedAndCoalesced() {
+  func concurrentInvocationsAreSerializedAndCoalesced() async {
     let probe = InvocationProbe()
     let handler = GraphTrackingHandler {
       probe.invoke()
     }
-    let firstInvocationFinished = DispatchSemaphore(value: 0)
+    let firstInvocationFinished = TestSignal()
 
     DispatchQueue.global().async {
       handler.invoke()
       firstInvocationFinished.signal()
     }
 
-    #expect(probe.firstInvocationStarted.wait(timeout: .now() + 1) == .success)
+    #expect(await probe.firstInvocationStarted.wait(for: .seconds(5)))
 
     let pendingInvocations = DispatchGroup()
+    let pendingInvocationsFinished = TestSignal()
     for _ in 0..<10 {
       pendingInvocations.enter()
       DispatchQueue.global().async {
@@ -126,10 +127,13 @@ struct GraphTrackingHandlerTests {
         pendingInvocations.leave()
       }
     }
+    pendingInvocations.notify(queue: .global()) {
+      pendingInvocationsFinished.signal()
+    }
 
-    #expect(pendingInvocations.wait(timeout: .now() + 1) == .success)
+    #expect(await pendingInvocationsFinished.wait(for: .seconds(5)))
     probe.resumeFirstInvocation.signal()
-    #expect(firstInvocationFinished.wait(timeout: .now() + 1) == .success)
+    #expect(await firstInvocationFinished.wait(for: .seconds(5)))
 
     let result = probe.result
     #expect(result.invocationCount == 2)

--- a/Tests/StateGraphTests/TestSignal.swift
+++ b/Tests/StateGraphTests/TestSignal.swift
@@ -1,0 +1,64 @@
+import Foundation
+import os
+
+/// A one-shot test signal that resumes asynchronous waiters from synchronous callbacks.
+///
+/// Unlike `DispatchSemaphore.wait()`, waiting on this type suspends the test task instead of
+/// blocking a cooperative-executor thread. This keeps synchronization-heavy tests from
+/// starving unrelated tests when Swift Testing runs suites in parallel.
+final class TestSignal: @unchecked Sendable {
+
+  private struct State {
+    var isSignaled = false
+    var waiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+  }
+
+  private let state = OSAllocatedUnfairLock(initialState: State())
+
+  /// Marks the signal as completed and resumes every current or future waiter.
+  func signal() {
+    let waiters = state.withLock { state in
+      guard !state.isSignaled else { return [CheckedContinuation<Bool, Never>]() }
+
+      state.isSignaled = true
+      let waiters = Array(state.waiters.values)
+      state.waiters.removeAll()
+      return waiters
+    }
+
+    waiters.forEach { $0.resume(returning: true) }
+  }
+
+  /// Suspends until the signal is completed or the timeout expires.
+  ///
+  /// - Parameter timeout: The maximum duration to wait.
+  /// - Returns: `true` when signaled, or `false` when the timeout expires first.
+  func wait(for timeout: Duration) async -> Bool {
+    let id = UUID()
+
+    return await withCheckedContinuation { continuation in
+      let isAlreadySignaled = state.withLock { state in
+        guard !state.isSignaled else { return true }
+        state.waiters[id] = continuation
+        return false
+      }
+
+      guard !isAlreadySignaled else {
+        continuation.resume(returning: true)
+        return
+      }
+
+      Task.detached { [self] in
+        try? await Task.sleep(for: timeout)
+        timeOutWaiter(id: id)
+      }
+    }
+  }
+
+  private func timeOutWaiter(id: UUID) {
+    let waiter = state.withLock { state in
+      state.waiters.removeValue(forKey: id)
+    }
+    waiter?.resume(returning: false)
+  }
+}


### PR DESCRIPTION
## Summary

- add an async-safe one-shot test signal for synchronous callbacks
- replace blocking waits in the GraphTrackingHandler and EntityStore coordination tests
- make the heavy tracking-handler tests use deterministic handoffs instead of fixed sleeps
- serialize only the suite that intentionally suspends synchronous handlers

## Root cause

Several tests synchronously waited on semaphores or dispatch groups while Swift Testing was running suites in parallel. On a lower-width CI runner, those waits could occupy the available executor workers before the tasks expected to signal them were scheduled. This produced clusters of unrelated timeout failures in GraphTrackingHandlerTests, NormalizationTests, and the heavy-operation tracking tests.

The production implementation and the package-test parallel configuration are unchanged.

## Impact

The package suite keeps its parallel coverage while the synchronization-heavy tests suspend their test tasks or coordinate through an executor-independent queue. The heavy-handler cases no longer depend on 100 ms to 4 second timing windows.

## Validation

- `swift test` — 138 tests in 32 suites passed
- `LIBDISPATCH_COOPERATIVE_POOL_STRICT=1 swift test --skip-build` — full suite passed 10 consecutive runs
- focused GraphTrackingHandlerTests, IssuesTrackingOnHeavyOperation, and EntityStore coordination tests passed
- `git diff --check` passed