### PR TITLE
Warn about graph tracking self-invalidation

### DIFF
--- a/Sources/StateGraph/Logger.swift
+++ b/Sources/StateGraph/Logger.swift
@@ -1,9 +1,55 @@
 import os.log
 
+/// Runtime diagnostics emitted by StateGraph during development.
+///
+/// Diagnostic settings are process-wide and thread-safe. They affect only developer
+/// feedback and never change graph mutation or notification behavior.
+public enum StateGraphDiagnostics {
+
+  private struct State: Sendable {
+    var isSelfInvalidationWarningEnabled = true
+  }
+
+  private static let state = OSAllocatedUnfairLock(initialState: State())
+
+  /// Controls the warning emitted when a tracking handler suppresses its own invalidation.
+  ///
+  /// The mutation is still applied and peer registrations are notified normally. The
+  /// suppressed one-shot registration is not restored to the invalidated node.
+  ///
+  /// The default value is `true`. StateGraph logging is disabled automatically in
+  /// non-DEBUG builds regardless of this value.
+  public static var isSelfInvalidationWarningEnabled: Bool {
+    get {
+      state.withLock { $0.isSelfInvalidationWarningEnabled }
+    }
+    set {
+      state.withLock { $0.isSelfInvalidationWarningEnabled = newValue }
+    }
+  }
+}
+
 enum Log {
-  
+
+#if DEBUG
+  @TaskLocal
+  static var selfInvalidationWarningObserver: (@Sendable () -> Void)?
+#endif
+
   static let generic = Logger(OSLog.makeOSLogInDebug { OSLog.init(subsystem: "state-graph", category: "generic") })
-  
+  static let tracking = Logger(
+    OSLog.makeOSLogInDebug { OSLog.init(subsystem: "state-graph", category: "tracking") }
+  )
+
+  static func logSuppressedSelfInvalidation() {
+#if DEBUG
+    selfInvalidationWarningObserver?()
+#endif
+
+    tracking.warning(
+      "A tracking handler invalidated its own active registration. The mutation was applied and peer registrations were notified, but this registration was not restored to the invalidated node."
+    )
+  }
 }
 
 extension OSLog {

--- a/Sources/StateGraph/Observation/withGraphTracking.swift
+++ b/Sources/StateGraph/Observation/withGraphTracking.swift
@@ -7,6 +7,16 @@
  scope are automatically managed and cleaned up when the returned cancellable is cancelled or
  deallocated.
 
+ - Important: If a `withGraphTrackingGroup` or `withGraphTrackingMap` handler
+   synchronously mutates graph state that invalidates a node accessed during the same
+   execution, StateGraph suppresses that handler's own invalidation. The mutation is still
+   applied and peer registrations continue through normal invalidation. The one-shot
+   registration is not restored to the invalidated node, so later changes to that node may
+   not be observed until another tracked change re-executes the handler. DEBUG builds emit
+   a warning unless ``StateGraphDiagnostics/isSelfInvalidationWarningEnabled`` is `false`.
+   This prevents direct self-re-entry only; cycles between multiple mutating handlers are
+   not suppressed.
+
  ## Basic Usage
  ```swift
  let node = Stored(wrappedValue: 0)

--- a/Sources/StateGraph/Observation/withGraphTrackingGroup.swift
+++ b/Sources/StateGraph/Observation/withGraphTrackingGroup.swift
@@ -12,6 +12,15 @@
  - The handler closure is executed initially and re-executed whenever any tracked node changes
  - Only nodes accessed during execution are tracked for the next iteration
  - Nodes are dynamically added/removed from tracking based on runtime conditions
+
+ ## Self-Mutation
+
+ If the handler synchronously mutates graph state that invalidates a node accessed in
+ the same execution, the mutation is applied and peer tracking registrations are notified.
+ This handler is not re-executed for its own mutation. Its one-shot registration is not
+ restored to the invalidated node, so tracking for that node is re-established only if
+ another tracked change later re-executes the handler. A DEBUG warning is emitted unless
+ ``StateGraphDiagnostics/isSelfInvalidationWarningEnabled`` is `false`.
  
  ## Example: Group Tracking
  ```swift

--- a/Sources/StateGraph/Observation/withGraphTrackingMap.swift
+++ b/Sources/StateGraph/Observation/withGraphTrackingMap.swift
@@ -13,6 +13,12 @@
  - The projected value is passed through a `DistinctFilter` (for `Equatable` types)
  - `onChange` is only called when the filtered value passes through (i.e., when it's different)
 
+ - Important: A synchronous mutation that invalidates an accessed node does not
+   re-execute this map for its own mutation. Peer registrations are notified, but its
+   one-shot registration is not restored to the invalidated node. Tracking for that node is
+   re-established only if another tracked change later re-executes the map. A DEBUG warning
+   is emitted unless ``StateGraphDiagnostics/isSelfInvalidationWarningEnabled`` is `false`.
+
  ## Example: Computed Value Tracking
  ```swift
  let firstName = Stored(wrappedValue: "John")
@@ -237,6 +243,12 @@ public func withGraphTrackingMap<Dependency: AnyObject, Projection>(
  - Tracking stops automatically when the dependency is deallocated
  - The projected value is passed through the provided filter
  - `onChange` is only called when the filtered value passes through
+
+ - Important: A synchronous mutation that invalidates an accessed node does not
+   re-execute this map for its own mutation. Peer registrations are notified, but its
+   one-shot registration is not restored to the invalidated node. Tracking for that node is
+   re-established only if another tracked change later re-executes the map. A DEBUG warning
+   is emitted unless ``StateGraphDiagnostics/isSelfInvalidationWarningEnabled`` is `false`.
 
  ## Example with Custom Filter
  ```swift

--- a/Sources/StateGraph/Observation/withTracking.swift
+++ b/Sources/StateGraph/Observation/withTracking.swift
@@ -294,6 +294,9 @@ public final class TrackingRegistration: Sendable, Hashable {
 
   private struct State: Sendable {
     var isInvalidated: Bool = false
+#if DEBUG
+    var hasEmittedSelfInvalidationWarning = false
+#endif
     let didChange: @isolated(any) @Sendable () -> Void
   }
 
@@ -316,9 +319,13 @@ public final class TrackingRegistration: Sendable, Hashable {
   }
 
   func perform() {
-    state.withLock { state in
+#if DEBUG
+    let isSelfInvalidationWarningEnabled = StateGraphDiagnostics.isSelfInvalidationWarningEnabled
+#endif
+
+    let shouldEmitSelfInvalidationWarning = state.withLock { state in
       guard state.isInvalidated == false else {
-        return
+        return false
       }
       
       // Re-entry Prevention Guard
@@ -367,7 +374,13 @@ public final class TrackingRegistration: Sendable, Hashable {
       // prevents that group from re-entering itself while allowing peer groups to
       // observe the assignment.
       if ThreadLocal.registration.value == self {
-        return
+#if DEBUG
+        if isSelfInvalidationWarningEnabled, state.hasEmittedSelfInvalidationWarning == false {
+          state.hasEmittedSelfInvalidationWarning = true
+          return true
+        }
+#endif
+        return false
       }
       
       state.isInvalidated = true
@@ -376,7 +389,14 @@ public final class TrackingRegistration: Sendable, Hashable {
       Task {
         await closure()
       }
+      return false
     }
+
+#if DEBUG
+    if shouldEmitSelfInvalidationWarning {
+      Log.logSuppressedSelfInvalidation()
+    }
+#endif
   }
 
 }

--- a/Tests/StateGraphTests/StateGraphDiagnosticsTests.swift
+++ b/Tests/StateGraphTests/StateGraphDiagnosticsTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import StateGraph
+
+#if DEBUG
+@Suite("StateGraph Diagnostics Tests", .serialized)
+struct StateGraphDiagnosticsTests {
+
+  @Test
+  func selfInvalidationWarningIsEmittedOncePerRegistrationAndCanBeDisabled() {
+    struct NonEquatableValue: Sendable {
+      let rawValue: Int
+    }
+
+    let previousValue = StateGraphDiagnostics.isSelfInvalidationWarningEnabled
+    defer {
+      StateGraphDiagnostics.isSelfInvalidationWarningEnabled = previousValue
+    }
+
+    let warningCount = OSAllocatedUnfairLock(initialState: 0)
+
+    Log.$selfInvalidationWarningObserver.withValue({
+      warningCount.withLock { $0 += 1 }
+    }) {
+      StateGraphDiagnostics.isSelfInvalidationWarningEnabled = true
+
+      let firstWarningNode = Stored(
+        wrappedValue: NonEquatableValue(rawValue: 0)
+      )
+      let secondWarningNode = Stored(
+        wrappedValue: NonEquatableValue(rawValue: 0)
+      )
+      let warningCancellable = withGraphTracking {
+        withGraphTrackingGroup {
+          let firstValue = firstWarningNode.wrappedValue
+          let secondValue = secondWarningNode.wrappedValue
+          firstWarningNode.wrappedValue = firstValue
+          secondWarningNode.wrappedValue = secondValue
+        }
+      }
+      warningCancellable.cancel()
+
+      #expect(warningCount.withLock { $0 } == 1)
+
+      StateGraphDiagnostics.isSelfInvalidationWarningEnabled = false
+
+      let silentNode = Stored(
+        wrappedValue: NonEquatableValue(rawValue: 0)
+      )
+      let silentCancellable = withGraphTracking {
+        withGraphTrackingGroup {
+          let value = silentNode.wrappedValue
+          silentNode.wrappedValue = value
+        }
+      }
+      silentCancellable.cancel()
+
+      #expect(warningCount.withLock { $0 } == 1)
+    }
+  }
+}
+#endif


### PR DESCRIPTION
## Summary

- emit a DEBUG warning in the `state-graph` / `tracking` category when the existing re-entry guard suppresses a tracking registration's own invalidation
- allow the warning to be disabled with `StateGraphDiagnostics.isSelfInvalidationWarningEnabled`
- document the existing self-invalidation behavior on `withGraphTracking`, Group, and Map APIs
- add focused coverage for warning de-duplication and disabling diagnostics

## Scope

This PR does not change graph invalidation or subscription behavior. `Node`, `Stored`, `Computed`, `ThreadLocal`, and the Group/Map implementations remain identical to `main`.

When a handler synchronously invalidates a node it accessed in the same execution:

- the existing identity guard prevents direct self-re-entry
- the mutation is applied
- peer registrations continue through normal invalidation
- the active one-shot registration is not restored to the invalidated node
- cycles between multiple mutating handlers are outside this guard

The warning makes that existing but easy-to-miss behavior visible during development.

## Validation

- focused diagnostics and peer-notification tests passed
- `swift test --build-system native` passed
- `swift test --build-system native --no-parallel` passed
- `ConcurrencyTests.testEdgePropagation` passed 100/100 repeated runs
- `swift build -c release --build-system native` passed
- `git diff --check origin/main...HEAD` passed
