### PR TITLE
Add graph-aware iCloud key-value storage

### DIFF
--- a/.swiftpm/swift-state-graph.xctestplan
+++ b/.swiftpm/swift-state-graph.xctestplan
@@ -31,6 +31,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "StateGraphUbiquitousKeyValueTests",
+        "name" : "StateGraphUbiquitousKeyValueTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "StateGraphNormalizationTests",
         "name" : "StateGraphNormalizationTests"
       }

--- a/.swiftpm/xcode/xcshareddata/xcschemes/StateGraphUbiquitousKeyValue.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/StateGraphUbiquitousKeyValue.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StateGraphUbiquitousKeyValue"
+               BuildableName = "StateGraphUbiquitousKeyValue"
+               BlueprintName = "StateGraphUbiquitousKeyValue"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "StateGraphUbiquitousKeyValue"
+            BuildableName = "StateGraphUbiquitousKeyValue"
+            BlueprintName = "StateGraphUbiquitousKeyValue"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-state-graph-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-state-graph-Package.xcscheme
@@ -38,6 +38,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StateGraphUbiquitousKeyValue"
+               BuildableName = "StateGraphUbiquitousKeyValue"
+               BlueprintName = "StateGraphUbiquitousKeyValue"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "StateGraphNormalization"
                BuildableName = "StateGraphNormalization"
                BlueprintName = "StateGraphNormalization"
@@ -80,6 +94,16 @@
                BlueprintIdentifier = "StateGraphTests"
                BuildableName = "StateGraphTests"
                BlueprintName = "StateGraphTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StateGraphUbiquitousKeyValueTests"
+               BuildableName = "StateGraphUbiquitousKeyValueTests"
+               BlueprintName = "StateGraphUbiquitousKeyValueTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-state-graph.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-state-graph.xcscheme
@@ -30,6 +30,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StateGraphUbiquitousKeyValue"
+               BuildableName = "StateGraphUbiquitousKeyValue"
+               BlueprintName = "StateGraphUbiquitousKeyValue"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -61,6 +75,16 @@
                BlueprintIdentifier = "StateGraphTests"
                BuildableName = "StateGraphTests"
                BlueprintName = "StateGraphTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StateGraphUbiquitousKeyValueTests"
+               BuildableName = "StateGraphUbiquitousKeyValueTests"
+               BlueprintName = "StateGraphUbiquitousKeyValueTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,10 @@ let package = Package(
       targets: ["StateGraph"]
     ),
     .library(
+      name: "StateGraphUbiquitousKeyValue",
+      targets: ["StateGraphUbiquitousKeyValue"]
+    ),
+    .library(
       name: "StateGraphNormalization",
       targets: ["StateGraphNormalization"]
     )
@@ -45,6 +49,12 @@ let package = Package(
       ]
     ),
     .target(
+      name: "StateGraphUbiquitousKeyValue",
+      dependencies: [
+        "StateGraph"
+      ]
+    ),
+    .target(
       name: "StateGraphNormalization",
       dependencies: [
         "StateGraph",
@@ -62,6 +72,13 @@ let package = Package(
     .testTarget(
       name: "StateGraphTests",
       dependencies: ["StateGraph"]
+    ),
+    .testTarget(
+      name: "StateGraphUbiquitousKeyValueTests",
+      dependencies: [
+        "StateGraph",
+        "StateGraphUbiquitousKeyValue"
+      ]
     ),
     .testTarget(
       name: "StateGraphNormalizationTests",

--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ The projected value, `$theme`, is the reference-identity
 `GraphUserDefault<String>` handle. Its reads participate in graph dependency
 tracking, and its writes persist to UserDefaults.
 
+### iCloud Key-Value Synchronization
+
+Synchronize small, infrequently changing values across a person's devices
+without changing the in-memory `Stored` primitive:
+
+```swift
+import StateGraphUbiquitousKeyValue
+
+@GraphUbiquitousKeyValue("currentPage")
+var currentPage = 1
+```
+
+The host app must enable the iCloud key-value store entitlement. Local changes
+publish to the graph synchronously, while propagation between devices remains
+asynchronous.
+
 ## Installation
 
 Add to your `Package.swift`:
@@ -119,6 +135,21 @@ dependencies: [
 .target(
   name: "YourTarget",
   dependencies: ["StateGraph"]
+)
+```
+
+Targets using iCloud key-value synchronization add the optional extension
+product instead. It re-exports `StateGraph`, so one import provides both APIs:
+
+```swift
+.target(
+  name: "YourTarget",
+  dependencies: [
+    .product(
+      name: "StateGraphUbiquitousKeyValue",
+      package: "swift-state-graph"
+    )
+  ]
 )
 ```
 
@@ -254,6 +285,7 @@ For detailed guides, see the [Documentation](Sources/StateGraph/Documentation.do
 - [SwiftUI Integration](Sources/StateGraph/Documentation.docc/SwiftUI-Integration.md) - Bindings, GraphObject, Environment
 - [UIKit Integration](Sources/StateGraph/Documentation.docc/UIKit-Integration.md) - withGraphTracking patterns
 - [UserDefaults](Sources/StateGraph/Documentation.docc/UserDefaults.md) - Persistent values composed with Stored nodes
+- [iCloud Key-Value Store](Sources/StateGraphUbiquitousKeyValue/Documentation.docc/iCloud-Key-Value-Store.md) - Small graph-aware values synchronized across devices
 - [Data Normalization](Sources/StateGraph/Documentation.docc/Data-Normalization.md) - EntityStore for relational data
 - [Migration from Observable](Sources/StateGraph/Documentation.docc/Migration-from-Observable.md) - Step-by-step guide
 

--- a/Sources/StateGraphUbiquitousKeyValue/Documentation.docc/StateGraphUbiquitousKeyValue.md
+++ b/Sources/StateGraphUbiquitousKeyValue/Documentation.docc/StateGraphUbiquitousKeyValue.md
@@ -1,0 +1,25 @@
+# ``StateGraphUbiquitousKeyValue``
+
+Synchronize small graph-aware values through iCloud key-value storage.
+
+## Overview
+
+StateGraphUbiquitousKeyValue is an optional extension module for the
+`StateGraph` module. It composes an in-memory graph node with
+`NSUbiquitousKeyValueStore` without adding iCloud synchronization to the core
+StateGraph module.
+
+Import `StateGraphUbiquitousKeyValue` in targets that need this integration.
+The module re-exports StateGraph so graph primitives remain available from the
+same import.
+
+## Topics
+
+### Getting Started
+
+- <doc:iCloud-Key-Value-Store>
+
+### Synchronized Values
+
+- ``GraphUbiquitousKeyValue``
+- ``UbiquitousKeyValueStorable``

--- a/Sources/StateGraphUbiquitousKeyValue/Documentation.docc/iCloud-Key-Value-Store.md
+++ b/Sources/StateGraphUbiquitousKeyValue/Documentation.docc/iCloud-Key-Value-Store.md
@@ -1,0 +1,138 @@
+# iCloud Key-Value Store
+
+Synchronize small graph-aware values across a person's devices by composing
+iCloud key-value storage with an in-memory `Stored` node.
+
+## Overview
+
+``StateGraphUbiquitousKeyValue/GraphUbiquitousKeyValue`` is the iCloud
+counterpart to `GraphUserDefault`. It owns one `Stored<Value>` and
+synchronizes that snapshot with one key in
+[`NSUbiquitousKeyValueStore.default`](https://developer.apple.com/documentation/foundation/nsubiquitouskeyvaluestore/default).
+
+Use it for small settings, configuration, and app state that change
+infrequently. It is not appropriate for sensitive information, documents,
+large values, or high-frequency state.
+
+## Configure the App Target
+
+Enable iCloud key-value storage for every app target that uses the wrapper. The
+signed app needs the `com.apple.developer.ubiquity-kvstore-identifier`
+entitlement. Targets that should share a store must use the same key-value store
+identifier.
+
+The Swift package itself doesn't add or validate this entitlement. A missing or
+incorrect entitlement prevents the host app from synchronizing with iCloud.
+
+## Basic Usage
+
+Declare a default value and an iCloud key-value store key:
+
+```swift
+import StateGraphUbiquitousKeyValue
+
+final class ReadingState {
+  @GraphUbiquitousKeyValue("currentPage")
+  var currentPage = 1
+}
+```
+
+The wrapped property reads the in-memory graph snapshot and writes through to
+the shared iCloud key-value store. The projected value is the same
+reference-identity synchronization handle:
+
+```swift
+let state = ReadingState()
+let currentPage: GraphUbiquitousKeyValue<Int> = state.$currentPage
+
+currentPage.wrappedValue = 42
+```
+
+Retaining the projected value keeps its store subscription active. Its reads
+participate in graph dependency tracking in the same way as a projected
+`@GraphStored` value.
+
+## Synchronization Semantics
+
+The first live wrapper installs the external-change observer and then calls
+`synchronize()` once for the process-wide coordinator. Local assignments update
+the backing store and graph snapshot synchronously. Other live wrappers for the
+same key are also refreshed without waiting for an iCloud notification.
+
+Treat the wrapper or its projected value as the exclusive in-process writer for
+a managed key. Foundation's external-change notification reports incoming
+iCloud data, not direct writes made elsewhere in the same process, so a raw
+`NSUbiquitousKeyValueStore.default.set` call can't refresh an existing graph
+snapshot.
+
+Changes arriving from iCloud update the relevant graph snapshots. An Apple
+account change refreshes all live keys because values from the previous account
+may have disappeared. Duplicate notifications that decode to the current value
+don't publish another graph change.
+
+Device-to-device propagation remains asynchronous. `synchronize()` doesn't
+force an upload, and assigning a value doesn't mean another device has already
+received it. Initial iCloud reconciliation can also replace a value written
+during startup.
+
+`GraphUbiquitousKeyValue` intentionally doesn't mirror values into
+`UserDefaults`. If a value must have an independent, durable local source of
+truth when iCloud is unavailable, own that local persistence separately and use
+the iCloud store as a synchronization channel.
+
+## Supported Values
+
+``StateGraphUbiquitousKeyValue/UbiquitousKeyValueStorable`` has built-in
+conformances for:
+
+- `Bool`
+- `Int` and `Int64`
+- `Float` and `Double`
+- `String`
+- `Data`
+- `Date`
+- `Array` when its elements conform
+- `Dictionary<String, Value>` when its values conform
+- `Optional` when its wrapped value conforms
+
+Assigning an optional `nil` removes the key. A missing or invalid value exposes
+the default declared by the property, so declare an optional default of `nil`
+when removal should read back as `nil`.
+
+A Codable value can adopt the protocol and use its JSON `Data` representation:
+
+```swift
+struct ReaderPreferences:
+  Codable,
+  Equatable,
+  Sendable,
+  UbiquitousKeyValueStorable
+{
+  var usesSerifFont: Bool
+}
+
+final class ReadingState {
+  @GraphUbiquitousKeyValue("readerPreferences")
+  var preferences = ReaderPreferences(usesSerifFont: true)
+}
+```
+
+Prefer the native property-list conformances for simple values. Codable data
+counts against the same iCloud storage quota.
+
+## Platform Limits
+
+The host app is responsible for keeping values within
+[the limits of `NSUbiquitousKeyValueStore`](https://developer.apple.com/documentation/foundation/nsubiquitouskeyvaluestore):
+
+- At most 1,024 keys.
+- At most 1 MB across all values.
+- At most 1 MB for any one value.
+- At most 128 UTF-16 characters in a key.
+
+Foundation raises an exception for an overlong key. A quota violation is a
+store-wide operational failure and isn't surfaced as a successful value change
+by this wrapper.
+
+Do not store personal or sensitive information here. Apple documents that the
+on-disk representation isn't encrypted; use Keychain for secrets.

--- a/Sources/StateGraphUbiquitousKeyValue/GraphUbiquitousKeyValue.swift
+++ b/Sources/StateGraphUbiquitousKeyValue/GraphUbiquitousKeyValue.swift
@@ -1,0 +1,166 @@
+@_exported import StateGraph
+import Foundation
+
+/// A reference-identity property wrapper synchronized with one iCloud
+/// key-value store key.
+///
+/// `GraphUbiquitousKeyValue` owns an in-memory `Stored` node together with the
+/// iCloud observation and synchronization lifecycle around it. Its projected
+/// value is the same `GraphUbiquitousKeyValue` instance, so retaining
+/// `$property` preserves synchronization and mutations continue to write
+/// through to the iCloud key-value store.
+///
+/// Use this wrapper for small settings and app state that change infrequently.
+/// iCloud propagation is asynchronous, and assigning `wrappedValue` doesn't
+/// mean that another device has received the value.
+@propertyWrapper
+public final class GraphUbiquitousKeyValue<
+  Value: UbiquitousKeyValueStorable & SendableMetatype
+>: Sendable {
+  private struct State: Sendable {
+    var lastValue: Value
+    var subscription: UbiquitousKeyValueSubscription?
+  }
+
+  private let stored: Stored<Value>
+  private let key: String
+  private let defaultValue: Value
+  private let coordinator: UbiquitousKeyValueAccessCoordinator
+  private let state: OSAllocatedUnfairLock<State>
+
+  /// Creates a graph-aware value synchronized with the app's iCloud key-value
+  /// store.
+  ///
+  /// The wrapper observes the shared `NSUbiquitousKeyValueStore.default`
+  /// instance before the process requests its initial synchronization.
+  ///
+  /// - Parameters:
+  ///   - wrappedValue: The value used when the key is absent or invalid.
+  ///   - key: The iCloud key-value store key.
+  public convenience init(
+    wrappedValue: Value,
+    _ key: String
+  ) {
+    self.init(
+      wrappedValue: wrappedValue,
+      key,
+      coordinator: .shared
+    )
+  }
+
+  init(
+    wrappedValue: Value,
+    _ key: String,
+    coordinator: UbiquitousKeyValueAccessCoordinator
+  ) {
+    self.key = key
+    self.defaultValue = wrappedValue
+    self.coordinator = coordinator
+
+    let initialValue = coordinator.withAccess { client in
+      Self.loadValue(
+        from: client,
+        forKey: key,
+        defaultValue: wrappedValue
+      )
+    }
+
+    self.stored = Stored(wrappedValue: initialValue)
+    self.state = OSAllocatedUnfairLock(
+      initialState: State(lastValue: initialValue)
+    )
+
+    let subscription = coordinator.observeChanges(forKey: key) { [weak self] change in
+      guard change.includes(key) else { return }
+      self?.refresh()
+    }
+    state.withLock { $0.subscription = subscription }
+
+    // Close the gap between the initial read and observer installation.
+    refresh()
+  }
+
+  deinit {
+    let subscription = state.withLock { state in
+      defer { state.subscription = nil }
+      return state.subscription
+    }
+    subscription?.cancel()
+  }
+
+  public var wrappedValue: Value {
+    get {
+      stored.wrappedValue
+    }
+    set {
+      coordinator.mutateValue(forKey: key) { client in
+        if let object = newValue._encodeUbiquitousKeyValue() {
+          client.set(object, forKey: key)
+        } else {
+          client.removeObject(forKey: key)
+        }
+
+        // Read through the same decoding path so the graph snapshot reflects
+        // the representation the backing store actually accepted.
+        enqueue(
+          Self.loadValue(
+            from: client,
+            forKey: key,
+            defaultValue: defaultValue
+          )
+        )
+      }
+    }
+  }
+
+  /// The reference-identity handle for this synchronized value.
+  ///
+  /// Retaining the projection keeps iCloud key-value store observation active.
+  /// Reads participate in graph dependency tracking, and writes follow the
+  /// same synchronization path as assigning the wrapped property.
+  public var projectedValue: GraphUbiquitousKeyValue<Value> {
+    self
+  }
+
+  /// Sets a closure to call after the graph value is assigned.
+  public func onDidSet(_ handler: @escaping (Value, Value) -> Void) {
+    stored.onDidSet(handler)
+  }
+
+  private func refresh() {
+    coordinator.withAccess { client in
+      enqueue(
+        Self.loadValue(
+          from: client,
+          forKey: key,
+          defaultValue: defaultValue
+        )
+      )
+    }
+  }
+
+  private func enqueue(_ value: Value) {
+    let shouldPublish = state.withLock { state in
+      guard state.lastValue != value else { return false }
+      state.lastValue = value
+      return true
+    }
+
+    guard shouldPublish else { return }
+
+    coordinator.publish { [weak self] in
+      self?.stored.wrappedValue = value
+    }
+  }
+
+  private static func loadValue(
+    from client: any UbiquitousKeyValueStoreClient,
+    forKey key: String,
+    defaultValue: Value
+  ) -> Value {
+    guard let object = client.object(forKey: key) else {
+      return defaultValue
+    }
+    return Value._decodeUbiquitousKeyValue(from: object) ?? defaultValue
+  }
+}

--- a/Sources/StateGraphUbiquitousKeyValue/UbiquitousKeyValueAccessCoordinator.swift
+++ b/Sources/StateGraphUbiquitousKeyValue/UbiquitousKeyValueAccessCoordinator.swift
@@ -1,0 +1,317 @@
+import Foundation
+
+/// Serializes this module's access to the app-wide iCloud key-value store and
+/// publishes graph updates synchronously after releasing the access lock.
+final class UbiquitousKeyValueAccessCoordinator: @unchecked Sendable {
+  typealias ChangeHandler = @Sendable (UbiquitousKeyValueStoreChange) -> Void
+
+  private struct PublicationBatch: Sendable {
+    let id: UInt64
+    let publications: [@Sendable () -> Void]
+  }
+
+  private struct PublicationTicket {
+    let id: UInt64
+    let shouldDrain: Bool
+  }
+
+  static let shared = UbiquitousKeyValueAccessCoordinator(
+    client: FoundationUbiquitousKeyValueStoreClient(store: .default)
+  )
+
+  /// The unchecked sendability boundary is owned here; every client operation
+  /// runs while `accessLock` is held.
+  nonisolated(unsafe)
+  private let client: any UbiquitousKeyValueStoreClient
+  private let accessLock = NSRecursiveLock()
+  private let publicationCondition = NSCondition()
+  private let drainingContextKey =
+    "org.vergegroup.state-graph.ubiquitous-key-value-publication-drainer.\(UUID())"
+
+  private var accessDepth = 0
+  private var currentPublications: [@Sendable () -> Void] = []
+
+  private var nextBatchID: UInt64 = 0
+  private var completedThroughBatchID: UInt64 = 0
+  private var completedOutOfOrderBatchIDs: Set<UInt64> = []
+  private var isDraining = false
+  private var pendingBatches: [PublicationBatch] = []
+
+  private var changeHandlers: [String: [UUID: ChangeHandler]] = [:]
+  private var storeObservation: UbiquitousKeyValueStoreObservation?
+  private var hasRequestedInitialSynchronization = false
+
+  init(client: any UbiquitousKeyValueStoreClient) {
+    self.client = client
+  }
+
+  func withAccess<Result: Sendable>(
+    _ body: (any UbiquitousKeyValueStoreClient) -> Result
+  ) -> Result {
+    accessLock.lock()
+    accessDepth += 1
+
+    let result = body(client)
+
+    accessDepth -= 1
+    let ticket: PublicationTicket?
+    if accessDepth == 0, !currentPublications.isEmpty {
+      let publications = currentPublications
+      currentPublications = []
+      ticket = enqueue(publications)
+    } else {
+      ticket = nil
+    }
+    accessLock.unlock()
+
+    finish(ticket)
+
+    return result
+  }
+
+  /// Adds a keyed-value change handler and starts the process-wide store
+  /// observation before requesting the initial iCloud synchronization.
+  func observeChanges(
+    forKey key: String,
+    _ receiveChange: @escaping ChangeHandler
+  ) -> UbiquitousKeyValueSubscription {
+    let registration = withAccess { client in
+      let id = UUID()
+      changeHandlers[key, default: [:]][id] = receiveChange
+
+      if storeObservation == nil {
+        storeObservation = client.observe { [weak self] change in
+          self?.receive(change)
+        }
+      }
+
+      let shouldSynchronize = !hasRequestedInitialSynchronization
+      hasRequestedInitialSynchronization = true
+
+      return (id: id, shouldSynchronize: shouldSynchronize)
+    }
+
+    if registration.shouldSynchronize {
+      _ = withAccess { client in
+        client.synchronize()
+      }
+    }
+
+    return UbiquitousKeyValueSubscription { [weak self] in
+      self?.removeChangeHandler(id: registration.id, forKey: key)
+    }
+  }
+
+  /// Performs one local mutation and then refreshes each wrapper for the key.
+  ///
+  /// The mutation closure may enqueue the writer's read-back value. That
+  /// publication finishes before peer wrappers are refreshed, and no
+  /// coordinator lock is held while their graph callbacks run.
+  func mutateValue(
+    forKey key: String,
+    _ mutation: (any UbiquitousKeyValueStoreClient) -> Void
+  ) {
+    withAccess(mutation)
+    deliver(
+      UbiquitousKeyValueStoreChange(
+        reason: .local,
+        changedKeys: [key]
+      )
+    )
+  }
+
+  func publish(_ publication: @escaping @Sendable () -> Void) {
+    accessLock.lock()
+
+    if accessDepth > 0 {
+      currentPublications.append(publication)
+      accessLock.unlock()
+      return
+    }
+
+    let ticket = enqueue([publication])
+    accessLock.unlock()
+
+    finish(ticket)
+  }
+
+  private func receive(_ change: UbiquitousKeyValueStoreChange) {
+    deliver(change)
+  }
+
+  /// Delivers handlers sequentially so a reentrant write completes before the
+  /// next peer reloads the current store value.
+  private func deliver(_ change: UbiquitousKeyValueStoreChange) {
+    accessLock.lock()
+
+    let handlers: [ChangeHandler]
+    let usesChangedKeys: Bool
+    switch change.reason {
+    case .account:
+      usesChangedKeys = false
+    case .local, .server, .initialSync, .quotaViolation, .unknown:
+      usesChangedKeys = true
+    }
+
+    if usesChangedKeys, let changedKeys = change.changedKeys {
+      handlers = changedKeys.flatMap { key -> [ChangeHandler] in
+        guard let handlers = changeHandlers[key] else { return [] }
+        return Array(handlers.values)
+      }
+    } else {
+      handlers = changeHandlers.values.flatMap { Array($0.values) }
+    }
+
+    accessLock.unlock()
+
+    for handler in handlers {
+      handler(change)
+    }
+  }
+
+  private func removeChangeHandler(id: UUID, forKey key: String) {
+    accessLock.lock()
+    changeHandlers[key]?[id] = nil
+    if changeHandlers[key]?.isEmpty == true {
+      changeHandlers[key] = nil
+    }
+
+    let observation: UbiquitousKeyValueStoreObservation?
+    if changeHandlers.isEmpty {
+      observation = storeObservation
+      storeObservation = nil
+    } else {
+      observation = nil
+    }
+
+    accessLock.unlock()
+    observation?.cancel()
+  }
+
+  /// Enqueues a complete access batch while preserving access-lock order.
+  /// Must be called while `accessLock` is held.
+  private func enqueue(
+    _ publications: [@Sendable () -> Void]
+  ) -> PublicationTicket {
+    publicationCondition.lock()
+
+    nextBatchID &+= 1
+    let batch = PublicationBatch(
+      id: nextBatchID,
+      publications: publications
+    )
+    pendingBatches.append(batch)
+
+    let shouldDrain: Bool
+    if isDraining {
+      shouldDrain = false
+    } else {
+      isDraining = true
+      shouldDrain = true
+    }
+
+    publicationCondition.unlock()
+    return PublicationTicket(id: batch.id, shouldDrain: shouldDrain)
+  }
+
+  private func finish(_ ticket: PublicationTicket?) {
+    guard let ticket else { return }
+
+    if ticket.shouldDrain {
+      drainAsOwner()
+    } else if isDrainingOnCurrentThread {
+      // A publication callback may synchronously write another value. Drain
+      // through that batch without waiting on the current drainer thread.
+      drainPublications(until: ticket.id)
+    } else {
+      publicationCondition.lock()
+      while !isCompleted(ticket.id) {
+        publicationCondition.wait()
+      }
+      publicationCondition.unlock()
+    }
+  }
+
+  private var isDrainingOnCurrentThread: Bool {
+    Thread.current.threadDictionary[drainingContextKey] as? Bool == true
+  }
+
+  private func drainAsOwner() {
+    let threadDictionary = Thread.current.threadDictionary
+    threadDictionary[drainingContextKey] = true
+    defer { threadDictionary.removeObject(forKey: drainingContextKey) }
+
+    drainPublications(until: nil)
+  }
+
+  private func drainPublications(until targetID: UInt64?) {
+    while true {
+      publicationCondition.lock()
+
+      guard !pendingBatches.isEmpty else {
+        if targetID == nil {
+          isDraining = false
+        }
+        publicationCondition.unlock()
+        return
+      }
+
+      let batch = pendingBatches.removeFirst()
+      publicationCondition.unlock()
+
+      for publication in batch.publications {
+        publication()
+      }
+
+      publicationCondition.lock()
+      markCompleted(batch.id)
+      publicationCondition.broadcast()
+      publicationCondition.unlock()
+
+      if batch.id == targetID {
+        return
+      }
+    }
+  }
+
+  /// Must be called while `publicationCondition` is held.
+  private func isCompleted(_ id: UInt64) -> Bool {
+    id <= completedThroughBatchID || completedOutOfOrderBatchIDs.contains(id)
+  }
+
+  /// Must be called while `publicationCondition` is held.
+  private func markCompleted(_ id: UInt64) {
+    guard id == completedThroughBatchID &+ 1 else {
+      completedOutOfOrderBatchIDs.insert(id)
+      return
+    }
+
+    completedThroughBatchID = id
+    while completedOutOfOrderBatchIDs.remove(completedThroughBatchID &+ 1) != nil {
+      completedThroughBatchID &+= 1
+    }
+  }
+}
+
+/// A reference-identity cancellation token for one coordinator subscription.
+final class UbiquitousKeyValueSubscription: @unchecked Sendable {
+  private let lock = NSLock()
+  private var cancellation: (@Sendable () -> Void)?
+
+  init(cancellation: @escaping @Sendable () -> Void) {
+    self.cancellation = cancellation
+  }
+
+  deinit {
+    cancel()
+  }
+
+  func cancel() {
+    lock.lock()
+    let cancellation = self.cancellation
+    self.cancellation = nil
+    lock.unlock()
+
+    cancellation?()
+  }
+}

--- a/Sources/StateGraphUbiquitousKeyValue/UbiquitousKeyValueStorable.swift
+++ b/Sources/StateGraphUbiquitousKeyValue/UbiquitousKeyValueStorable.swift
@@ -1,0 +1,235 @@
+import Foundation
+
+/// A value that can be represented in an iCloud key-value store.
+///
+/// Conforming values convert synchronously to and from property-list values.
+/// `GraphUbiquitousKeyValue` uses the decoded result as the snapshot owned by
+/// its internal `StateGraph.Stored` node.
+public protocol UbiquitousKeyValueStorable: Equatable, Sendable {
+  /// Decodes one property-list value from the iCloud key-value store.
+  ///
+  /// Return `nil` when `object` doesn't contain a valid representation of
+  /// `Self`. The property wrapper then uses its declared default value.
+  @_spi(Internal)
+  static func _decodeUbiquitousKeyValue(from object: Any) -> Self?
+
+  /// Encodes this value as an iCloud property-list value.
+  ///
+  /// Returning `nil` removes the key. This is also how an optional `nil`
+  /// value is represented because property lists don't contain null values.
+  @_spi(Internal)
+  func _encodeUbiquitousKeyValue() -> Any?
+}
+
+extension Bool: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Bool? {
+    if let value = object as? Bool {
+      return value
+    }
+    return (object as? NSNumber)?.boolValue
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    self
+  }
+}
+
+extension Int: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Int? {
+    if let value = object as? Int {
+      return value
+    }
+    guard let number = object as? NSNumber else { return nil }
+    return Int(exactly: number.int64Value)
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    Int64(self)
+  }
+}
+
+extension Int64: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Int64? {
+    if let value = object as? Int64 {
+      return value
+    }
+    return (object as? NSNumber)?.int64Value
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    self
+  }
+}
+
+extension Float: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Float? {
+    if let value = object as? Float {
+      return value
+    }
+    return (object as? NSNumber)?.floatValue
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    Double(self)
+  }
+}
+
+extension Double: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Double? {
+    if let value = object as? Double {
+      return value
+    }
+    return (object as? NSNumber)?.doubleValue
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    self
+  }
+}
+
+extension String: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> String? {
+    object as? String
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    self
+  }
+}
+
+extension Data: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Data? {
+    object as? Data
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    self
+  }
+}
+
+extension Date: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Date? {
+    object as? Date
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    self
+  }
+}
+
+extension Array: UbiquitousKeyValueStorable where Element: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> [Element]? {
+    guard let objects = object as? [Any] else { return nil }
+
+    var result: [Element] = []
+    result.reserveCapacity(objects.count)
+
+    for object in objects {
+      guard let value = Element._decodeUbiquitousKeyValue(from: object) else {
+        return nil
+      }
+      result.append(value)
+    }
+
+    return result
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    var result: [Any] = []
+    result.reserveCapacity(count)
+
+    for value in self {
+      guard let object = value._encodeUbiquitousKeyValue() else {
+        return nil
+      }
+      result.append(object)
+    }
+
+    return result
+  }
+}
+
+extension Dictionary: UbiquitousKeyValueStorable
+where Key == String, Value: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> [String: Value]? {
+    guard let objects = object as? [String: Any] else { return nil }
+
+    var result: [String: Value] = [:]
+    result.reserveCapacity(objects.count)
+
+    for (key, object) in objects {
+      guard let value = Value._decodeUbiquitousKeyValue(from: object) else {
+        return nil
+      }
+      result[key] = value
+    }
+
+    return result
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    var result: [String: Any] = [:]
+    result.reserveCapacity(count)
+
+    for (key, value) in self {
+      guard let object = value._encodeUbiquitousKeyValue() else {
+        return nil
+      }
+      result[key] = object
+    }
+
+    return result
+  }
+}
+
+extension UbiquitousKeyValueStorable where Self: Codable {
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Self? {
+    guard let data = object as? Data else { return nil }
+    return try? JSONDecoder().decode(Self.self, from: data)
+  }
+
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    try? JSONEncoder().encode(self)
+  }
+}
+
+extension Optional: UbiquitousKeyValueStorable
+where Wrapped: UbiquitousKeyValueStorable {
+  @_spi(Internal)
+  public static func _decodeUbiquitousKeyValue(from object: Any) -> Self? {
+    guard let value = Wrapped._decodeUbiquitousKeyValue(from: object) else {
+      return nil
+    }
+    return .some(value)
+  }
+
+  @_spi(Internal)
+  public func _encodeUbiquitousKeyValue() -> Any? {
+    switch self {
+    case .some(let value):
+      value._encodeUbiquitousKeyValue()
+    case .none:
+      nil
+    }
+  }
+}

--- a/Sources/StateGraphUbiquitousKeyValue/UbiquitousKeyValueStoreClient.swift
+++ b/Sources/StateGraphUbiquitousKeyValue/UbiquitousKeyValueStoreClient.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+/// The reason attached to an external iCloud key-value store notification.
+enum UbiquitousKeyValueStoreChangeReason: Equatable, Sendable {
+  case local
+  case server
+  case initialSync
+  case quotaViolation
+  case account
+  case unknown(Int?)
+}
+
+/// A normalized external change delivered by an iCloud key-value store client.
+struct UbiquitousKeyValueStoreChange: Equatable, Sendable {
+  let reason: UbiquitousKeyValueStoreChangeReason
+  let changedKeys: Set<String>?
+
+  func includes(_ key: String) -> Bool {
+    switch reason {
+    case .local, .server, .initialSync:
+      changedKeys?.contains(key) ?? true
+    case .account:
+      // An account replacement can remove keys without listing each old key.
+      true
+    case .quotaViolation:
+      false
+    case .unknown:
+      false
+    }
+  }
+}
+
+/// The synchronous store operations needed by `GraphUbiquitousKeyValue`.
+///
+/// The production client wraps `NSUbiquitousKeyValueStore.default`. Keeping
+/// this boundary internal to the extension module lets tests provide a
+/// deterministic store without exposing a second public storage abstraction.
+protocol UbiquitousKeyValueStoreClient: AnyObject {
+  func object(forKey key: String) -> Any?
+  func set(_ object: Any, forKey key: String)
+  func removeObject(forKey key: String)
+  func synchronize() -> Bool
+  func observe(
+    _ receiveChange: @escaping @Sendable (UbiquitousKeyValueStoreChange) -> Void
+  ) -> UbiquitousKeyValueStoreObservation
+}
+
+/// Owns one idempotent observation-cancellation action.
+final class UbiquitousKeyValueStoreObservation: @unchecked Sendable {
+  private let lock = NSLock()
+  private var cancellation: (@Sendable () -> Void)?
+
+  init(cancellation: @escaping @Sendable () -> Void) {
+    self.cancellation = cancellation
+  }
+
+  deinit {
+    cancel()
+  }
+
+  func cancel() {
+    lock.lock()
+    let cancellation = self.cancellation
+    self.cancellation = nil
+    lock.unlock()
+
+    cancellation?()
+  }
+}
+
+/// Adapts the app-wide Foundation iCloud key-value store to the internal client.
+final class FoundationUbiquitousKeyValueStoreClient: UbiquitousKeyValueStoreClient {
+  private struct ObserverToken: @unchecked Sendable {
+    let value: NSObjectProtocol
+  }
+
+  private let store: NSUbiquitousKeyValueStore
+
+  init(store: NSUbiquitousKeyValueStore) {
+    self.store = store
+  }
+
+  func object(forKey key: String) -> Any? {
+    store.object(forKey: key)
+  }
+
+  func set(_ object: Any, forKey key: String) {
+    store.set(object, forKey: key)
+  }
+
+  func removeObject(forKey key: String) {
+    store.removeObject(forKey: key)
+  }
+
+  func synchronize() -> Bool {
+    store.synchronize()
+  }
+
+  func observe(
+    _ receiveChange: @escaping @Sendable (UbiquitousKeyValueStoreChange) -> Void
+  ) -> UbiquitousKeyValueStoreObservation {
+    let token = NotificationCenter.default.addObserver(
+      forName: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+      object: store,
+      queue: nil
+    ) { notification in
+      receiveChange(Self.change(from: notification.userInfo))
+    }
+
+    let observerToken = ObserverToken(value: token)
+    return UbiquitousKeyValueStoreObservation {
+      NotificationCenter.default.removeObserver(observerToken.value)
+    }
+  }
+
+  /// Normalizes Foundation notification metadata into the coordinator's
+  /// deterministic change model.
+  static func change(
+    from userInfo: [AnyHashable: Any]?
+  ) -> UbiquitousKeyValueStoreChange {
+    let rawReason = (userInfo?[NSUbiquitousKeyValueStoreChangeReasonKey]
+      as? NSNumber)?.intValue
+
+    let reason: UbiquitousKeyValueStoreChangeReason
+    switch rawReason {
+    case NSUbiquitousKeyValueStoreServerChange:
+      reason = .server
+    case NSUbiquitousKeyValueStoreInitialSyncChange:
+      reason = .initialSync
+    case NSUbiquitousKeyValueStoreQuotaViolationChange:
+      reason = .quotaViolation
+    case NSUbiquitousKeyValueStoreAccountChange:
+      reason = .account
+    default:
+      reason = .unknown(rawReason)
+    }
+
+    let changedKeys = (
+      userInfo?[NSUbiquitousKeyValueStoreChangedKeysKey] as? [String]
+    ).map(Set.init)
+
+    return UbiquitousKeyValueStoreChange(
+      reason: reason,
+      changedKeys: changedKeys
+    )
+  }
+}

--- a/Tests/StateGraphUbiquitousKeyValueTests/GraphUbiquitousKeyValueTests.swift
+++ b/Tests/StateGraphUbiquitousKeyValueTests/GraphUbiquitousKeyValueTests.swift
@@ -1,0 +1,815 @@
+import Foundation
+import StateGraph
+import Testing
+@testable import StateGraphUbiquitousKeyValue
+
+@Suite("@GraphUbiquitousKeyValue", .serialized)
+struct GraphUbiquitousKeyValueTests {
+
+  /// A deterministic, in-memory boundary for the process-wide iCloud store.
+  ///
+  /// The fake deliberately invokes synchronization hooks and observers after
+  /// releasing its state lock. This matches the production requirement that
+  /// Foundation callbacks may synchronously reenter the graph coordinator.
+  private final class FakeClient: UbiquitousKeyValueStoreClient, @unchecked Sendable {
+    enum Operation: Equatable, Sendable {
+      case read(String)
+      case set(String)
+      case remove(String)
+      case observe
+      case cancelObservation
+      case synchronize
+    }
+
+    private struct State {
+      var values: [String: Any] = [:]
+      var observers: [
+        UUID: @Sendable (UbiquitousKeyValueStoreChange) -> Void
+      ] = [:]
+      var operations: [Operation] = []
+      var observationCount = 0
+      var cancellationCount = 0
+      var synchronizationCount = 0
+      var synchronizationResult = true
+      var synchronizationAction: (@Sendable () -> Void)?
+      var nextReadBarrier: BlockingRead?
+    }
+
+    private let lock = NSLock()
+    private var state = State()
+
+    /// Protects the fake's intentionally type-erased property-list storage.
+    ///
+    /// `OSAllocatedUnfairLock` requires a `Sendable` protected value, while the
+    /// Foundation client contract necessarily carries `Any`. The fake owns the
+    /// unchecked boundary and never accesses `state` outside this method.
+    private func withState<Result>(
+      _ body: (inout State) throws -> Result
+    ) rethrows -> Result {
+      lock.lock()
+      defer { lock.unlock() }
+      return try body(&state)
+    }
+
+    var operations: [Operation] {
+      withState { $0.operations }
+    }
+
+    var observationCount: Int {
+      withState { $0.observationCount }
+    }
+
+    var cancellationCount: Int {
+      withState { $0.cancellationCount }
+    }
+
+    var synchronizationCount: Int {
+      withState { $0.synchronizationCount }
+    }
+
+    var currentObserverCount: Int {
+      withState { $0.observers.count }
+    }
+
+    func readCount(forKey key: String) -> Int {
+      operations.reduce(into: 0) { count, operation in
+        if case .read(let operationKey) = operation, operationKey == key {
+          count += 1
+        }
+      }
+    }
+
+    func setCount(forKey key: String) -> Int {
+      operations.reduce(into: 0) { count, operation in
+        if case .set(let operationKey) = operation, operationKey == key {
+          count += 1
+        }
+      }
+    }
+
+    func string(forKey key: String) -> String? {
+      withState { $0.values[key] as? String }
+    }
+
+    /// Changes the fake store without generating a local or external event.
+    func setValue(_ value: Any, forKey key: String) {
+      withState { $0.values[key] = value }
+    }
+
+    /// Removes a fake store value without generating an event.
+    func removeValue(forKey key: String) {
+      withState { $0.values[key] = nil }
+    }
+
+    func setSynchronizationAction(
+      _ action: @escaping @Sendable () -> Void
+    ) {
+      withState { $0.synchronizationAction = action }
+    }
+
+    func blockNextRead(with barrier: BlockingRead) {
+      withState { $0.nextReadBarrier = barrier }
+    }
+
+    /// Delivers one normalized iCloud event to the active observation.
+    func send(
+      reason: UbiquitousKeyValueStoreChangeReason,
+      changedKeys: Set<String>?
+    ) {
+      let observers = withState { Array($0.observers.values) }
+      let change = UbiquitousKeyValueStoreChange(
+        reason: reason,
+        changedKeys: changedKeys
+      )
+
+      for observer in observers {
+        observer(change)
+      }
+    }
+
+    func object(forKey key: String) -> Any? {
+      let snapshot: (value: Any?, barrier: BlockingRead?) = withState { state in
+        state.operations.append(.read(key))
+        let barrier = state.nextReadBarrier
+        state.nextReadBarrier = nil
+        return (state.values[key], barrier)
+      }
+
+      snapshot.barrier?.wait()
+      return snapshot.value
+    }
+
+    func set(_ object: Any, forKey key: String) {
+      withState { state in
+        state.operations.append(.set(key))
+        state.values[key] = object
+      }
+    }
+
+    func removeObject(forKey key: String) {
+      withState { state in
+        state.operations.append(.remove(key))
+        state.values[key] = nil
+      }
+    }
+
+    func synchronize() -> Bool {
+      let snapshot: (result: Bool, action: (@Sendable () -> Void)?) =
+        withState { state in
+          state.operations.append(.synchronize)
+          state.synchronizationCount += 1
+          return (state.synchronizationResult, state.synchronizationAction)
+        }
+
+      snapshot.action?()
+      return snapshot.result
+    }
+
+    func observe(
+      _ receiveChange: @escaping @Sendable (UbiquitousKeyValueStoreChange) -> Void
+    ) -> UbiquitousKeyValueStoreObservation {
+      let id = UUID()
+      withState { state in
+        state.operations.append(.observe)
+        state.observationCount += 1
+        state.observers[id] = receiveChange
+      }
+
+      return UbiquitousKeyValueStoreObservation { [weak self] in
+        self?.cancelObservation(id: id)
+      }
+    }
+
+    private func cancelObservation(id: UUID) {
+      withState { state in
+        guard state.observers.removeValue(forKey: id) != nil else { return }
+        state.operations.append(.cancelObservation)
+        state.cancellationCount += 1
+      }
+    }
+  }
+
+  /// Suspends one fake read after it captures its return value.
+  private final class BlockingRead: @unchecked Sendable {
+    let didStart = DispatchSemaphore(value: 0)
+    let resume = DispatchSemaphore(value: 0)
+
+    func wait() {
+      didStart.signal()
+      resume.wait()
+    }
+  }
+
+  private final class Counter: @unchecked Sendable {
+    private let value = OSAllocatedUnfairLock(initialState: 0)
+
+    var current: Int {
+      value.withLock { $0 }
+    }
+
+    func increment() {
+      value.withLock { $0 += 1 }
+    }
+  }
+
+  /// Allows exactly one reentrant callback to claim the nested mutation.
+  private final class OnceFlag: @unchecked Sendable {
+    private let value = OSAllocatedUnfairLock(initialState: false)
+
+    var isClaimed: Bool {
+      value.withLock { $0 }
+    }
+
+    func claim() -> Bool {
+      value.withLock { isClaimed in
+        guard !isClaimed else { return false }
+        isClaimed = true
+        return true
+      }
+    }
+  }
+
+  private final class ValueBox<Value: Sendable>: @unchecked Sendable {
+    private let value = OSAllocatedUnfairLock<Value?>(initialState: nil)
+
+    var current: Value? {
+      value.withLock { $0 }
+    }
+
+    func store(_ newValue: Value) {
+      value.withLock { $0 = newValue }
+    }
+  }
+
+  private final class PublicationLockProbe: @unchecked Sendable {
+    private struct State {
+      var didRun = false
+      var concurrentOperationCompleted = false
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var result: (didRun: Bool, concurrentOperationCompleted: Bool) {
+      state.withLock { ($0.didRun, $0.concurrentOperationCompleted) }
+    }
+
+    func verifyConcurrentOperation(
+      _ operation: @escaping @Sendable () -> Void
+    ) {
+      let operationFinished = DispatchSemaphore(value: 0)
+      DispatchQueue.global().async {
+        operation()
+        operationFinished.signal()
+      }
+
+      let didComplete = operationFinished.wait(timeout: .now() + 1) == .success
+      state.withLock {
+        $0.didRun = true
+        $0.concurrentOperationCompleted = didComplete
+      }
+    }
+  }
+
+  private final class Model<
+    Value: UbiquitousKeyValueStorable & SendableMetatype
+  > {
+    @GraphUbiquitousKeyValue var value: Value
+
+    init(
+      key: String,
+      defaultValue: Value,
+      coordinator: UbiquitousKeyValueAccessCoordinator
+    ) {
+      _value = GraphUbiquitousKeyValue(
+        wrappedValue: defaultValue,
+        key,
+        coordinator: coordinator
+      )
+    }
+
+    var projection: GraphUbiquitousKeyValue<Value> {
+      $value
+    }
+  }
+
+  private struct CodableValue:
+    Codable,
+    Equatable,
+    Sendable,
+    UbiquitousKeyValueStorable
+  {
+    var name: String
+    var count: Int
+  }
+
+  private func makeCoordinator(
+    client: FakeClient
+  ) -> UbiquitousKeyValueAccessCoordinator {
+    UbiquitousKeyValueAccessCoordinator(client: client)
+  }
+
+  @Test
+  func foundationNotificationMetadataIsNormalized() {
+    let reasons: [(Int, UbiquitousKeyValueStoreChangeReason)] = [
+      (NSUbiquitousKeyValueStoreServerChange, .server),
+      (NSUbiquitousKeyValueStoreInitialSyncChange, .initialSync),
+      (NSUbiquitousKeyValueStoreQuotaViolationChange, .quotaViolation),
+      (NSUbiquitousKeyValueStoreAccountChange, .account),
+    ]
+
+    for (rawReason, expectedReason) in reasons {
+      let userInfo: [AnyHashable: Any] = [
+        NSUbiquitousKeyValueStoreChangeReasonKey: NSNumber(value: rawReason)
+      ]
+      #expect(
+        FoundationUbiquitousKeyValueStoreClient.change(from: userInfo).reason
+          == expectedReason
+      )
+    }
+
+    let userInfo: [AnyHashable: Any] = [
+      NSUbiquitousKeyValueStoreChangeReasonKey:
+        NSNumber(value: NSUbiquitousKeyValueStoreServerChange),
+      NSUbiquitousKeyValueStoreChangedKeysKey: ["value", "value", "other"],
+    ]
+    #expect(
+      FoundationUbiquitousKeyValueStoreClient.change(from: userInfo)
+        == UbiquitousKeyValueStoreChange(
+          reason: .server,
+          changedKeys: ["value", "other"]
+        )
+    )
+    #expect(
+      FoundationUbiquitousKeyValueStoreClient.change(from: nil)
+        == UbiquitousKeyValueStoreChange(
+          reason: .unknown(nil),
+          changedKeys: nil
+        )
+    )
+  }
+
+  @Test
+  func observesBeforeRequestingInitialSynchronizationAndRequestsItOnce() {
+    let key = "value"
+    let client = FakeClient()
+    let coordinator = makeCoordinator(client: client)
+    client.setSynchronizationAction { [weak client] in
+      guard let client else { return }
+      client.setValue("synchronized", forKey: key)
+      client.send(reason: .initialSync, changedKeys: [key])
+    }
+
+    let first = GraphUbiquitousKeyValue(
+      wrappedValue: "default",
+      key,
+      coordinator: coordinator
+    )
+    let second = GraphUbiquitousKeyValue(
+      wrappedValue: "default",
+      key,
+      coordinator: coordinator
+    )
+
+    #expect(first.wrappedValue == "synchronized")
+    #expect(second.wrappedValue == "synchronized")
+    #expect(client.observationCount == 1)
+    #expect(client.synchronizationCount == 1)
+
+    let operations = client.operations
+    let observationIndex = operations.firstIndex(of: .observe)
+    let synchronizationIndex = operations.firstIndex(of: .synchronize)
+    #expect(observationIndex != nil)
+    #expect(synchronizationIndex != nil)
+    if let observationIndex, let synchronizationIndex {
+      #expect(observationIndex < synchronizationIndex)
+    }
+  }
+
+  @Test
+  func assigningDefaultValuePersistsAnAbsentKey() {
+    let key = "value"
+    let client = FakeClient()
+    let value = GraphUbiquitousKeyValue(
+      wrappedValue: "default",
+      key,
+      coordinator: makeCoordinator(client: client)
+    )
+    let counter = Counter()
+    value.onDidSet { _, _ in counter.increment() }
+
+    value.wrappedValue = "default"
+
+    #expect(client.string(forKey: key) == "default")
+    #expect(client.setCount(forKey: key) == 1)
+    #expect(value.wrappedValue == "default")
+    #expect(counter.current == 0)
+  }
+
+  @Test
+  func propertyListAndOptionalValuesRoundTrip() {
+    let client = FakeClient()
+    let coordinator = makeCoordinator(client: client)
+    let integer = GraphUbiquitousKeyValue(
+      wrappedValue: 0,
+      "integer",
+      coordinator: coordinator
+    )
+    let float = GraphUbiquitousKeyValue(
+      wrappedValue: Float.zero,
+      "float",
+      coordinator: coordinator
+    )
+    let data = GraphUbiquitousKeyValue(
+      wrappedValue: Data(),
+      "data",
+      coordinator: coordinator
+    )
+    let date = GraphUbiquitousKeyValue(
+      wrappedValue: Date(timeIntervalSince1970: 0),
+      "date",
+      coordinator: coordinator
+    )
+    let array = GraphUbiquitousKeyValue(
+      wrappedValue: [Int](),
+      "array",
+      coordinator: coordinator
+    )
+    let dictionary = GraphUbiquitousKeyValue(
+      wrappedValue: [String: Bool](),
+      "dictionary",
+      coordinator: coordinator
+    )
+    let optional = GraphUbiquitousKeyValue<String?>(
+      wrappedValue: nil,
+      "optional",
+      coordinator: coordinator
+    )
+
+    integer.wrappedValue = 42
+    float.wrappedValue = 1.25
+    data.wrappedValue = Data([1, 2, 3])
+    date.wrappedValue = Date(timeIntervalSince1970: 1_234)
+    array.wrappedValue = [1, 2, 3]
+    dictionary.wrappedValue = ["enabled": true]
+    optional.wrappedValue = "present"
+
+    #expect(integer.wrappedValue == 42)
+    #expect(client.object(forKey: "integer") as? Int64 == 42)
+    #expect(float.wrappedValue == 1.25)
+    #expect(client.object(forKey: "float") as? Double == 1.25)
+    #expect(data.wrappedValue == Data([1, 2, 3]))
+    #expect(date.wrappedValue == Date(timeIntervalSince1970: 1_234))
+    #expect(array.wrappedValue == [1, 2, 3])
+    #expect(dictionary.wrappedValue == ["enabled": true])
+    #expect(optional.wrappedValue == "present")
+
+    optional.wrappedValue = nil
+
+    #expect(client.object(forKey: "optional") == nil)
+    #expect(optional.wrappedValue == nil)
+  }
+
+  @Test
+  func codableValueRoundTripsThroughDataRepresentation() {
+    let key = "codable"
+    let client = FakeClient()
+    let coordinator = makeCoordinator(client: client)
+    let value = GraphUbiquitousKeyValue(
+      wrappedValue: CodableValue(name: "default", count: 0),
+      key,
+      coordinator: coordinator
+    )
+
+    value.wrappedValue = CodableValue(name: "saved", count: 42)
+
+    let restored = GraphUbiquitousKeyValue(
+      wrappedValue: CodableValue(name: "fallback", count: -1),
+      key,
+      coordinator: coordinator
+    )
+    #expect(client.object(forKey: key) is Data)
+    #expect(restored.wrappedValue == CodableValue(name: "saved", count: 42))
+  }
+
+  @Test
+  func invalidCollectionRepresentationRestoresDeclaredDefault() {
+    let key = "array"
+    let client = FakeClient()
+    client.setValue([Int64(1)], forKey: key)
+    let value = GraphUbiquitousKeyValue(
+      wrappedValue: [9],
+      key,
+      coordinator: makeCoordinator(client: client)
+    )
+
+    #expect(value.wrappedValue == [1])
+
+    client.setValue(["invalid"], forKey: key)
+    client.send(reason: .server, changedKeys: [key])
+
+    #expect(value.wrappedValue == [9])
+  }
+
+  @Test
+  func localWriteConvergesPeerWrappersWithoutExternalNotification() {
+    let key = "value"
+    let client = FakeClient()
+    let coordinator = makeCoordinator(client: client)
+    let first = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      key,
+      coordinator: coordinator
+    )
+    let second = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      key,
+      coordinator: coordinator
+    )
+    let firstCounter = Counter()
+    let secondCounter = Counter()
+    first.onDidSet { _, _ in firstCounter.increment() }
+    second.onDidSet { _, _ in secondCounter.increment() }
+
+    first.wrappedValue = "shared"
+
+    #expect(client.string(forKey: key) == "shared")
+    #expect(first.wrappedValue == "shared")
+    #expect(second.wrappedValue == "shared")
+    #expect(firstCounter.current == 1)
+    #expect(secondCounter.current == 1)
+  }
+
+  @Test
+  func externalReasonsRefreshOnlyTheirIntendedKeys() {
+    let key = "value"
+    let client = FakeClient()
+    let value = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      key,
+      coordinator: makeCoordinator(client: client)
+    )
+    let counter = Counter()
+    value.onDidSet { _, _ in counter.increment() }
+
+    let readsBeforeUnrelatedChange = client.readCount(forKey: key)
+    client.setValue("server", forKey: key)
+    client.send(reason: .server, changedKeys: ["other"])
+
+    #expect(value.wrappedValue == "initial")
+    #expect(client.readCount(forKey: key) == readsBeforeUnrelatedChange)
+
+    client.send(reason: .server, changedKeys: [key])
+    #expect(value.wrappedValue == "server")
+
+    client.setValue("initial-sync", forKey: key)
+    client.send(reason: .initialSync, changedKeys: nil)
+    #expect(value.wrappedValue == "initial-sync")
+    #expect(counter.current == 2)
+
+    let readsBeforeIgnoredReasons = client.readCount(forKey: key)
+    client.setValue("ignored", forKey: key)
+    client.send(reason: .quotaViolation, changedKeys: [key])
+    client.send(reason: .unknown(nil), changedKeys: [key])
+
+    #expect(value.wrappedValue == "initial-sync")
+    #expect(client.readCount(forKey: key) == readsBeforeIgnoredReasons)
+    #expect(counter.current == 2)
+  }
+
+  @Test
+  func accountChangeRefreshesAllKeysAndRemovalRestoresDefault() {
+    let key = "value"
+    let client = FakeClient()
+    client.setValue("persisted", forKey: key)
+    let value = GraphUbiquitousKeyValue(
+      wrappedValue: "default",
+      key,
+      coordinator: makeCoordinator(client: client)
+    )
+    let counter = Counter()
+    value.onDidSet { _, _ in counter.increment() }
+
+    client.removeValue(forKey: key)
+    client.send(reason: .account, changedKeys: ["other"])
+
+    #expect(value.wrappedValue == "default")
+    #expect(counter.current == 1)
+  }
+
+  @Test
+  func duplicateExternalNotificationsPublishOnlyOnce() {
+    let key = "value"
+    let client = FakeClient()
+    let value = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      key,
+      coordinator: makeCoordinator(client: client)
+    )
+    let counter = Counter()
+    value.onDidSet { _, _ in counter.increment() }
+
+    client.setValue("external", forKey: key)
+    client.send(reason: .server, changedKeys: [key])
+    client.send(reason: .server, changedKeys: [key])
+
+    #expect(value.wrappedValue == "external")
+    #expect(counter.current == 1)
+  }
+
+  @Test
+  func externalChangeInvalidatesGraphDependencies() async {
+    let key = "value"
+    let client = FakeClient()
+    let value = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      key,
+      coordinator: makeCoordinator(client: client)
+    )
+    let projection = value.projectedValue
+    let computed = Computed<String>(name: "dependent") { _ in
+      "computed_\(projection.wrappedValue)"
+    }
+
+    #expect(computed.wrappedValue == "computed_initial")
+
+    await confirmation(expectedCount: 1) { confirmation in
+      let cancellable = withGraphTracking {
+        withGraphTrackingMap {
+          computed.wrappedValue
+        } onChange: { value in
+          guard value == "computed_external" else { return }
+          confirmation.confirm()
+        }
+      }
+
+      client.setValue("external", forKey: key)
+      client.send(reason: .server, changedKeys: [key])
+
+      try? await Task.sleep(for: .milliseconds(20))
+      withExtendedLifetime(cancellable) {}
+    }
+  }
+
+  @Test
+  func retainedProjectionKeepsSynchronizationAlive() {
+    let key = "value"
+    let client = FakeClient()
+    let coordinator = makeCoordinator(client: client)
+    var model: Model<String>? = Model(
+      key: key,
+      defaultValue: "initial",
+      coordinator: coordinator
+    )
+    var projection: GraphUbiquitousKeyValue<String>? = model!.projection
+
+    #expect(model!.projection === projection!)
+
+    model = nil
+    client.setValue("external", forKey: key)
+    client.send(reason: .server, changedKeys: [key])
+
+    #expect(projection?.wrappedValue == "external")
+    projection?.wrappedValue = "projected"
+    #expect(client.string(forKey: key) == "projected")
+    #expect(client.currentObserverCount == 1)
+
+    projection = nil
+    #expect(client.currentObserverCount == 0)
+    #expect(client.cancellationCount == 1)
+
+    let restarted = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      key,
+      coordinator: coordinator
+    )
+    #expect(restarted.wrappedValue == "projected")
+    #expect(client.observationCount == 2)
+    #expect(client.synchronizationCount == 1)
+  }
+
+  @Test
+  func finalRefreshClosesInitialReadObservationGap() {
+    let key = "value"
+    let client = FakeClient()
+    client.setValue("initial", forKey: key)
+    let coordinator = makeCoordinator(client: client)
+    let barrier = BlockingRead()
+    client.blockNextRead(with: barrier)
+    let valueBox = ValueBox<GraphUbiquitousKeyValue<String>>()
+    let initializationFinished = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global().async {
+      valueBox.store(
+        GraphUbiquitousKeyValue(
+          wrappedValue: "default",
+          key,
+          coordinator: coordinator
+        )
+      )
+      initializationFinished.signal()
+    }
+
+    #expect(barrier.didStart.wait(timeout: .now() + 1) == .success)
+    client.setValue("during-initialization", forKey: key)
+    barrier.resume.signal()
+
+    #expect(initializationFinished.wait(timeout: .now() + 1) == .success)
+    #expect(valueBox.current?.wrappedValue == "during-initialization")
+  }
+
+  @Test
+  func publicationRunsAfterCoordinatorUnlocks() {
+    let client = FakeClient()
+    let coordinator = makeCoordinator(client: client)
+    let observed = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      "observed",
+      coordinator: coordinator
+    )
+    let concurrent = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      "concurrent",
+      coordinator: coordinator
+    )
+    let probe = PublicationLockProbe()
+
+    observed.onDidSet { _, _ in
+      probe.verifyConcurrentOperation {
+        // Equal assignment exercises the coordinator without queuing another
+        // graph publication behind the callback that is currently running.
+        concurrent.wrappedValue = "initial"
+      }
+    }
+
+    observed.wrappedValue = "updated"
+
+    let result = probe.result
+    #expect(result.didRun)
+    #expect(result.concurrentOperationCompleted)
+  }
+
+  @Test
+  func nestedCoordinatorPublicationPreservesOuterReentrancy() {
+    let firstClient = FakeClient()
+    let secondClient = FakeClient()
+    let first = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      "first",
+      coordinator: makeCoordinator(client: firstClient)
+    )
+    let second = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      "second",
+      coordinator: makeCoordinator(client: secondClient)
+    )
+
+    first.onDidSet { _, newValue in
+      guard newValue == "first" else { return }
+      second.wrappedValue = "nested"
+      first.wrappedValue = "second"
+    }
+
+    let mutationFinished = DispatchSemaphore(value: 0)
+    DispatchQueue.global().async {
+      first.wrappedValue = "first"
+      mutationFinished.signal()
+    }
+
+    #expect(mutationFinished.wait(timeout: .now() + 1) == .success)
+    #expect(first.wrappedValue == "second")
+    #expect(second.wrappedValue == "nested")
+  }
+
+  @Test
+  func reentrantWriteConvergesAllPeerWrappers() {
+    let key = "value"
+    let client = FakeClient()
+    let coordinator = makeCoordinator(client: client)
+    let first = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      key,
+      coordinator: coordinator
+    )
+    let second = GraphUbiquitousKeyValue(
+      wrappedValue: "initial",
+      key,
+      coordinator: coordinator
+    )
+    let nestedWrite = OnceFlag()
+
+    let handler: (String, String) -> Void = { _, newValue in
+      guard newValue == "first", nestedWrite.claim() else { return }
+      first.wrappedValue = "second"
+    }
+    first.onDidSet(handler)
+    second.onDidSet(handler)
+
+    client.setValue("first", forKey: key)
+    client.send(reason: .server, changedKeys: [key])
+
+    #expect(nestedWrite.isClaimed)
+    #expect(client.string(forKey: key) == "second")
+    #expect(first.wrappedValue == "second")
+    #expect(second.wrappedValue == "second")
+  }
+}

--- a/Tests/StateGraphUbiquitousKeyValueTests/ModuleBoundaryTests.swift
+++ b/Tests/StateGraphUbiquitousKeyValueTests/ModuleBoundaryTests.swift
@@ -1,0 +1,13 @@
+import StateGraphUbiquitousKeyValue
+import Testing
+
+/// Verifies the public import contract of the optional extension module.
+@Suite("StateGraphUbiquitousKeyValue module")
+struct StateGraphUbiquitousKeyValueModuleTests {
+  @Test("The extension module re-exports StateGraph")
+  func reexportsStateGraph() {
+    let value = Stored(wrappedValue: 42)
+
+    #expect(value.wrappedValue == 42)
+  }
+}


### PR DESCRIPTION
## Summary

- add the optional `StateGraphUbiquitousKeyValue` library product and target, with a one-way dependency on `StateGraph`
- add `GraphUbiquitousKeyValue`, a reference-identity property wrapper that owns an in-memory `Stored` node while synchronizing one `NSUbiquitousKeyValueStore.default` key
- add property-list and Codable value conversion, keyed observation, local peer fan-out, initial synchronization, and account-change handling
- add a dedicated test target, DocC catalog, shared scheme, and aggregate test-plan entries for the extension module

## Why

`Stored` remains intentionally in-memory-only. Keeping iCloud key-value synchronization in `StateGraphUbiquitousKeyValue` prevents Foundation's iCloud lifecycle from entering the core `StateGraph` module, while allowing clients to opt in explicitly.

The extension module re-exports `StateGraph`, so clients that use this integration can add the optional product and write:

```swift
import StateGraphUbiquitousKeyValue
```

## Validation

- rebased onto current `main` (`b551472`)
- `swift test --build-system native --filter StateGraphUbiquitousKeyValue` (17 tests in 2 suites)
- `swift test --build-system native --skip-build` (166 Swift Testing tests in 35 suites + 17 XCTest tests)
- fresh strict-concurrency build of `StateGraphUbiquitousKeyValue` with `ClosureIsolation`
- DocC conversion for the new module with warnings treated as errors
- package dependency inspection, test-plan JSON validation, and shared-scheme XML validation

## Notes

Real cross-device propagation still requires an entitlement-enabled host app and multiple Apple devices. This package checkout validates the wrapper and notification/coordinator semantics deterministically.

Xcode MCP was unavailable in this environment, so the new shared scheme was syntax-validated but not run from Xcode.