### PR TITLE
Preserve tracking invalidation delivery semantics

### DIFF
--- a/Sources/StateGraph/Documentation.docc/Core-Concepts.md
+++ b/Sources/StateGraph/Documentation.docc/Core-Concepts.md
@@ -303,6 +303,7 @@ let subscription = withGraphTracking {
 - Must be called within a `withGraphTracking` scope
 - The handler should perform side effects, not return values
 - All subscriptions are cleaned up when the returned cancellable is cancelled
+- See <doc:Tracking-Registrations> for the lifecycle of the one-shot registrations used by each execution
 
 ## Memory Management
 

--- a/Sources/StateGraph/Documentation.docc/Documentation.md
+++ b/Sources/StateGraph/Documentation.docc/Documentation.md
@@ -95,8 +95,10 @@ final class CounterViewModel {
 ### Observation and Tracking
 
 - ``withGraphTracking(_:)``
-- ``withGraphTrackingGroup(_:)``
+- ``withGraphTrackingGroup(_:isolation:)``
 - ``Node/onChange(_:)``
+- <doc:Tracking-Registrations>
+- ``TrackingRegistration``
 - <doc:Observation-Patterns>
 
 ### Utilities

--- a/Sources/StateGraph/Documentation.docc/Tracking-Registrations.md
+++ b/Sources/StateGraph/Documentation.docc/Tracking-Registrations.md
@@ -1,0 +1,128 @@
+# Tracking Registrations
+
+Understand how one tracking pass records node reads and turns them into a one-shot change notification.
+
+## Overview
+
+Public APIs such as ``withGraphTrackingGroup(_:isolation:)`` and
+``withGraphTrackingMap(_:filter:onChange:isolation:)`` continuously re-run work when the
+State Graph nodes read by that work change. A ``TrackingRegistration`` is the internal record
+that connects one execution of that work to the nodes it read.
+
+You don't create or retain registrations directly. StateGraph creates a fresh registration for
+each tracking pass and manages it through the public tracking APIs:
+
+```swift
+let subscription = withGraphTracking {
+  withGraphTrackingGroup {
+    print(model.count)
+  }
+}
+```
+
+In this example, the registration belongs to one execution of the group handler. The returned
+subscription owns the overall observation lifetime; the registration only describes the node
+reads made by that particular execution.
+
+## Responsibilities
+
+Several objects participate in continuous tracking, but they have different lifetimes:
+
+| Component | Responsibility |
+| --- | --- |
+| `AnyCancellable` and `GraphTrackingCancellable` | Own the overall tracking scope and its nested scopes. |
+| ``TrackingRegistration`` | Represent the node reads and change callback for one tracking pass. |
+| `ThreadLocal.registration` | Make the current pass visible to synchronous node reads. |
+| `Node.trackingRegistrations` | Retain the registrations that have read that node. |
+| Handler storage lock | Retain the handler until cancellation and serialize handler execution. |
+
+Keeping these responsibilities separate is important. Cancelling a subscription ends the whole
+observation, while invalidating a registration only completes one pass and allows continuous
+tracking to establish the next one.
+
+## Lifecycle of a Registration
+
+A registration moves through the following lifecycle:
+
+1. `withStateGraphTracking` creates a registration containing the pass's `didChange` callback.
+2. StateGraph installs it in `ThreadLocal.registration` for the synchronous duration of `apply`.
+3. Every ``Stored`` or ``Computed`` value read by `apply` inserts that same registration into its
+   `trackingRegistrations` set.
+4. When an eligible change occurs, the node snapshots and clears its registrations while holding
+   the node lock.
+5. After releasing the node lock, the node calls `perform()` on each captured registration.
+6. The first eligible `perform()` marks the registration invalidated and enqueues `didChange` in a
+   task. If the tracking pass inherited an actor, StateGraph returns to that actor. Otherwise the
+   callback executes on an unspecified executor.
+7. A continuous tracking API runs a new pass with a fresh registration, recording the dependencies
+   read by that new execution.
+
+The callback runs after both the node lock and the registration's state lock are released. This
+allows the next tracking pass to read graph state or establish nested tracking without re-entering
+either lock.
+
+### One-shot invalidation
+
+A registration may be stored by several nodes because one pass can read several values. The first
+eligible node invalidation delivers its callback. Later calls to `perform()` on the same
+registration do nothing.
+
+This one-shot behavior aggregates changes that occur before the next pass. It also means that
+continuous observation must create a fresh registration rather than reusing the invalidated one.
+The new pass dynamically replaces the dependency set: only nodes read during that pass participate
+in its next invalidation.
+
+## Stored and Computed Nodes
+
+``Stored`` evaluates its notification predicate before invalidating registrations:
+
+- An `Equatable` value notifies when the old and new values differ.
+- A non-Equatable reference value notifies when its identity changes.
+- A value without an equality or identity comparison notifies on every assignment.
+
+An assignment rejected by the predicate doesn't call `perform()` and leaves the current
+registrations attached. Therefore, assigning the same `Int` doesn't exercise registration
+invalidation or self-invalidation protection.
+
+``Computed`` captures registrations when it changes from clean to potentially dirty. It clears the
+captured set and invalidates those registrations once, even if additional upstream changes arrive
+before the computed value is read and recomputed.
+
+## Self-Invalidation
+
+A tracking handler can read a node and then synchronously assign to that same node. In that case,
+the node's captured registrations include the registration that is currently executing.
+
+StateGraph compares the registration passed to `perform()` with `ThreadLocal.registration`. It
+doesn't invoke the active registration's own callback, which prevents an immediate feedback loop.
+Registrations belonging to peer handlers have different identities and continue to receive the
+change normally.
+
+The mutated node has already removed the active registration from its set. StateGraph doesn't
+restore it automatically, so that handler won't observe another change to the same node until a
+different tracked dependency causes a new pass. In DEBUG builds, StateGraph emits a warning for
+this condition unless ``StateGraphDiagnostics/isSelfInvalidationWarningEnabled`` is disabled.
+
+> Important: Self-invalidation protection only suppresses the active registration. It doesn't
+> detect or stop a cycle formed by multiple handlers that mutate one another's dependencies.
+
+## Concurrent Invalidation and Serialized Reruns
+
+Tracking callbacks can be requested concurrently with a handler that is already running. The
+current implementation keeps handler bodies serialized by holding the handler storage lock while
+the user handler executes. An overlapping tracking pass waits for that lock.
+
+Because the waiting pass remains inside its own `withStateGraphTracking` scope, it executes with
+the fresh registration created for that pass after the lock becomes available. It doesn't hand
+the handler execution to the previous pass.
+
+This preserves the following implementation invariant:
+
+> Every rerun must execute with the registration and nested tracking scope created for that pass.
+
+## See Also
+
+- ``withGraphTracking(_:)``
+- ``withGraphTrackingGroup(_:isolation:)``
+- ``withGraphTrackingMap(_:filter:onChange:isolation:)``
+- ``StateGraphDiagnostics/isSelfInvalidationWarningEnabled``

--- a/Sources/StateGraph/Observation/withTracking.swift
+++ b/Sources/StateGraph/Observation/withTracking.swift
@@ -2,11 +2,14 @@ import Observation
 
 /// Tracks access to the properties of StoredNode or Computed.
 /// Similarly to Observation.withObservationTracking, didChange runs one time after property changes applied.
+/// Callback delivery is enqueued asynchronously. An actor-isolated callback returns to that actor;
+/// a nonisolated callback runs on an unspecified executor.
 /// To observe properties continuously, use ``withContinuousStateGraphTracking``.
 @discardableResult
 func withStateGraphTracking<R>(
   apply: () -> R,
-  @_inheritActorContext didChange: @escaping @isolated(any) @Sendable () -> Void
+  didChange: @escaping () -> Void,
+  isolation: isolated (any Actor)? = #isolation
 ) -> R {
   #if false  // #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     return withObservationTracking(
@@ -19,7 +22,10 @@ func withStateGraphTracking<R>(
     )
   #else
     /// Need this for now as https://github.com/VergeGroup/swift-state-graph/pull/79
-    let registration = TrackingRegistration(didChange: didChange)
+    let registration = TrackingRegistration(
+      didChange: didChange,
+      isolation: isolation
+    )
     return ThreadLocal.registration.withValue(registration) {
       apply()
     }
@@ -102,22 +108,26 @@ private func _withContinuousStateGraphTracking<R>(
   didChange: ClosureBox<StateGraphTrackingContinuation>,
   isolation: isolated (any Actor)? = #isolation
 ) {
-  withStateGraphTracking(apply: apply.closure) {
-    let continuation = perform(didChange, isolation: isolation)
-    switch continuation {
-    case .stop:
-      break
-    case .next:
-      // continue tracking on next event loop.
-      // It uses isolation and task dispatching to ensure apply closure is called on the same actor.
-      // Pass the already-wrapped closures directly to avoid thunk stack growing.
-      _withContinuousStateGraphTracking(
-        apply: apply,
-        didChange: didChange,
-        isolation: isolation
-      )
-    }
-  }
+  withStateGraphTracking(
+    apply: apply.closure,
+    didChange: {
+      let continuation = perform(didChange, isolation: isolation)
+      switch continuation {
+      case .stop:
+        break
+      case .next:
+        // continue tracking on next event loop.
+        // It uses isolation and task dispatching to ensure apply closure is called on the same actor.
+        // Pass the already-wrapped closures directly to avoid thunk stack growing.
+        _withContinuousStateGraphTracking(
+          apply: apply,
+          didChange: didChange,
+          isolation: isolation
+        )
+      }
+    },
+    isolation: isolation
+  )
 }
 
 /// Creates an `AsyncStream` that emits projected values whenever tracked StateGraph nodes change.
@@ -219,6 +229,61 @@ public func withStateGraphTrackingStream<T>(
 
 // MARK: - Internals
 
+/// Delivers a one-shot invalidation callback in its requested isolation context.
+///
+/// Delivery is always enqueued in a task. When an actor was captured at registration time, the
+/// callback returns to that actor. Without an actor, it executes on an unspecified executor.
+///
+/// `@unchecked Sendable` deliberately localizes the existing internal transport of a non-`Sendable`
+/// callback. It doesn't make the closure's captures thread-safe. The recorded isolation determines
+/// where an actor-isolated callback executes, while `nil` retains the unspecified-executor contract.
+private struct TrackingInvalidationCallback: @unchecked Sendable {
+
+  private let closure: () -> Void
+  private let isolation: (any Actor)?
+
+  init(
+    closure: @escaping () -> Void,
+    isolation: isolated (any Actor)?
+  ) {
+    self.closure = closure
+    self.isolation = isolation
+  }
+
+  func callAsFunction() {
+    Task { [self] in
+      if let isolation {
+        await perform(isolation: isolation)
+      } else {
+        perform()
+      }
+    }
+  }
+
+  private func perform() {
+    closure()
+  }
+
+  private func perform(isolation: isolated (any Actor)) {
+    closure()
+  }
+}
+
+/// A one-shot record of the State Graph nodes read during one tracking pass.
+///
+/// StateGraph creates a fresh registration for each execution of a continuous tracking API and
+/// installs it as the current tracking context while that execution reads nodes. Each accessed
+/// node retains the registration until an eligible change captures and invalidates it.
+///
+/// The first eligible invalidation delivers the registration's change callback. Further
+/// invalidations are ignored, and the next continuous tracking pass creates a new registration
+/// for its newly read dependencies.
+///
+/// You don't create or manage registrations directly. Use ``withGraphTracking(_:)`` together with
+/// ``withGraphTrackingGroup(_:isolation:)`` or a graph tracking map instead.
+///
+/// For the complete lifecycle, notification filtering, self-invalidation behavior, and concurrent
+/// rerun invariant, see <doc:Tracking-Registrations>.
 public final class TrackingRegistration: Sendable, Hashable {
 
   private struct State: Sendable {
@@ -226,7 +291,7 @@ public final class TrackingRegistration: Sendable, Hashable {
 #if DEBUG
     var hasEmittedSelfInvalidationWarning = false
 #endif
-    let didChange: @isolated(any) @Sendable () -> Void
+    let didChange: TrackingInvalidationCallback
   }
 
   public static func == (lhs: TrackingRegistration, rhs: TrackingRegistration) -> Bool {
@@ -239,10 +304,16 @@ public final class TrackingRegistration: Sendable, Hashable {
 
   private let state: OSAllocatedUnfairLock<State>
 
-  init(didChange: @escaping @isolated(any) @Sendable () -> Void) {
+  init(
+    didChange: @escaping () -> Void,
+    isolation: isolated (any Actor)? = #isolation
+  ) {
     self.state = .init(uncheckedState:
       .init(
-        didChange: didChange
+        didChange: .init(
+          closure: didChange,
+          isolation: isolation
+        )
       )
     )
   }
@@ -252,9 +323,12 @@ public final class TrackingRegistration: Sendable, Hashable {
     let isSelfInvalidationWarningEnabled = StateGraphDiagnostics.isSelfInvalidationWarningEnabled
 #endif
 
-    let shouldEmitSelfInvalidationWarning = state.withLock { state in
+    let invalidation: (
+      didChange: TrackingInvalidationCallback?,
+      shouldEmitSelfInvalidationWarning: Bool
+    ) = state.withLock { state in
       guard state.isInvalidated == false else {
-        return false
+        return (nil, false)
       }
       
       // Re-entry Prevention Guard
@@ -278,7 +352,7 @@ public final class TrackingRegistration: Sendable, Hashable {
       // the node before it finishes, the setter asks every captured registration
       // to perform, including the registration that is currently executing.
       //
-      // Without this identity check, the active registration would schedule its
+      // Without this identity check, the active registration would invoke its
       // own `didChange` closure. Continuous tracking would run the handler again,
       // install a new registration, perform the same mutation, and repeat the cycle.
       //
@@ -306,23 +380,21 @@ public final class TrackingRegistration: Sendable, Hashable {
 #if DEBUG
         if isSelfInvalidationWarningEnabled, state.hasEmittedSelfInvalidationWarning == false {
           state.hasEmittedSelfInvalidationWarning = true
-          return true
+          return (nil, true)
         }
 #endif
-        return false
+        return (nil, false)
       }
-      
+
       state.isInvalidated = true
-      
-      let closure = state.didChange
-      Task {
-        await closure()
-      }
-      return false
+
+      return (state.didChange, false)
     }
 
+    invalidation.didChange?()
+
 #if DEBUG
-    if shouldEmitSelfInvalidationWarning {
+    if invalidation.shouldEmitSelfInvalidationWarning {
       Log.logSuppressedSelfInvalidation()
     }
 #endif

--- a/Tests/StateGraphTests/GraphTrackingGroupTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingGroupTests.swift
@@ -30,6 +30,38 @@ struct GraphTrackingGroupTests {
   }
 
   @Test
+  func nonisolatedGroupEnqueuesRerun() async {
+    let node = Stored(wrappedValue: 0)
+    let rerunFinished = TestSignal()
+    let setterStackMarker = "StateGraphTests.nonisolatedGroupEnqueuesRerun.\(UUID())"
+    let callbackObservedSetterStack = OSAllocatedUnfairLock(initialState: false)
+
+    let cancellable = withGraphTracking {
+      withGraphTrackingGroup(
+        {
+          guard node.wrappedValue == 1 else { return }
+          callbackObservedSetterStack.withLock {
+            $0 = Thread.current.threadDictionary[setterStackMarker] != nil
+          }
+          rerunFinished.signal()
+        },
+        isolation: nil
+      )
+    }
+    defer { cancellable.cancel() }
+
+    func setNodeFromMarkedStack() {
+      Thread.current.threadDictionary[setterStackMarker] = true
+      defer { Thread.current.threadDictionary.removeObject(forKey: setterStackMarker) }
+      node.wrappedValue = 1
+    }
+
+    setNodeFromMarkedStack()
+    #expect(await rerunFinished.wait(for: .seconds(5)))
+    #expect(callbackObservedSetterStack.withLock { $0 } == false)
+  }
+
+  @Test
   func basicConditionalTracking() async throws {
     let node1 = Stored(wrappedValue: 5)  // condition node
     let node2 = Stored(wrappedValue: 10)  // conditional node
@@ -692,8 +724,8 @@ struct ContinuousTrackingTests {
 
 }
 
-// These tests intentionally suspend a synchronous tracking handler. Running both at once can
-// occupy every cooperative-executor worker on small CI machines before either test can resume it.
+// These tests intentionally suspend a tracking handler. Running them concurrently can
+// exhaust the execution contexts needed by another test to resume its handler on small CI machines.
 @Suite(.serialized)
 struct IssuesTrackingOnHeavyOperation {
 
@@ -705,54 +737,80 @@ struct IssuesTrackingOnHeavyOperation {
   }
 
   @Test
-  func groupKeepsTrackingAfterCoalescedRerun() async throws {
+  func concurrentGroupKeepsTrackingAcrossSerializedRerun() async {
     let value = Stored(wrappedValue: 0)
-    let secondInvocationStarted = TestSignal()
-    let thirdInvocationReadValue = TestSignal()
-    let fourthInvocationReadValue = TestSignal()
+    let secondInvocationStarted = DispatchSemaphore(value: 0)
+    let thirdInvocationReadValue = DispatchSemaphore(value: 0)
+    let fourthInvocationReadValue = DispatchSemaphore(value: 0)
     let resumeSecondInvocation = DispatchSemaphore(value: 0)
+    let coordinatorFinished = TestSignal()
+    let scenarioResult = OSAllocatedUnfairLock(
+      initialState: (
+        secondInvocationStarted: false,
+        thirdInvocationReadValue: false,
+        fourthInvocationReadValue: false
+      )
+    )
 
     let cancellable = withGraphTracking {
-      withGraphTrackingGroup {
-        switch value.wrappedValue {
-        case 1:
-          secondInvocationStarted.signal()
-          resumeSecondInvocation.wait()
-        case 2:
-          thirdInvocationReadValue.signal()
-        case 3:
-          fourthInvocationReadValue.signal()
-        default:
-          break
-        }
-      }
+      withGraphTrackingGroup(
+        {
+          switch value.wrappedValue {
+          case 1:
+            secondInvocationStarted.signal()
+            resumeSecondInvocation.wait()
+          case 2:
+            thirdInvocationReadValue.signal()
+          case 3:
+            fourthInvocationReadValue.signal()
+          default:
+            break
+          }
+        },
+        isolation: nil
+      )
     }
     defer {
       resumeSecondInvocation.signal()
       cancellable.cancel()
     }
 
-    // Keep the second group invocation busy.
-    value.wrappedValue = 1
-    let secondStarted = await secondInvocationStarted.wait(for: .seconds(5))
-    #expect(secondStarted)
-    guard secondStarted else { return }
+    // Keep every write on one nonisolated synchronous producer. The coordinator uses a Dispatch
+    // queue so it can release the blocked handler even when Swift's cooperative pool has one worker.
+    DispatchQueue.global().async {
+      defer {
+        resumeSecondInvocation.signal()
+        coordinatorFinished.signal()
+      }
 
-    // Request another group invocation while the second invocation is still running.
-    value.wrappedValue = 2
+      value.wrappedValue = 1
+      let secondStarted =
+        secondInvocationStarted.wait(timeout: .now() + .seconds(5)) == .success
+      scenarioResult.withLock { $0.secondInvocationStarted = secondStarted }
+      guard secondStarted else { return }
 
-    // The public API intentionally hides its internal tracking pass. Keep the second
-    // invocation blocked while the value-2 notification enqueues its coalesced rerun.
-    try await Task.sleep(for: .milliseconds(250))
-    resumeSecondInvocation.signal()
+      // Invalidate the pass registration while its handler is still active, then let the enqueued
+      // rerun continue. No timing delay is needed: the setter has already requested the callback.
+      value.wrappedValue = 2
+      resumeSecondInvocation.signal()
 
-    let didReadValueInThirdInvocation = await thirdInvocationReadValue.wait(for: .seconds(5))
-    #expect(didReadValueInThirdInvocation)
-    guard didReadValueInThirdInvocation else { return }
+      let didReadValueInThirdInvocation =
+        thirdInvocationReadValue.wait(timeout: .now() + .seconds(5)) == .success
+      scenarioResult.withLock { $0.thirdInvocationReadValue = didReadValueInThirdInvocation }
+      guard didReadValueInThirdInvocation else { return }
 
-    // The coalesced invocation must reestablish tracking for this later update.
-    value.wrappedValue = 3
-    #expect(await fourthInvocationReadValue.wait(for: .seconds(5)))
+      // The rerun must install a fresh registration for this later update.
+      value.wrappedValue = 3
+      let didReadValueInFourthInvocation =
+        fourthInvocationReadValue.wait(timeout: .now() + .seconds(5)) == .success
+      scenarioResult.withLock { $0.fourthInvocationReadValue = didReadValueInFourthInvocation }
+    }
+
+    #expect(await coordinatorFinished.wait(for: .seconds(20)))
+    let result = scenarioResult.withLock { $0 }
+    #expect(result.secondInvocationStarted)
+    #expect(result.thirdInvocationReadValue)
+    #expect(result.fourthInvocationReadValue)
   }
 
   @Test

--- a/Tests/StateGraphTests/GraphTrackingGroupTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingGroupTests.swift
@@ -705,6 +705,57 @@ struct IssuesTrackingOnHeavyOperation {
   }
 
   @Test
+  func groupKeepsTrackingAfterCoalescedRerun() async throws {
+    let value = Stored(wrappedValue: 0)
+    let secondInvocationStarted = TestSignal()
+    let thirdInvocationReadValue = TestSignal()
+    let fourthInvocationReadValue = TestSignal()
+    let resumeSecondInvocation = DispatchSemaphore(value: 0)
+
+    let cancellable = withGraphTracking {
+      withGraphTrackingGroup {
+        switch value.wrappedValue {
+        case 1:
+          secondInvocationStarted.signal()
+          resumeSecondInvocation.wait()
+        case 2:
+          thirdInvocationReadValue.signal()
+        case 3:
+          fourthInvocationReadValue.signal()
+        default:
+          break
+        }
+      }
+    }
+    defer {
+      resumeSecondInvocation.signal()
+      cancellable.cancel()
+    }
+
+    // Keep the second group invocation busy.
+    value.wrappedValue = 1
+    let secondStarted = await secondInvocationStarted.wait(for: .seconds(5))
+    #expect(secondStarted)
+    guard secondStarted else { return }
+
+    // Request another group invocation while the second invocation is still running.
+    value.wrappedValue = 2
+
+    // The public API intentionally hides its internal tracking pass. Keep the second
+    // invocation blocked while the value-2 notification enqueues its coalesced rerun.
+    try await Task.sleep(for: .milliseconds(250))
+    resumeSecondInvocation.signal()
+
+    let didReadValueInThirdInvocation = await thirdInvocationReadValue.wait(for: .seconds(5))
+    #expect(didReadValueInThirdInvocation)
+    guard didReadValueInThirdInvocation else { return }
+
+    // The coalesced invocation must reestablish tracking for this later update.
+    value.wrappedValue = 3
+    #expect(await fourthInvocationReadValue.wait(for: .seconds(5)))
+  }
+
+  @Test
   func stuck() async {
 
     let model = Model()


### PR DESCRIPTION
## Summary

- move tracking invalidation callback scheduling outside the registration state lock
- preserve asynchronous delivery for both actor-isolated and nonisolated subscriptions
- store the callback and captured actor separately so the non-Sendable handler stays unchanged without an `@isolated(any)` function conversion
- document the one-shot `TrackingRegistration` lifecycle
- cover nonisolated enqueue behavior and serialized reruns with public API regression tests

## Behavior

This is intended to preserve the existing delivery contract:

- a registration invalidates only once
- callbacks are enqueued in a `Task`
- an actor-isolated subscription returns to its captured actor
- `isolation: nil` runs on an unspecified executor
- a waiting tracking pass resumes with the fresh registration created for that pass

The `@unchecked Sendable` boundary remains internal and explicit. It does not claim that captured non-Sendable state is thread-safe.

## Why

Previously, `TrackingRegistration.perform()` created the callback task while holding the registration state lock. The stored callback also encoded actor isolation in its function type.

The new wrapper keeps the same runtime delivery semantics while limiting the lock to the one-shot state transition and callback extraction. Task scheduling happens after the lock is released, and actor isolation is carried separately from the callback.

## Out of scope

This does not change handler serialization or the self-cancellation limitation restored by #121. That behavior will be addressed separately.

## Validation

- Xcode 26.6 / Swift 6.3.3
- `swift test`: 17 XCTest tests and 142 Swift Testing tests passed
- `LIBDISPATCH_COOPERATIVE_POOL_STRICT=1 swift test --skip-build`: the same 17 + 142 tests passed
- clean scratch strict-concurrency build passed
- existing `GraphTracking.swift` isolation-conversion warnings remain; this change adds no warning in `withTracking.swift`
- symbol graph generation and DocC conversion passed; only pre-existing catalog warnings remain
- `git diff --check`
