### PR TITLE
Publish EntityStore updates after coordinator unlock

### DIFF
--- a/Sources/StateGraphNormalization/StateGraphNormalization.swift
+++ b/Sources/StateGraphNormalization/StateGraphNormalization.swift
@@ -4,16 +4,190 @@
 import Foundation
 import TypedIdentifier
 
-/// Serializes access across a related set of entity stores.
+/// Serializes access and graph publication across a related set of entity stores.
 ///
 /// Give every ``EntityStore`` in one database the same coordinator to protect
 /// canonical entity lookup and mutation across tables. The lock is recursive
 /// because an entity import may synchronously access another coordinated store.
-public final class EntityStoreCoordinator: Sendable {
+///
+/// Graph updates are queued while coordinated access is active, then published
+/// synchronously after the outermost access releases the database lock.
+public final class EntityStoreCoordinator: @unchecked Sendable {
 
-  fileprivate let lock = NSRecursiveLock()
+  private struct PublicationBatch: Sendable {
+    let id: UInt64
+    let publications: [@Sendable () -> Void]
+  }
+
+  private struct PublicationTicket {
+    let id: UInt64
+    let shouldDrain: Bool
+  }
+
+  private let accessLock = NSRecursiveLock()
+  private let publicationCondition = NSCondition()
+  private let drainingContextKey =
+    "org.vergegroup.state-graph.entity-store-publication.\(UUID().uuidString)"
+
+  private var accessDepth = 0
+  private var currentPublications: [@Sendable () -> Void] = []
+
+  private var nextBatchID: UInt64 = 0
+  private var completedThroughBatchID: UInt64 = 0
+  private var completedOutOfOrderBatchIDs: Set<UInt64> = []
+  private var isDraining = false
+  private var pendingBatches: [PublicationBatch] = []
 
   public init() {}
+
+  @discardableResult
+  fileprivate func withAccess<Result, Failure: Error>(
+    _ body: () throws(Failure) -> Result
+  ) throws(Failure) -> Result {
+    accessLock.lock()
+    accessDepth += 1
+
+    defer {
+      let ticket = endAccess()
+      finish(ticket)
+    }
+
+    return try body()
+  }
+
+  /// Adds a graph update to the current coordinated access.
+  ///
+  /// This method must be called from inside ``withAccess(_:)``.
+  fileprivate func enqueuePublication(
+    _ publication: @escaping @Sendable () -> Void
+  ) {
+    precondition(accessDepth > 0)
+    currentPublications.append(publication)
+  }
+
+  /// Ends one recursive access level and enqueues the complete outermost batch.
+  private func endAccess() -> PublicationTicket? {
+    accessDepth -= 1
+
+    let ticket: PublicationTicket?
+    if accessDepth == 0, !currentPublications.isEmpty {
+      let publications = currentPublications
+      currentPublications = []
+      ticket = enqueue(publications)
+    } else {
+      ticket = nil
+    }
+
+    accessLock.unlock()
+    return ticket
+  }
+
+  /// Enqueues a publication batch while preserving database access order.
+  ///
+  /// This method must be called while `accessLock` is held.
+  private func enqueue(
+    _ publications: [@Sendable () -> Void]
+  ) -> PublicationTicket {
+    publicationCondition.lock()
+
+    nextBatchID &+= 1
+    let batch = PublicationBatch(
+      id: nextBatchID,
+      publications: publications
+    )
+    pendingBatches.append(batch)
+
+    let shouldDrain: Bool
+    if isDraining {
+      shouldDrain = false
+    } else {
+      isDraining = true
+      shouldDrain = true
+    }
+
+    publicationCondition.unlock()
+    return PublicationTicket(id: batch.id, shouldDrain: shouldDrain)
+  }
+
+  private func finish(_ ticket: PublicationTicket?) {
+    guard let ticket else { return }
+
+    if ticket.shouldDrain {
+      drainAsOwner()
+    } else if isDrainingOnCurrentThread {
+      // A graph callback may synchronously mutate another coordinated store.
+      // Drain through that mutation without waiting on the current drainer.
+      drainPublications(until: ticket.id)
+    } else {
+      publicationCondition.lock()
+      while !isCompleted(ticket.id) {
+        publicationCondition.wait()
+      }
+      publicationCondition.unlock()
+    }
+  }
+
+  private var isDrainingOnCurrentThread: Bool {
+    Thread.current.threadDictionary[drainingContextKey] as? Bool == true
+  }
+
+  private func drainAsOwner() {
+    let threadDictionary = Thread.current.threadDictionary
+    threadDictionary[drainingContextKey] = true
+    defer { threadDictionary.removeObject(forKey: drainingContextKey) }
+
+    drainPublications(until: nil)
+  }
+
+  private func drainPublications(until targetID: UInt64?) {
+    while true {
+      publicationCondition.lock()
+
+      guard !pendingBatches.isEmpty else {
+        if targetID == nil {
+          isDraining = false
+        }
+        publicationCondition.unlock()
+        return
+      }
+
+      let batch = pendingBatches.removeFirst()
+      publicationCondition.unlock()
+
+      for publication in batch.publications {
+        publication()
+      }
+
+      publicationCondition.lock()
+      markCompleted(batch.id)
+      publicationCondition.broadcast()
+      publicationCondition.unlock()
+
+      if batch.id == targetID {
+        return
+      }
+    }
+  }
+
+  /// Returns whether a publication batch finished, with the condition held.
+  private func isCompleted(_ id: UInt64) -> Bool {
+    id <= completedThroughBatchID || completedOutOfOrderBatchIDs.contains(id)
+  }
+
+  /// Records a completed batch while preserving a contiguous completion prefix.
+  ///
+  /// This method must be called while `publicationCondition` is held.
+  private func markCompleted(_ id: UInt64) {
+    guard id == completedThroughBatchID &+ 1 else {
+      completedOutOfOrderBatchIDs.insert(id)
+      return
+    }
+
+    completedThroughBatchID = id
+    while completedOutOfOrderBatchIDs.remove(completedThroughBatchID &+ 1) != nil {
+      completedThroughBatchID &+= 1
+    }
+  }
 }
 
 /// A uniquely owned canonical entity table.
@@ -229,9 +403,7 @@ public final class EntityStore<T: TypedIdentifiable & Sendable>: Sendable {
   private func withLock<Result, Failure: Error>(
     _ body: () throws(Failure) -> Result
   ) throws(Failure) -> Result {
-    coordinator.lock.lock()
-    defer { coordinator.lock.unlock() }
-    return try body()
+    try coordinator.withAccess(body)
   }
 
   @discardableResult
@@ -240,7 +412,12 @@ public final class EntityStore<T: TypedIdentifiable & Sendable>: Sendable {
   ) throws(Failure) -> Result {
     try withLock { () throws(Failure) -> Result in
       let result = try body()
-      publishMutation()
+      let revision = table.advanceRevision()
+
+      coordinator.enqueuePublication { [graphRevision] in
+        graphRevision.wrappedValue = revision
+      }
+
       return result
     }
   }
@@ -249,8 +426,4 @@ public final class EntityStore<T: TypedIdentifiable & Sendable>: Sendable {
     _ = graphRevision.wrappedValue
   }
 
-  private func publishMutation() {
-    let revision = table.advanceRevision()
-    graphRevision.wrappedValue = revision
-  }
 }

--- a/Tests/StateGraphNormalizationTests/NormalizationTests.swift
+++ b/Tests/StateGraphNormalizationTests/NormalizationTests.swift
@@ -478,6 +478,87 @@ struct NormalizationTests {
     #expect(await workFinished.wait(for: .seconds(5)))
   }
 
+  @Test func nestedMutationPublishesAfterOutermostCoordinatorUnlocks() async {
+    let coordinator = EntityStoreCoordinator()
+    let outerStore = EntityStore<ValueEntity>(
+      entities: [.init(1): .init(id: 1, value: 1)],
+      coordinator: coordinator
+    )
+    let nestedStore = EntityStore<ValueEntity>(
+      entities: [.init(1): .init(id: 1, value: 1)],
+      coordinator: coordinator
+    )
+    let pauseNextUpstreamComputation = OSAllocatedUnfairLock(initialState: false)
+    let upstreamComputationEntered = TestSignal()
+    let allowUpstreamComputation = DispatchSemaphore(value: 0)
+    let mutationEntered = TestSignal()
+    let allowMutationToPublish = DispatchSemaphore(value: 0)
+    let computationFinished = TestSignal()
+    let mutationFinished = TestSignal()
+    let upstreamTrigger = Stored(wrappedValue: 0)
+
+    let upstreamValue = Computed { _ in
+      let value = upstreamTrigger.wrappedValue
+      let shouldPause = pauseNextUpstreamComputation.withLock { shouldPause in
+        defer { shouldPause = false }
+        return shouldPause
+      }
+      if shouldPause {
+        upstreamComputationEntered.signal()
+        _ = allowUpstreamComputation.wait(timeout: .now() + .seconds(5))
+      }
+      return value
+    }
+
+    let computedValue = Computed { _ in
+      _ = upstreamValue.wrappedValue
+      return nestedStore.get(by: .init(1))?.value
+    }
+
+    #expect(computedValue.wrappedValue == 1)
+    pauseNextUpstreamComputation.withLock { $0 = true }
+    upstreamTrigger.wrappedValue = 1
+
+    DispatchQueue.global().async {
+      _ = computedValue.wrappedValue
+      computationFinished.signal()
+    }
+
+    #expect(await upstreamComputationEntered.wait(for: .seconds(5)))
+
+    DispatchQueue.global().async {
+      outerStore.updateOrCreate(
+        id: .init(1),
+        update: { entity in
+          entity.value = 2
+          nestedStore.updateOrCreate(
+            id: .init(1),
+            update: { nestedEntity in
+              nestedEntity.value = 2
+              mutationEntered.signal()
+              _ = allowMutationToPublish.wait(timeout: .now() + .seconds(5))
+            },
+            create: { .init(id: 1, value: 2) }
+          )
+        },
+        create: { .init(id: 1, value: 2) }
+      )
+      mutationFinished.signal()
+    }
+
+    #expect(await mutationEntered.wait(for: .seconds(5)))
+    allowMutationToPublish.signal()
+
+    // Publication waits for the Computed lock, but the Computed must still be able
+    // to acquire the coordinator. Publishing under the outer lock deadlocks here.
+    #expect(await mutationFinished.wait(for: .milliseconds(100)) == false)
+    allowUpstreamComputation.signal()
+
+    #expect(await computationFinished.wait(for: .seconds(5)))
+    #expect(await mutationFinished.wait(for: .seconds(5)))
+    #expect(computedValue.wrappedValue == 2)
+  }
+
   @Test func getAllReturnsIndependentSnapshot() {
     let store = EntityStore<ValueEntity>()
     store.add(.init(id: 1, value: 1))


### PR DESCRIPTION
## Summary

- queue EntityStore graph publications in EntityStoreCoordinator
- release the outermost database lock before invalidating graph dependents
- preserve synchronous, access-ordered publication across concurrent and reentrant mutations
- add a regression for nested coordinated mutation racing a Computed read

## Problem

EntityStore 0.27.0 publishes its graph revision while EntityStoreCoordinator is still locked. A Computed can hold its node lock while waiting to read the store, while mutation publication holds the coordinator and waits to invalidate that Computed. Nested mutation is especially important because releasing one recursive lock level still leaves the outer access locked.

## Design

The coordinator collects successful mutation publications into the current recursive access batch. The outermost access enqueues that batch, unlocks the database, and synchronously drains publications in access order. Reentrant graph callbacks drain through their own batch on the current publication thread rather than waiting on themselves.

This PR does not add transaction or rollback behavior.

## Validation

- `swift test --no-parallel`: 143 tests in 32 suites passed
- focused nested lock-order regression passed
- focused concurrency selection passed 20 consecutive stress runs
- standard Codex review with GPT-5.6 Sol / Extra High: no remaining findings
- `git diff --check` passed