### PR TITLE
withGraphTransaction

### DIFF
--- a/Documentation/Design-Notes/Stored-Mutation.md
+++ b/Documentation/Design-Notes/Stored-Mutation.md
@@ -88,9 +88,12 @@ all of the following:
 
 Keep mutable application state, including value-semantic `EntityStore`
 instances, in `Stored` or `@GraphStored`. Prefer an operation that performs a
-whole batch in one method call when possible. Applications that permit
-concurrent mutation of the same property must currently serialize the complete
-read-modify-write operation at the owning actor or queue.
+whole batch in one method call when possible. When multiple threads can mutate
+the same property, wrap the complete synchronous read-modify-write operation in
+`withGraphTransaction`, or serialize it at the owning actor or queue. A graph
+transaction prevents competing writers from losing updates, but it still uses
+the current getter/writeback materialization and therefore does not solve the
+copy optimization described above.
 
 This issue concerns in-memory `Stored` mutation. It does not require
 `EntityStore` to have reference semantics, and it is not a database transaction

--- a/Sources/StateGraph/Documentation.docc/Core-Concepts.md
+++ b/Sources/StateGraph/Documentation.docc/Core-Concepts.md
@@ -87,7 +87,7 @@ store injection, suites, and custom value types.
 ### Graph Transactions
 
 Use `withGraphTransaction` when a synchronous operation must publish several
-`Stored` assignments as one graph update:
+`Stored` assignments without exposing a partial commit:
 
 ```swift
 withGraphTransaction {
@@ -110,6 +110,9 @@ StateGraph tracking and `onDidSet(_:)` callbacks run. Other writers wait until
 that work finishes, and readers briefly wait during publication so a computed
 value cannot observe a partial commit.
 
+Transactions do not coalesce per-node callbacks. Each `Stored` value uses its
+existing comparator and notification pipeline at commit.
+
 The API is synchronous and thread-local; it does not cross `await`, task
 creation, or executor hops. Nested calls join the outer transaction rather than
 creating savepoints. An inner error that the outer body catches leaves its staged
@@ -129,16 +132,17 @@ delivery hops to MainActor: that handler reads the coherent committed snapshot
 current when it runs rather than transaction-local staged storage.
 
 Rollback cannot undo side effects outside ordinary `Stored` assignment. For
-example, mutating a property on a class retrieved from `Stored<SomeClass>`
-changes that object immediately and is not reversible by the transaction.
-`Stored.unsafeModify(_:)` also changes committed storage directly and bypasses
-transaction staging and notifications.
+example, mutating a property through reference storage reachable from a
+`Stored` value changes that object immediately and is not reversible by the
+transaction. This includes a class stored directly or as an entity in a
+value-semantic collection. `Stored.unsafeModify(_:)` also changes committed
+storage directly and bypasses transaction staging and notifications.
 
-Do not mutate `GraphUserDefault`, `EntityStore`, databases, or other externally
-committed sources inside `withGraphTransaction`. Their persistence, locking,
+Do not mutate `GraphUserDefault`, databases, or other externally committed
+sources inside `withGraphTransaction`. Their persistence, locking,
 notification, and rollback semantics are outside this Stored-level API.
-Likewise, accessing an externally locked store from the body while another thread
-mutates it is outside the transaction's lock-order guarantees.
+Likewise, accessing an externally locked store from the body while another
+thread mutates it is outside the transaction's lock-order guarantees.
 
 Keep committed `Computed` descriptors free of graph mutations. Descriptors own
 their node's evaluation lock, so beginning a transaction, or blocking on one

--- a/Sources/StateGraph/Documentation.docc/Core-Concepts.md
+++ b/Sources/StateGraph/Documentation.docc/Core-Concepts.md
@@ -106,12 +106,20 @@ Observation nodes after current readers finish, then invokes the existing `willS
 delivery path before publication. A synchronously delivered handler on the
 committing thread reads the complete staged snapshot while other threads still
 read the old committed graph. All final values are then installed before
-StateGraph tracking and `onDidSet(_:)` callbacks run. Other writers wait until
-that work finishes, and readers briefly wait during publication so a computed
-value cannot observe a partial commit.
+StateGraph tracking invalidation and Observation's `didSet` delivery. Other
+writers wait until that work finishes, and readers briefly wait during
+publication so a computed value cannot observe a partial commit.
 
-Transactions do not coalesce per-node callbacks. Each `Stored` value uses its
-existing comparator and notification pipeline at commit.
+`Stored.onDidSet(_:)` and `@GraphStored` property observers remain assignment
+observers. They run synchronously for every staged assignment, including repeated
+or comparator-equivalent assignments. `willSet` reads the preceding staged
+snapshot; `didSet` and `Stored.onDidSet(_:)` read the newly staged value. Ordinary
+`Stored` assignments made by any of these observers join the same transaction. A
+rollback discards those assignments but cannot undo other side effects already
+performed by the observer.
+
+Each `Stored` value uses its existing comparator and graph notification pipeline
+once at commit, comparing the committed old value with the final staged value.
 
 The API is synchronous and thread-local; it does not cross `await`, task
 creation, or executor hops. Nested calls join the outer transaction rather than
@@ -120,16 +128,17 @@ assignments in place; only an error that escapes the outermost call rolls all
 staged `Stored` assignments back.
 
 Transaction-time `Computed` reads are evaluated from the staged `Stored` values
-without updating the committed cache or dependency edges. Callback mutations
-join a following commit batch: they are immediately readable by later callbacks
-on the committing thread, and every resulting batch is published before the
-outer call returns. Synchronous callbacks run while other threads' graph writes
-remain suspended. They may mutate `Stored` values reentrantly, but neither a
-comparator nor a callback may wait synchronously for another thread to finish a
-graph write. Callbacks that existing tracking APIs schedule asynchronously do not
-inherit the thread-local transaction. The same applies when existing Observation
-delivery hops to MainActor: that handler reads the coherent committed snapshot
-current when it runs rather than transaction-local staged storage.
+without updating the committed cache or dependency edges. A mutation made by a
+synchronously delivered Observation handler during commit joins a following
+commit batch: it is immediately readable by later synchronous handlers on the
+committing thread, and every resulting batch is published before the outer call
+returns. These handlers run while other threads' graph writes remain suspended,
+but neither a comparator nor a handler may wait synchronously for another thread
+to finish a graph write. Handlers that existing tracking APIs schedule
+asynchronously do not inherit the thread-local transaction. The same applies when
+existing Observation delivery hops to MainActor: that handler reads the coherent
+committed snapshot current when it runs rather than transaction-local staged
+storage.
 
 Rollback cannot undo side effects outside ordinary `Stored` assignment. For
 example, mutating a property through reference storage reachable from a

--- a/Sources/StateGraph/Documentation.docc/Core-Concepts.md
+++ b/Sources/StateGraph/Documentation.docc/Core-Concepts.md
@@ -84,6 +84,75 @@ store injection, suites, and custom value types.
 - **Change Propagation**: When their value changes, all dependent nodes are notified
 - **Observable**: They integrate with SwiftUI and other observation systems
 
+### Graph Transactions
+
+Use `withGraphTransaction` when a synchronous operation must publish several
+`Stored` assignments as one graph update:
+
+```swift
+withGraphTransaction {
+  profile.$name.wrappedValue = "Taylor"
+  profile.$age.wrappedValue = 30
+
+  // Reads in this scope see both staged assignments.
+  print(profile.$name.wrappedValue)
+}
+```
+
+The outermost call stages assignments in each `Stored` node. Its body reads the
+latest staged value, while other threads continue to read the previously
+committed graph. When the body returns normally, StateGraph snapshots affected
+Observation nodes after current readers finish, then invokes the existing `willSet`
+delivery path before publication. A synchronously delivered handler on the
+committing thread reads the complete staged snapshot while other threads still
+read the old committed graph. All final values are then installed before
+StateGraph tracking and `onDidSet(_:)` callbacks run. Other writers wait until
+that work finishes, and readers briefly wait during publication so a computed
+value cannot observe a partial commit.
+
+The API is synchronous and thread-local; it does not cross `await`, task
+creation, or executor hops. Nested calls join the outer transaction rather than
+creating savepoints. An inner error that the outer body catches leaves its staged
+assignments in place; only an error that escapes the outermost call rolls all
+staged `Stored` assignments back.
+
+Transaction-time `Computed` reads are evaluated from the staged `Stored` values
+without updating the committed cache or dependency edges. Callback mutations
+join a following commit batch: they are immediately readable by later callbacks
+on the committing thread, and every resulting batch is published before the
+outer call returns. Synchronous callbacks run while other threads' graph writes
+remain suspended. They may mutate `Stored` values reentrantly, but neither a
+comparator nor a callback may wait synchronously for another thread to finish a
+graph write. Callbacks that existing tracking APIs schedule asynchronously do not
+inherit the thread-local transaction. The same applies when existing Observation
+delivery hops to MainActor: that handler reads the coherent committed snapshot
+current when it runs rather than transaction-local staged storage.
+
+Rollback cannot undo side effects outside ordinary `Stored` assignment. For
+example, mutating a property on a class retrieved from `Stored<SomeClass>`
+changes that object immediately and is not reversible by the transaction.
+`Stored.unsafeModify(_:)` also changes committed storage directly and bypasses
+transaction staging and notifications.
+
+Do not mutate `GraphUserDefault`, `EntityStore`, databases, or other externally
+committed sources inside `withGraphTransaction`. Their persistence, locking,
+notification, and rollback semantics are outside this Stored-level API.
+Likewise, accessing an externally locked store from the body while another thread
+mutates it is outside the transaction's lock-order guarantees.
+
+Keep committed `Computed` descriptors free of graph mutations. Descriptors own
+their node's evaluation lock, so beginning a transaction, or blocking on one
+through a `Stored` assignment, conflicts with writer lock ordering. StateGraph
+fails fast in those cases instead of deadlocking; initiate mutations from the
+descriptor's caller.
+
+An ordinary immediate assignment evaluates its `Stored` comparator and
+synchronously delivered Observation `willSet` handlers while a node lock is held.
+Do not begin a transaction there or from `Stored.unsafeModify(_:)`; start it from
+`onDidSet(_:)` or another post-mutation callback instead. Transaction commit
+evaluates comparators and delivers its Observation callbacks outside node locks,
+but comparators should remain free of mutation side effects.
+
 ## Computed Value Nodes
 
 Computed nodes derive their values from other nodes and automatically update when their dependencies change. They represent the "derived state" in your application.

--- a/Sources/StateGraph/Documentation.docc/Documentation.md
+++ b/Sources/StateGraph/Documentation.docc/Documentation.md
@@ -56,6 +56,7 @@ final class CounterViewModel {
 - ``Node``
 - ``GraphStored``
 - ``GraphComputed``
+- ``withGraphTransaction(_:_:_:_:)``
 
 ### Persistence and Storage
 

--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -158,9 +158,9 @@ private func commitTransactionBatches(
       // Phase 1 captures Observation's pre-mutation traversal without publishing a
       // Stored value or invoking user callbacks. The short barrier prevents a
       // committed reader from crossing the snapshot boundary while work is collected.
-      let observationDelivery = GraphTransactionObservationDelivery()
+      let observationWillSetDelivery = GraphTransactionObservationWillSetDelivery()
       coordinator.withPublicationBarrier(transaction) {
-        batch.prepareObservationWillSet(observationDelivery)
+        batch.prepareObservationWillSet(observationWillSetDelivery)
       }
 
       // Observation delivery is outside the condition mutex, reader barrier, and
@@ -169,7 +169,7 @@ private func commitTransactionBatches(
       // callbacks. The committing thread sees pending values while outside readers
       // still see old committed values.
       nextBatch.beginCallbackDelivery()
-      observationDelivery.deliver()
+      observationWillSetDelivery.deliverWillSet()
 
       // Phase 2 installs all values and propagates dirty state before committed
       // readers resume, preventing a reader from observing a partial batch. It only
@@ -207,7 +207,7 @@ protocol GraphTransactionParticipant: AnyObject {
 
   /// Captures Observation's pre-mutation notifications without invoking callbacks.
   func prepareTransactionObservationWillSet(
-    _ observationDelivery: GraphTransactionObservationDelivery
+    _ observationWillSetDelivery: GraphTransactionObservationWillSetDelivery
   )
 
   /// Replaces the committed value without running callbacks.
@@ -271,10 +271,10 @@ final class GraphTransactionContext {
   }
 
   func prepareObservationWillSet(
-    _ observationDelivery: GraphTransactionObservationDelivery
+    _ observationWillSetDelivery: GraphTransactionObservationWillSetDelivery
   ) {
     for participant in frozenParticipants {
-      participant.prepareTransactionObservationWillSet(observationDelivery)
+      participant.prepareTransactionObservationWillSet(observationWillSetDelivery)
     }
   }
 
@@ -344,7 +344,7 @@ final class GraphTransactionContext {
 /// rather than exposing a clean cache after its sources have committed.
 protocol GraphTransactionInvalidatableNode: AnyObject {
   func prepareGraphTransactionObservationWillSet(
-    _ observationDelivery: GraphTransactionObservationDelivery
+    _ observationWillSetDelivery: GraphTransactionObservationWillSetDelivery
   )
 
   func prepareGraphTransactionInvalidation(
@@ -352,23 +352,49 @@ protocol GraphTransactionInvalidatableNode: AnyObject {
   )
 }
 
-/// Freezes Observation's `willSet` work from the committed dependency graph.
+/// Collects Observation `willSet` work for one transaction commit batch.
 ///
-/// The transaction briefly drains committed readers while this object traverses the
-/// graph, then releases that barrier before invoking the captured callbacks. A
-/// synchronously delivered callback can therefore read the complete staged snapshot
-/// without blocking another thread from reading the old committed graph. Nodes
-/// registered afterwards follow the same concurrent-access boundary as a
-/// registration racing an ordinary setter after its `willSet` call.
-final class GraphTransactionObservationDelivery {
+/// Observation requires a pre-mutation notification, but running arbitrary user
+/// callbacks while the publication barrier is active could block graph progress or
+/// deadlock with work performed by those callbacks. This object separates those
+/// responsibilities:
+///
+/// 1. While committed readers are briefly drained, it traverses the committed
+///    dependency graph and queues one `willSet` notification operation for each
+///    reachable node in that snapshot.
+/// 2. After the barrier and all node locks have been released, it invokes the queued
+///    operations. Transaction-local reads on the committing thread then see the
+///    complete pending snapshot, while outside readers still see the old committed
+///    snapshot.
+///
+/// The collector does not carry transaction values, publish values, or mark nodes
+/// dirty. ``GraphTransactionCallbackDelivery`` separately owns the callbacks that
+/// run after value publication and graph invalidation.
+final class GraphTransactionObservationWillSetDelivery {
 
-  private var deliveredNodes: Set<ObjectIdentifier> = []
-  private var callbacks: [() -> Void] = []
+  /// Nodes already visited during the pre-publication dependency traversal.
+  ///
+  /// Multiple changed sources can reach the same computed node. Identity
+  /// de-duplication gives that node one `willSet` preparation for this commit batch.
+  private var visitedNodes: Set<ObjectIdentifier> = []
 
-  func append(_ callback: @escaping () -> Void) {
-    callbacks.append(callback)
+  /// Deferred registrar operations, kept inert until the publication barrier ends.
+  ///
+  /// These are not a snapshot of Observation's registered callbacks. The registrar
+  /// determines its delivery when each operation invokes `willSet`.
+  private var willSetOperations: [() -> Void] = []
+
+  /// Queues one registrar `willSet` operation without invoking user code.
+  func appendWillSetOperation(_ operation: @escaping () -> Void) {
+    willSetOperations.append(operation)
   }
 
+  /// Continues pre-publication traversal through an outgoing dependency edge.
+  ///
+  /// A diamond-shaped graph can encounter the same target more than once, so each
+  /// target is prepared only on its first visit. Preparation may append its own
+  /// Observation notification operation and recursively visit its outgoing edges;
+  /// it must not dirty the target or invoke user code.
   func prepareWillSet(for edge: Edge) {
     guard let target = edge.to else { return }
     guard let node = target as? any GraphTransactionInvalidatableNode else {
@@ -378,15 +404,16 @@ final class GraphTransactionObservationDelivery {
     }
 
     let identifier = ObjectIdentifier(node)
-    guard deliveredNodes.insert(identifier).inserted else { return }
+    guard visitedNodes.insert(identifier).inserted else { return }
     node.prepareGraphTransactionObservationWillSet(self)
   }
 
-  func deliver() {
-    for callback in callbacks {
-      callback()
+  /// Invokes the queued `willSet` operations after leaving the publication barrier.
+  func deliverWillSet() {
+    for operation in willSetOperations {
+      operation()
     }
-    callbacks.removeAll()
+    willSetOperations.removeAll()
   }
 }
 

--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -10,12 +10,19 @@ import Foundation
 /// publication. A synchronously delivered handler on the committing thread can
 /// read the complete staged snapshot while other threads still read the old
 /// committed graph. The staged values are then committed together before
-/// graph-tracking and `onDidSet(_:)` callbacks are delivered.
+/// graph-tracking invalidation and Observation's `didSet` delivery.
 ///
-/// A callback mutation joins a following commit batch owned by the same outer
-/// transaction. Its staged value is immediately readable by later callbacks on the
-/// committing thread, and the batch is published before this function returns.
-/// Every batch uses each `Stored` node's ordinary comparator and callback pipeline.
+/// ``Stored/onDidSet(_:)`` and `@GraphStored` property observers retain ordinary
+/// assignment semantics: they run synchronously for every staged assignment.
+/// `Stored` assignments made by those observers join the same transaction and are
+/// discarded if the outer body throws. The observers themselves are not deferred,
+/// so rollback cannot undo their non-`Stored` side effects.
+///
+/// A mutation made by a synchronously delivered Observation handler during commit
+/// joins a following batch owned by the same outer transaction. Its staged value is
+/// immediately readable by later synchronous handlers on the committing thread, and
+/// the batch is published before this function returns. Every batch uses each
+/// `Stored` node's ordinary comparator and graph notification pipeline.
 ///
 /// Nested calls join the active transaction. They do not create a savepoint or an
 /// independent commit or rollback boundary: if an inner error is caught by `body`,
@@ -29,7 +36,7 @@ import Foundation
 /// short commit phase, reads wait so they cannot observe a partially committed set
 /// of nodes.
 ///
-/// `Computed` values read by the transaction or its synchronous callbacks are
+/// `Computed` values read by the transaction or its synchronous observers are
 /// evaluated from staged values without updating the committed cache or dependency
 /// graph. The next ordinary read continues to use the committed graph.
 ///
@@ -42,10 +49,10 @@ import Foundation
 /// - Important: ``Stored/unsafeModify(_:)`` deliberately bypasses assignment,
 ///   invalidation, and transaction staging. A mutation made through it is not
 ///   rolled back.
-/// - Important: Synchronous callbacks run before the outer call returns and while
+/// - Important: Synchronous observers run before the outer call returns and while
 ///   writes from other threads remain suspended. Reentrant `Stored` assignments are
-///   supported, but a comparator or callback must not synchronously wait for another
-///   thread to complete a graph write. Callbacks that existing APIs schedule
+///   supported, but a comparator or observer must not synchronously wait for another
+///   thread to complete a graph write. Handlers that existing APIs schedule
 ///   asynchronously do not inherit the thread-local transaction.
 ///   This includes Observation delivery that uses StateGraph's existing MainActor
 ///   hop: after a hop, the handler reads the coherent committed snapshot current
@@ -67,8 +74,8 @@ import Foundation
 ///   - column: The source column that starts the transaction.
 ///   - body: The synchronous work whose `Stored` assignments are staged.
 /// - Returns: The value returned by `body`. The outermost call returns after every
-///   staged callback batch commits. A nested call returns to the active outer body
-///   without committing.
+///   staged Observation-handler batch commits. A nested call returns to the active
+///   outer body without committing.
 /// - Throws: The error thrown by `body`. An error escaping the outermost call
 ///   discards every staged assignment before it is rethrown.
 @discardableResult
@@ -112,7 +119,7 @@ public func withGraphTransaction<Result, Failure: Error>(
 
   let result = try body()
 
-  // The body has finished staging. Callback delivery receives its own fresh
+  // The body has finished staging. Synchronous Observation delivery receives fresh
   // thread-local contexts inside the iterative commit trampoline below.
   ThreadLocal.graphTransaction.replaceValue(previousContext)
   commitTransactionBatches(
@@ -120,25 +127,25 @@ public func withGraphTransaction<Result, Failure: Error>(
     coordinator: coordinator
   )
 
-  // Callback-generated batches are now empty, so external writers may resume.
+  // Observation-generated batches are now empty, so external writers may resume.
   coordinator.finishTransaction(context)
   transactionFinished = true
 
   return result
 }
 
-/// Commits the body batch and any mutations synchronously staged by its callbacks.
+/// Commits the body batch and mutations staged by synchronous Observation delivery.
 ///
-/// Callback delivery is one hook boundary: a callback mutation is immediately
-/// readable on the committing thread, but its graph publication is deferred until
-/// every callback in the current batch has completed. The next batch is drained
-/// before the outer `withGraphTransaction` call returns.
+/// An Observation-handler mutation is immediately readable on the committing thread,
+/// but its graph publication is deferred until every synchronous handler in the
+/// current batch has completed. The next batch is drained before the outer
+/// `withGraphTransaction` call returns.
 ///
-/// The loop acts as a synchronous trampoline. Callbacks still run on the current
-/// stack, but their mutations never recursively enter the commit pipeline. They
-/// stage into a fresh context that the next loop iteration drains after the current
-/// callback wave returns. This prevents recursive stack growth; it does not make a
-/// callback that continuously stages new mutations terminate.
+/// The loop acts as a synchronous trampoline. Observation handlers still run on the
+/// current stack, but their mutations never recursively enter the commit pipeline.
+/// They stage into a fresh context that the next loop iteration drains after the
+/// current delivery wave returns. This prevents recursive stack growth; it does not
+/// make a handler that continuously stages new mutations terminate.
 private func commitTransactionBatches(
   beginningWith transaction: GraphTransactionContext,
   coordinator: GraphTransactionCoordinator
@@ -146,8 +153,8 @@ private func commitTransactionBatches(
   var batch = transaction
 
   while batch.freezeParticipantsForCommit() {
-    // Mutations made by this batch's callbacks collect here instead of recursively
-    // reentering commit. An empty context makes the next loop condition terminate.
+    // Mutations made by synchronous Observation handlers collect here instead of
+    // recursively reentering commit. An empty context terminates the next iteration.
     let nextBatch = GraphTransactionContext()
     ThreadLocal.graphTransaction.withValue(nextBatch) {
       // Move every participant's staged value into stable commit work before any
@@ -180,15 +187,15 @@ private func commitTransactionBatches(
         batch.prepareCommitInvalidations(callbackDelivery)
       }
 
-      // Graph-tracking, onDidSet, and Observation didSet callbacks run after
-      // publication releases its reader barrier. Any mutations they make also join
-      // `nextBatch`.
+      // Graph-tracking invalidation is handed off after publication; its user handler
+      // is task-enqueued and does not inherit this thread-local transaction.
+      // Observation `didSet` may still run synchronously and join `nextBatch`.
       callbackDelivery.deliver()
-      batch.deliverCommitCallbacks()
+      batch.deliverObservationDidSet()
     }
 
-    // Continue with callback-generated work iteratively instead of committing from
-    // inside callback delivery.
+    // Continue with Observation-generated work instead of recursively committing
+    // from inside handler delivery.
     batch = nextBatch
   }
 }
@@ -219,8 +226,8 @@ protocol GraphTransactionParticipant: AnyObject {
     _ callbackDelivery: GraphTransactionCallbackDelivery
   )
 
-  /// Delivers `Stored` callbacks after graph invalidation has completed.
-  func deliverTransactionCallbacks()
+  /// Delivers Observation's post-publication notification.
+  func deliverTransactionObservationDidSet()
 
   /// Detaches the staged value while the transaction still excludes other writers.
   func prepareTransactionRollback(_ transaction: GraphTransactionContext)
@@ -292,11 +299,11 @@ final class GraphTransactionContext {
     }
   }
 
-  func deliverCommitCallbacks() {
+  func deliverObservationDidSet() {
     defer { frozenParticipants.removeAll() }
 
     for participant in frozenParticipants {
-      participant.deliverTransactionCallbacks()
+      participant.deliverTransactionObservationDidSet()
     }
   }
 
@@ -339,7 +346,7 @@ final class GraphTransactionContext {
 ///
 /// The pre-publication traversal preserves Observation's `willSet` boundary. The
 /// publication traversal then makes every cache dirty before releasing the read
-/// barrier and queues graph-tracking callbacks for delivery afterwards. Every
+/// barrier and queues graph-tracking invalidation handoffs for afterwards. Every
 /// concrete dependency target must provide this split; publication fails closed
 /// rather than exposing a clean cache after its sources have committed.
 protocol GraphTransactionInvalidatableNode: AnyObject {
@@ -368,8 +375,8 @@ protocol GraphTransactionInvalidatableNode: AnyObject {
 ///    snapshot.
 ///
 /// The collector does not carry transaction values, publish values, or mark nodes
-/// dirty. ``GraphTransactionCallbackDelivery`` separately owns the callbacks that
-/// run after value publication and graph invalidation.
+/// dirty. ``GraphTransactionCallbackDelivery`` separately owns the graph-tracking
+/// invalidation work handed off after value publication.
 final class GraphTransactionObservationWillSetDelivery {
 
   /// Nodes already visited during the pre-publication dependency traversal.
@@ -417,12 +424,13 @@ final class GraphTransactionObservationWillSetDelivery {
   }
 }
 
-/// User callbacks captured while a transaction marks its dependency graph dirty.
+/// Graph-tracking invalidation work captured while a transaction marks nodes dirty.
 ///
 /// The publication barrier protects only value installation and dirty-state
-/// propagation. Delivering graph-tracking and custom-node callbacks after releasing
-/// that barrier avoids making a callback that waits for another thread's graph read
-/// deadlock the commit.
+/// propagation. Running each `TrackingRegistration` handoff after releasing that
+/// barrier avoids executing its synchronization and task scheduling while committed
+/// reads are blocked. The registration enqueues its user handler separately; that
+/// handler does not inherit the transaction's thread-local context.
 final class GraphTransactionCallbackDelivery {
 
   private var callbacks: [() -> Void] = []
@@ -544,7 +552,13 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
   /// Outermost committed read scopes that may currently hold node or Computed locks.
   private var activeReaderCount = 0
 
-  /// Whether new committed reads must wait for a coherent publication boundary.
+  /// Whether a transaction has closed admission to new committed reads.
+  ///
+  /// `Publishing` here means running a short commit phase that must not overlap a
+  /// committed read: either traversing the pre-mutation graph to collect Observation
+  /// `willSet` operations, or installing every staged `Stored` value and propagating
+  /// invalidations as one coherent committed graph. Existing readers drain before the
+  /// phase body starts; new readers wait until this flag becomes `false`.
   private var isPublishing = false
 
   // MARK: - Outer Transaction
@@ -694,6 +708,25 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     )
   }
 
+  /// Admits one ordinary `Stored` setter into the immediate-writer group.
+  ///
+  /// Admission does not acquire a node lock or serialize ordinary setters with one
+  /// another. It reserves one counted writer slot so an outer transaction cannot
+  /// begin until this setter finishes. Different admitted setters may continue
+  /// concurrently and rely on each `Stored` node's lock for node-local exclusion.
+  ///
+  /// If a transaction is active or already waiting, this method sleeps on
+  /// `condition` until the transactions ahead of this setter have completed. Giving
+  /// queued transactions priority prevents a continuous stream of ordinary setters
+  /// from starving them.
+  ///
+  /// On return, `immediateWriterScope.isCounted` is `true`,
+  /// `activeImmediateWriterCount` includes this scope, and the condition mutex has
+  /// been released. The caller may then enter the ordinary node mutation pipeline.
+  ///
+  /// - Precondition: `immediateWriterScope` is not already counted. A mutation
+  ///   initiated from a committed graph read must also be able to enter without
+  ///   waiting; otherwise this method fails before creating a lock-order cycle.
   private func admitImmediateWriter(
     _ immediateWriterScope: GraphImmediateWriterScope
   ) {
@@ -742,6 +775,11 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     condition.unlock()
   }
 
+  /// Releases an ordinary setter's counted writer slot.
+  ///
+  /// The scope may already have relinquished its slot when a post-mutation callback
+  /// starts a transaction. Otherwise, decrementing the count wakes any outer
+  /// transaction waiting for the last admitted setter to finish.
   private func finishImmediateWriter(
     _ immediateWriterScope: GraphImmediateWriterScope
   ) {
@@ -808,7 +846,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
   ///
   /// This deterministic test seam verifies waiting semantics without relying on a
   /// scheduler delay as evidence that an outside setter has attempted its write.
-  func waitForImmediateWriterToBlock(until deadline: Date) -> Bool {
+  func __testing__waitForImmediateWriterToBlock(until deadline: Date) -> Bool {
     condition.lock()
     defer { condition.unlock() }
 
@@ -819,7 +857,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
   }
 
   /// Waits until another outer transaction is queued behind the active one.
-  func waitForTransactionToBlock(until deadline: Date) -> Bool {
+  func __testing__waitForTransactionToBlock(until deadline: Date) -> Bool {
     condition.lock()
     defer { condition.unlock() }
 
@@ -830,7 +868,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
   }
 
   /// Waits until a publication barrier is blocked by an active committed reader.
-  func waitForPublisherToBlock(until deadline: Date) -> Bool {
+  func __testing__waitForPublisherToBlock(until deadline: Date) -> Bool {
     condition.lock()
     defer { condition.unlock() }
 

--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -90,6 +90,9 @@ public func withGraphTransaction<Result, Failure: Error>(
 
   let context = GraphTransactionContext()
   let coordinator = GraphTransactionCoordinator.shared
+
+  // Reserve the single transaction-writer slot before installing thread-local
+  // staging. External writes now wait, while committed reads remain available.
   coordinator.beginTransaction(context)
 
   var transactionFinished = false
@@ -97,6 +100,9 @@ public func withGraphTransaction<Result, Failure: Error>(
 
   defer {
     if !transactionFinished {
+      // A thrown outer body rolls back as one unit. Detach staged values while no
+      // other writer can reach their nodes, then release writer admission before
+      // destroying arbitrary values whose deinit may reenter graph mutation.
       ThreadLocal.graphTransaction.replaceValue(previousContext)
       context.prepareRollback()
       coordinator.finishTransaction(context)
@@ -106,11 +112,15 @@ public func withGraphTransaction<Result, Failure: Error>(
 
   let result = try body()
 
+  // The body has finished staging. Callback delivery receives its own fresh
+  // thread-local contexts inside the iterative commit trampoline below.
   ThreadLocal.graphTransaction.replaceValue(previousContext)
   commitTransactionBatches(
     beginningWith: context,
     coordinator: coordinator
   )
+
+  // Callback-generated batches are now empty, so external writers may resume.
   coordinator.finishTransaction(context)
   transactionFinished = true
 
@@ -123,6 +133,12 @@ public func withGraphTransaction<Result, Failure: Error>(
 /// readable on the committing thread, but its graph publication is deferred until
 /// every callback in the current batch has completed. The next batch is drained
 /// before the outer `withGraphTransaction` call returns.
+///
+/// The loop acts as a synchronous trampoline. Callbacks still run on the current
+/// stack, but their mutations never recursively enter the commit pipeline. They
+/// stage into a fresh context that the next loop iteration drains after the current
+/// callback wave returns. This prevents recursive stack growth; it does not make a
+/// callback that continuously stages new mutations terminate.
 private func commitTransactionBatches(
   beginningWith transaction: GraphTransactionContext,
   coordinator: GraphTransactionCoordinator
@@ -130,29 +146,49 @@ private func commitTransactionBatches(
   var batch = transaction
 
   while batch.freezeParticipantsForCommit() {
+    // Mutations made by this batch's callbacks collect here instead of recursively
+    // reentering commit. An empty context makes the next loop condition terminate.
     let nextBatch = GraphTransactionContext()
     ThreadLocal.graphTransaction.withValue(nextBatch) {
+      // Move every participant's staged value into stable commit work before any
+      // comparator runs, so comparator reads see one complete pending snapshot.
       batch.prepareCommit()
       batch.evaluateCommitComparators()
 
+      // Phase 1 captures Observation's pre-mutation traversal without publishing a
+      // Stored value or invoking user callbacks. The short barrier prevents a
+      // committed reader from crossing the snapshot boundary while work is collected.
       let observationDelivery = GraphTransactionObservationDelivery()
       coordinator.withPublicationBarrier(transaction) {
         batch.prepareObservationWillSet(observationDelivery)
       }
 
+      // Observation delivery is outside the condition mutex, reader barrier, and
+      // node locks, although the outer transaction still owns writer admission.
+      // Reentrant assignments stage into `nextBatch` and are visible to later
+      // callbacks. The committing thread sees pending values while outside readers
+      // still see old committed values.
       nextBatch.beginCallbackDelivery()
       observationDelivery.deliver()
 
+      // Phase 2 installs all values and propagates dirty state before committed
+      // readers resume, preventing a reader from observing a partial batch. It only
+      // captures user callbacks; they do not run inside this barrier.
       let callbackDelivery = GraphTransactionCallbackDelivery()
       coordinator.withPublicationBarrier(transaction) {
         batch.publishCommit()
         batch.prepareCommitInvalidations(callbackDelivery)
       }
 
+      // Graph-tracking, onDidSet, and Observation didSet callbacks run after
+      // publication releases its reader barrier. Any mutations they make also join
+      // `nextBatch`.
       callbackDelivery.deliver()
       batch.deliverCommitCallbacks()
     }
 
+    // Continue with callback-generated work iteratively instead of committing from
+    // inside callback delivery.
     batch = nextBatch
   }
 }
@@ -404,7 +440,14 @@ final class GraphTransactionReadScope: @unchecked Sendable {
 /// synchronous post-mutation callback returns the counted slot permanently; a later
 /// setter in that callback reacquires it lazily before mutating.
 final class GraphImmediateWriterScope: @unchecked Sendable {
+
+  /// Whether this thread-local scope currently contributes to the global writer count.
   var isCounted = false
+
+  /// The number of `Stored` node locks currently held by this writer thread.
+  ///
+  /// A transaction may begin from this scope only after the depth returns to zero;
+  /// otherwise it could wait while still blocking another graph operation.
   var nodeLockDepth = 0
 
   var canBeginTransaction: Bool {
@@ -421,23 +464,68 @@ final class GraphImmediateWriterScope: @unchecked Sendable {
 /// reads remain available while the transaction body only stages values.
 ///
 /// No graph-node lock is held while this coordinator waits. Coordinator admission
-/// always precedes node locking, and user callbacks run with neither the condition
-/// nor a node lock held.
+/// always precedes node locking. Callbacks captured by transaction publication run
+/// after the condition mutex, reader barrier, and node locks are released; ordinary
+/// immediate setters retain their existing callback lock semantics.
+///
+/// `NSCondition` supplies both the mutex for the coordination state and a wait queue
+/// for its predicates. Calling `wait()` atomically releases that mutex while the
+/// thread sleeps and reacquires it before the predicate is tested again. It never
+/// protects a node's value; each node continues to use its own `NodeLock`.
+///
+/// The admission predicates are:
+/// - Outer transaction: no active transaction and no active immediate writer.
+/// - Immediate write: no active or waiting transaction.
+/// - Committed read: publication is not in progress.
+/// - Publication: close read admission, then drain every active reader.
+///
+/// A broadcast only means that one of these predicates may have changed. Every
+/// awakened thread must recheck its own predicate in a `while` loop. Broadcasting
+/// is intentional because this one condition hosts several waiter classes; waking
+/// one arbitrary waiter could select a thread whose predicate is still false.
 final class GraphTransactionCoordinator: @unchecked Sendable {
 
   static let shared = GraphTransactionCoordinator()
 
+  /// Protects all coordinator state below and wakes threads when a predicate may change.
   private let condition = NSCondition()
+
+  /// The logical writer owner; the condition mutex is not held for its lifetime.
+  ///
+  /// A non-nil value excludes every immediate writer and implies that
+  /// `activeImmediateWriterCount` is zero.
   private var activeTransaction: GraphTransactionContext?
+
+  /// Ordinary setters admitted before any transaction began waiting.
+  ///
+  /// Multiple setters may run concurrently against different nodes. A transaction
+  /// waits for this count to reach zero before it claims writer ownership.
   private var activeImmediateWriterCount = 0
+
+  /// Transactions that announced writer intent but have not claimed ownership.
+  ///
+  /// A nonzero count prevents new immediate writers from continually overtaking a
+  /// queued transaction while already-admitted writers drain.
   private var waitingTransactionCount = 0
+
 #if DEBUG
+  /// Deterministic test seams for observing each blocking branch.
   private var waitingImmediateWriterCount = 0
   private var waitingPublisherCount = 0
 #endif
+
+  /// Outermost committed read scopes that may currently hold node or Computed locks.
   private var activeReaderCount = 0
+
+  /// Whether new committed reads must wait for a coherent publication boundary.
   private var isPublishing = false
 
+  // MARK: - Outer Transaction
+
+  /// Acquires exclusive graph-writer ownership for an outer transaction.
+  ///
+  /// Once this transaction is counted as waiting, new immediate writers stop at
+  /// their admission predicate. Writers already admitted are allowed to finish.
   func beginTransaction(
     _ transaction: GraphTransactionContext
   ) {
@@ -449,14 +537,21 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
 
     condition.lock()
 
+    // A post-mutation callback may begin a transaction while its thread-local
+    // immediate-writer scope still exists. Once its node lock is released, returning
+    // that counted slot prevents the transaction from waiting for its own thread.
     if let immediateWriterScope, immediateWriterScope.isCounted {
       activeImmediateWriterCount -= 1
       immediateWriterScope.isCounted = false
     }
 
+    // Publish writer preference before waiting so no later ordinary setter can enter
+    // while the currently admitted setters are draining.
     waitingTransactionCount += 1
     condition.broadcast()
 
+    // `wait()` releases the condition mutex. Finishing writers and transactions can
+    // therefore update these predicates and wake this thread without spinning.
     while activeTransaction != nil || activeImmediateWriterCount != 0 {
       condition.wait()
     }
@@ -466,7 +561,11 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     condition.unlock()
   }
 
-  /// Runs one value or invalidation publication phase after draining current readers.
+  /// Runs one transaction phase after excluding committed readers.
+  ///
+  /// The condition mutex is released before `body` begins. The closure may therefore
+  /// acquire participant node locks without holding both lock domains at once. The
+  /// outer transaction continues to exclude other writers for the entire phase.
   func withPublicationBarrier(
     _ transaction: GraphTransactionContext,
     _ body: () -> Void
@@ -482,6 +581,9 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
 
     precondition(activeTransaction === transaction)
     precondition(!isPublishing)
+
+    // Close admission before draining. Existing readers can now only finish, so the
+    // count moves monotonically toward zero while every new reader waits.
     isPublishing = true
 
 #if DEBUG
@@ -491,6 +593,9 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
       condition.broadcast()
     }
 #endif
+
+    // An existing Computed evaluation may span several node reads. Waiting for its
+    // outer read scope prevents publication from splitting that snapshot.
     while activeReaderCount != 0 {
       condition.wait()
     }
@@ -501,6 +606,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
 #endif
   }
 
+  /// Releases writer ownership after every commit batch and callback has drained.
   func finishTransaction(_ transaction: GraphTransactionContext) {
     condition.lock()
     defer { condition.unlock() }
@@ -508,8 +614,10 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     precondition(activeTransaction === transaction)
     precondition(!isPublishing)
 
-    isPublishing = false
     activeTransaction = nil
+
+    // Both queued transactions and immediate writers may now satisfy their
+    // predicates. Each awakened thread rechecks its own `while` condition.
     condition.broadcast()
   }
 
@@ -520,14 +628,26 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     defer { condition.unlock() }
 
     precondition(activeTransaction === transaction)
+    precondition(isPublishing)
     isPublishing = false
+
+    // Committed readers may resume, but immediate writers still observe the active
+    // outer transaction and remain suspended.
     condition.broadcast()
   }
 
+  // MARK: - Immediate Writes
+
+  /// Runs an ordinary `Stored` setter after admitting its thread as a graph writer.
+  ///
+  /// Reentrant setters reuse one thread-local scope, so nested callback work is
+  /// counted once rather than appearing as multiple independent writers.
   func withImmediateWrite<Result, Failure: Error>(
     _ body: () throws(Failure) -> Result
   ) throws(Failure) -> Result {
     if let immediateWriterScope = ThreadLocal.graphImmediateWriterScope.value {
+      // Starting a transaction from a post-mutation callback returns the counted
+      // slot. A later ordinary setter in that callback must acquire it again.
       if !immediateWriterScope.isCounted {
         admitImmediateWriter(immediateWriterScope)
       }
@@ -553,6 +673,10 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     precondition(!immediateWriterScope.isCounted)
 
     condition.lock()
+
+    // A committed Computed read may own its evaluation lock. Waiting for a
+    // transaction from inside that descriptor could invert Computed and coordinator
+    // ordering, so fail before entering the wait branch.
     if ThreadLocal.graphTransactionReadScope.value != nil,
       activeTransaction != nil || waitingTransactionCount != 0
     {
@@ -565,6 +689,9 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
 #if DEBUG
     var isCountedAsWaiting = false
 #endif
+
+    // A queued transaction has priority over new setters. This lets already-admitted
+    // writers drain instead of allowing an unbounded stream of setters to starve it.
     while activeTransaction != nil || waitingTransactionCount != 0 {
 #if DEBUG
       if !isCountedAsWaiting {
@@ -580,6 +707,9 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
       waitingImmediateWriterCount -= 1
     }
 #endif
+
+    // Count admission before releasing the condition mutex so a transaction cannot
+    // claim ownership while this setter is about to acquire its node lock.
     activeImmediateWriterCount += 1
     immediateWriterScope.isCounted = true
     condition.unlock()
@@ -592,22 +722,40 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     if immediateWriterScope.isCounted {
       immediateWriterScope.isCounted = false
       activeImmediateWriterCount -= 1
+
+      // A transaction waiting for the final active setter can now retest its predicate.
       condition.broadcast()
     }
     condition.unlock()
   }
 
+  // MARK: - Committed Reads
+
+  /// Runs one committed-graph read scope that cannot overlap transaction publication.
+  ///
+  /// A thread-local marker lets every nested `Stored` and `Computed` read remain in
+  /// the same scope. The reader count therefore covers an entire Computed evaluation,
+  /// so a transaction publication cannot split its dependency reads. Ordinary
+  /// immediate writes retain their existing concurrent-read semantics.
   func withReadAccess<Result, Failure: Error>(
     _ body: () throws(Failure) -> Result
   ) throws(Failure) -> Result {
+    // Nested node reads inherit the outer admission and cannot independently cross
+    // a transaction-publication boundary.
     if ThreadLocal.graphTransactionReadScope.value != nil {
       return try body()
     }
 
     condition.lock()
+
+    // Publication closes admission before changing any participant. Waiting here
+    // happens without a node lock, so the publisher can finish and reopen the gate.
     while isPublishing {
       condition.wait()
     }
+
+    // Count this reader before releasing the condition mutex. A publisher can now
+    // either observe it and wait, or close admission only after this scope finishes.
     activeReaderCount += 1
     condition.unlock()
 
@@ -617,6 +765,8 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
       ThreadLocal.graphTransactionReadScope.replaceValue(previousReadScope)
       condition.lock()
       activeReaderCount -= 1
+
+      // Only the final active reader can satisfy a publisher's drain predicate.
       if activeReaderCount == 0 {
         condition.broadcast()
       }

--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -90,7 +90,7 @@ public func withGraphTransaction<Result, Failure: Error>(
 
   let context = GraphTransactionContext()
   let coordinator = GraphTransactionCoordinator.shared
-  let transactionAccess = coordinator.beginTransaction(context)
+  coordinator.beginTransaction(context)
 
   var transactionFinished = false
   let previousContext = ThreadLocal.graphTransaction.replaceValue(context)
@@ -99,7 +99,7 @@ public func withGraphTransaction<Result, Failure: Error>(
     if !transactionFinished {
       ThreadLocal.graphTransaction.replaceValue(previousContext)
       context.prepareRollback()
-      coordinator.finishTransaction(transactionAccess)
+      coordinator.finishTransaction(context)
       context.finishRollback()
     }
   }
@@ -109,10 +109,9 @@ public func withGraphTransaction<Result, Failure: Error>(
   ThreadLocal.graphTransaction.replaceValue(previousContext)
   commitTransactionBatches(
     beginningWith: context,
-    transactionAccess: transactionAccess,
     coordinator: coordinator
   )
-  coordinator.finishTransaction(transactionAccess)
+  coordinator.finishTransaction(context)
   transactionFinished = true
 
   return result
@@ -125,11 +124,10 @@ public func withGraphTransaction<Result, Failure: Error>(
 /// every callback in the current batch has completed. The next batch is drained
 /// before the outer `withGraphTransaction` call returns.
 private func commitTransactionBatches(
-  beginningWith firstBatch: GraphTransactionContext,
-  transactionAccess: GraphTransactionAccess,
+  beginningWith transaction: GraphTransactionContext,
   coordinator: GraphTransactionCoordinator
 ) {
-  var batch = firstBatch
+  var batch = transaction
 
   while batch.freezeParticipantsForCommit() {
     let nextBatch = GraphTransactionContext()
@@ -137,19 +135,19 @@ private func commitTransactionBatches(
       batch.prepareCommit()
       batch.evaluateCommitComparators()
 
-      coordinator.beginPublishing(transactionAccess)
       let observationDelivery = GraphTransactionObservationDelivery()
-      batch.prepareObservationWillSet(observationDelivery)
-      coordinator.finishPublishing(transactionAccess)
+      coordinator.withPublicationBarrier(transaction) {
+        batch.prepareObservationWillSet(observationDelivery)
+      }
 
       nextBatch.beginCallbackDelivery()
       observationDelivery.deliver()
 
-      coordinator.beginPublishing(transactionAccess)
-      batch.publishCommit()
       let callbackDelivery = GraphTransactionCallbackDelivery()
-      batch.prepareCommitInvalidations(callbackDelivery)
-      coordinator.finishPublishing(transactionAccess)
+      coordinator.withPublicationBarrier(transaction) {
+        batch.publishCommit()
+        batch.prepareCommitInvalidations(callbackDelivery)
+      }
 
       callbackDelivery.deliver()
       batch.deliverCommitCallbacks()
@@ -414,17 +412,17 @@ final class GraphImmediateWriterScope: @unchecked Sendable {
   }
 }
 
-/// The coordinator ownership held for one outer graph transaction.
-struct GraphTransactionAccess {
-  let transaction: GraphTransactionContext
-}
-
-/// Coordinates transaction writers with immediate `Stored` writes and commit reads.
+/// Coordinates cross-node writer exclusion and atomic graph publication.
 ///
-/// No graph-node lock is held while this coordinator waits. The lock order is always
-/// coordinator access first, then a node lock; callbacks run after both have been
-/// released. A transaction owns the writer slot only logically, so normal readers
-/// continue during its body and are paused only for the publication phase.
+/// A node lock protects one `Stored` value, but it cannot prevent readers from
+/// observing a transaction after one participant publishes and before another does.
+/// This coordinator therefore suspends other writers for the outer transaction and
+/// installs a reader barrier only around the short publication phases. Committed
+/// reads remain available while the transaction body only stages values.
+///
+/// No graph-node lock is held while this coordinator waits. Coordinator admission
+/// always precedes node locking, and user callbacks run with neither the condition
+/// nor a node lock held.
 final class GraphTransactionCoordinator: @unchecked Sendable {
 
   static let shared = GraphTransactionCoordinator()
@@ -442,7 +440,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
 
   func beginTransaction(
     _ transaction: GraphTransactionContext
-  ) -> GraphTransactionAccess {
+  ) {
     let immediateWriterScope = ThreadLocal.graphImmediateWriterScope.value
     precondition(
       immediateWriterScope?.canBeginTransaction != false,
@@ -466,15 +464,23 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     waitingTransactionCount -= 1
     activeTransaction = transaction
     condition.unlock()
-
-    return GraphTransactionAccess(transaction: transaction)
   }
 
-  func beginPublishing(_ access: GraphTransactionAccess) {
+  /// Runs one value or invalidation publication phase after draining current readers.
+  func withPublicationBarrier(
+    _ transaction: GraphTransactionContext,
+    _ body: () -> Void
+  ) {
+    beginPublishing(transaction)
+    defer { finishPublishing(transaction) }
+    body()
+  }
+
+  private func beginPublishing(_ transaction: GraphTransactionContext) {
     condition.lock()
     defer { condition.unlock() }
 
-    precondition(activeTransaction === access.transaction)
+    precondition(activeTransaction === transaction)
     precondition(!isPublishing)
     isPublishing = true
 
@@ -495,11 +501,11 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
 #endif
   }
 
-  func finishTransaction(_ access: GraphTransactionAccess) {
+  func finishTransaction(_ transaction: GraphTransactionContext) {
     condition.lock()
     defer { condition.unlock() }
 
-    precondition(activeTransaction === access.transaction)
+    precondition(activeTransaction === transaction)
     precondition(!isPublishing)
 
     isPublishing = false
@@ -509,11 +515,11 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
 
   /// Releases the short publication barrier after all source values and graph
   /// invalidations are coherent, while the transaction continues blocking writers.
-  func finishPublishing(_ access: GraphTransactionAccess) {
+  private func finishPublishing(_ transaction: GraphTransactionContext) {
     condition.lock()
     defer { condition.unlock() }
 
-    precondition(activeTransaction === access.transaction)
+    precondition(activeTransaction === transaction)
     isPublishing = false
     condition.broadcast()
   }

--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -34,10 +34,11 @@ import Foundation
 /// graph. The next ordinary read continues to use the committed graph.
 ///
 /// - Important: Rollback applies to `Stored` assignments only. Mutating properties
-///   of a reference obtained from `Stored<SomeClass>` is an external side effect and
-///   cannot be rolled back. Mutating `GraphUserDefault`, `EntityStore`, databases,
-///   or other externally committed sources inside `body` is unsupported; their
-///   persistence, locking, and rollback semantics are outside this API.
+///   through reference storage reachable from a `Stored` value is an external side
+///   effect and cannot be rolled back. This includes a class instance stored directly
+///   or as an entity in a value-semantic collection. Mutating `GraphUserDefault`,
+///   databases, or other externally committed sources inside `body` is unsupported;
+///   their persistence, locking, and rollback semantics are outside this API.
 /// - Important: ``Stored/unsafeModify(_:)`` deliberately bypasses assignment,
 ///   invalidation, and transaction staging. A mutation made through it is not
 ///   rolled back.
@@ -65,7 +66,9 @@ import Foundation
 ///   - line: The source line that starts the transaction.
 ///   - column: The source column that starts the transaction.
 ///   - body: The synchronous work whose `Stored` assignments are staged.
-/// - Returns: The value returned by `body` after its staged assignments commit.
+/// - Returns: The value returned by `body`. The outermost call returns after every
+///   staged callback batch commits. A nested call returns to the active outer body
+///   without committing.
 /// - Throws: The error thrown by `body`. An error escaping the outermost call
 ///   discards every staged assignment before it is rethrown.
 @discardableResult
@@ -302,7 +305,9 @@ final class GraphTransactionContext {
 ///
 /// The pre-publication traversal preserves Observation's `willSet` boundary. The
 /// publication traversal then makes every cache dirty before releasing the read
-/// barrier and queues graph-tracking callbacks for delivery afterwards.
+/// barrier and queues graph-tracking callbacks for delivery afterwards. Every
+/// concrete dependency target must provide this split; publication fails closed
+/// rather than exposing a clean cache after its sources have committed.
 protocol GraphTransactionInvalidatableNode: AnyObject {
   func prepareGraphTransactionObservationWillSet(
     _ observationDelivery: GraphTransactionObservationDelivery
@@ -331,8 +336,11 @@ final class GraphTransactionObservationDelivery {
   }
 
   func prepareWillSet(for edge: Edge) {
-    guard let node = edge.to as? any GraphTransactionInvalidatableNode else {
-      return
+    guard let target = edge.to else { return }
+    guard let node = target as? any GraphTransactionInvalidatableNode else {
+      preconditionFailure(
+        "A graph transaction reached a dependency node without two-phase invalidation support."
+      )
     }
 
     let identifier = ObjectIdentifier(node)
@@ -367,13 +375,9 @@ final class GraphTransactionCallbackDelivery {
 
     guard let node = edge.to else { return }
     guard let node = node as? any GraphTransactionInvalidatableNode else {
-      // StateGraph's built-in dependency targets conform to the transaction-aware
-      // invalidation path. A custom TypeErasedNode keeps its existing callback
-      // behavior as a compatibility fallback.
-      append {
-        node.potentiallyDirty = true
-      }
-      return
+      preconditionFailure(
+        "A graph transaction reached a dependency node without two-phase invalidation support."
+      )
     }
 
     node.prepareGraphTransactionInvalidation(self)

--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -1,0 +1,656 @@
+import Foundation
+
+/// Runs synchronous `Stored` mutations as one graph transaction.
+///
+/// The outermost call creates a transaction context. Assignments to ``Stored`` nodes
+/// are staged in node-local buffers, so reads made by `body` observe their latest
+/// staged values while other threads continue to observe the previously committed
+/// graph. At commit, StateGraph snapshots affected Observation nodes after current
+/// readers finish, then invokes the existing `willSet` delivery path before
+/// publication. A synchronously delivered handler on the committing thread can
+/// read the complete staged snapshot while other threads still read the old
+/// committed graph. The staged values are then committed together before
+/// graph-tracking and `onDidSet(_:)` callbacks are delivered.
+///
+/// A callback mutation joins a following commit batch owned by the same outer
+/// transaction. Its staged value is immediately readable by later callbacks on the
+/// committing thread, and the batch is published before this function returns.
+/// Every batch uses each `Stored` node's ordinary comparator and callback pipeline.
+///
+/// Nested calls join the active transaction. They do not create a savepoint or an
+/// independent commit or rollback boundary: if an inner error is caught by `body`,
+/// its staged assignments remain part of the outer transaction. Only an error that
+/// leaves the outermost call rolls all staged assignments back.
+///
+/// This API is synchronous and nonescaping. Its dynamic context is thread-local;
+/// do not assume it is preserved across `await`, task creation, or executor hops.
+/// While an outer transaction body is running, writes from other threads wait until
+/// it completes. Those threads may continue reading committed values. During the
+/// short commit phase, reads wait so they cannot observe a partially committed set
+/// of nodes.
+///
+/// `Computed` values read by the transaction or its synchronous callbacks are
+/// evaluated from staged values without updating the committed cache or dependency
+/// graph. The next ordinary read continues to use the committed graph.
+///
+/// - Important: Rollback applies to `Stored` assignments only. Mutating properties
+///   of a reference obtained from `Stored<SomeClass>` is an external side effect and
+///   cannot be rolled back. Mutating `GraphUserDefault`, `EntityStore`, databases,
+///   or other externally committed sources inside `body` is unsupported; their
+///   persistence, locking, and rollback semantics are outside this API.
+/// - Important: ``Stored/unsafeModify(_:)`` deliberately bypasses assignment,
+///   invalidation, and transaction staging. A mutation made through it is not
+///   rolled back.
+/// - Important: Synchronous callbacks run before the outer call returns and while
+///   writes from other threads remain suspended. Reentrant `Stored` assignments are
+///   supported, but a comparator or callback must not synchronously wait for another
+///   thread to complete a graph write. Callbacks that existing APIs schedule
+///   asynchronously do not inherit the thread-local transaction.
+///   This includes Observation delivery that uses StateGraph's existing MainActor
+///   hop: after a hop, the handler reads the coherent committed snapshot current
+///   when it runs rather than transaction-local staged storage.
+/// - Important: An ordinary immediate assignment evaluates `Stored`'s
+///   `shouldNotify` closure and synchronously delivered Observation `willSet`
+///   handlers while a node lock is held. Do not begin a transaction there or from
+///   ``Stored/unsafeModify(_:)``; use `onDidSet(_:)` or another post-mutation
+///   callback instead. Transaction commit evaluates comparators and delivers its
+///   Observation callbacks outside node locks, but comparators should remain free
+///   of mutation side effects.
+/// - Important: Keep committed ``Computed`` descriptors free of graph mutations.
+///   A descriptor owns its node's evaluation lock, so beginning a transaction, or
+///   blocking on one through a `Stored` assignment, would create a lock-order cycle.
+///   StateGraph fails fast in those cases instead of deadlocking.
+/// - Parameters:
+///   - file: The source file that starts the transaction.
+///   - line: The source line that starts the transaction.
+///   - column: The source column that starts the transaction.
+///   - body: The synchronous work whose `Stored` assignments are staged.
+/// - Returns: The value returned by `body` after its staged assignments commit.
+/// - Throws: The error thrown by `body`. An error escaping the outermost call
+///   discards every staged assignment before it is rethrown.
+@discardableResult
+public func withGraphTransaction<Result, Failure: Error>(
+  _ file: StaticString = #fileID,
+  _ line: UInt = #line,
+  _ column: UInt = #column,
+  _ body: () throws(Failure) -> Result
+) throws(Failure) -> Result {
+  if ThreadLocal.graphTransaction.value != nil {
+    Log.logNestedGraphTransaction(file, line, column)
+    return try body()
+  }
+
+  precondition(
+    ThreadLocal.graphTransactionReadScope.value == nil,
+    "withGraphTransaction cannot begin from a committed graph read. Move graph mutations outside Computed descriptors."
+  )
+
+  let context = GraphTransactionContext()
+  let coordinator = GraphTransactionCoordinator.shared
+  let transactionAccess = coordinator.beginTransaction(context)
+
+  var transactionFinished = false
+  let previousContext = ThreadLocal.graphTransaction.replaceValue(context)
+
+  defer {
+    if !transactionFinished {
+      ThreadLocal.graphTransaction.replaceValue(previousContext)
+      context.prepareRollback()
+      coordinator.finishTransaction(transactionAccess)
+      context.finishRollback()
+    }
+  }
+
+  let result = try body()
+
+  ThreadLocal.graphTransaction.replaceValue(previousContext)
+  commitTransactionBatches(
+    beginningWith: context,
+    transactionAccess: transactionAccess,
+    coordinator: coordinator
+  )
+  coordinator.finishTransaction(transactionAccess)
+  transactionFinished = true
+
+  return result
+}
+
+/// Commits the body batch and any mutations synchronously staged by its callbacks.
+///
+/// Callback delivery is one hook boundary: a callback mutation is immediately
+/// readable on the committing thread, but its graph publication is deferred until
+/// every callback in the current batch has completed. The next batch is drained
+/// before the outer `withGraphTransaction` call returns.
+private func commitTransactionBatches(
+  beginningWith firstBatch: GraphTransactionContext,
+  transactionAccess: GraphTransactionAccess,
+  coordinator: GraphTransactionCoordinator
+) {
+  var batch = firstBatch
+
+  while batch.freezeParticipantsForCommit() {
+    let nextBatch = GraphTransactionContext()
+    ThreadLocal.graphTransaction.withValue(nextBatch) {
+      batch.prepareCommit()
+      batch.evaluateCommitComparators()
+
+      coordinator.beginPublishing(transactionAccess)
+      let observationDelivery = GraphTransactionObservationDelivery()
+      batch.prepareObservationWillSet(observationDelivery)
+      coordinator.finishPublishing(transactionAccess)
+
+      nextBatch.beginCallbackDelivery()
+      observationDelivery.deliver()
+
+      coordinator.beginPublishing(transactionAccess)
+      batch.publishCommit()
+      let callbackDelivery = GraphTransactionCallbackDelivery()
+      batch.prepareCommitInvalidations(callbackDelivery)
+      coordinator.finishPublishing(transactionAccess)
+
+      callbackDelivery.deliver()
+      batch.deliverCommitCallbacks()
+    }
+
+    batch = nextBatch
+  }
+}
+
+/// A node that can stage and publish its own transaction-local value.
+///
+/// The context uses this protocol only to coordinate commands. Transaction values
+/// remain in the concrete `Stored` node that owns their static type.
+protocol GraphTransactionParticipant: AnyObject {
+
+  /// Moves the staged value into node-local commit work.
+  func prepareTransactionCommit()
+
+  /// Evaluates the node's existing comparator before publication blocks readers.
+  func evaluateTransactionComparator()
+
+  /// Captures Observation's pre-mutation notifications without invoking callbacks.
+  func prepareTransactionObservationWillSet(
+    _ observationDelivery: GraphTransactionObservationDelivery
+  )
+
+  /// Replaces the committed value without running callbacks.
+  func publishTransactionCommit()
+
+  /// Marks graph invalidations and queues their callbacks after every participant
+  /// has prepared its final committed value.
+  func prepareTransactionInvalidations(
+    _ callbackDelivery: GraphTransactionCallbackDelivery
+  )
+
+  /// Delivers `Stored` callbacks after graph invalidation has completed.
+  func deliverTransactionCallbacks()
+
+  /// Detaches the staged value while the transaction still excludes other writers.
+  func prepareTransactionRollback(_ transaction: GraphTransactionContext)
+
+  /// Destroys the detached value after releasing the transaction writer slot.
+  func finishTransactionRollback(_ transaction: GraphTransactionContext)
+}
+
+/// The thread-local command list for one graph transaction commit batch.
+///
+/// This context intentionally retains only weak, type-erased participants. Each
+/// `Stored` node owns its typed staged value directly, which keeps transaction
+/// values out of a shared `[ObjectIdentifier: Any]` container.
+final class GraphTransactionContext {
+
+  private struct WeakParticipant {
+    weak var value: (any GraphTransactionParticipant)?
+  }
+
+  private var participants: [WeakParticipant] = []
+  private var frozenParticipants: [any GraphTransactionParticipant] = []
+  private(set) var recordsDependencies = false
+
+  func register(_ participant: any GraphTransactionParticipant) {
+    participants.append(.init(value: participant))
+  }
+
+  /// Freezes one strong participant snapshot for every phase of this batch.
+  ///
+  /// The body owns only weak participant references, so a staged node may still
+  /// deallocate before commit. Once publication begins, keeping one stable snapshot
+  /// prevents lifetime changes from producing different phase participant sets.
+  func freezeParticipantsForCommit() -> Bool {
+    frozenParticipants = participants.compactMap(\.value)
+    return !frozenParticipants.isEmpty
+  }
+
+  func prepareCommit() {
+    for participant in frozenParticipants {
+      participant.prepareTransactionCommit()
+    }
+  }
+
+  func evaluateCommitComparators() {
+    for participant in frozenParticipants {
+      participant.evaluateTransactionComparator()
+    }
+  }
+
+  func prepareObservationWillSet(
+    _ observationDelivery: GraphTransactionObservationDelivery
+  ) {
+    for participant in frozenParticipants {
+      participant.prepareTransactionObservationWillSet(observationDelivery)
+    }
+  }
+
+  func publishCommit() {
+    for participant in frozenParticipants {
+      participant.publishTransactionCommit()
+    }
+  }
+
+  func prepareCommitInvalidations(
+    _ callbackDelivery: GraphTransactionCallbackDelivery
+  ) {
+    for participant in frozenParticipants {
+      participant.prepareTransactionInvalidations(callbackDelivery)
+    }
+  }
+
+  func deliverCommitCallbacks() {
+    defer { frozenParticipants.removeAll() }
+
+    for participant in frozenParticipants {
+      participant.deliverTransactionCallbacks()
+    }
+  }
+
+  /// Enables dependency registration while synchronous notification handlers rerun.
+  ///
+  /// Transaction body and comparator reads remain isolated from the committed graph.
+  /// Callback-driven tracking passes may register directly with their leaf `Stored`
+  /// dependencies so continuous tracking survives the transaction boundary.
+  func beginCallbackDelivery() {
+    recordsDependencies = true
+  }
+
+  /// Detaches every staged value while this transaction still owns the writer slot.
+  ///
+  /// The strong snapshot prevents a participant from disappearing between detach
+  /// and destruction. Values remain in their concrete nodes throughout both phases.
+  func prepareRollback() {
+    frozenParticipants = participants.compactMap(\.value)
+    for participant in frozenParticipants {
+      participant.prepareTransactionRollback(self)
+    }
+  }
+
+  /// Destroys detached staged values after another writer can safely reenter.
+  ///
+  /// Releasing an arbitrary `Value` may synchronously run user-defined `deinit`
+  /// work. Keeping that destruction outside node locks and the coordinator's writer
+  /// slot prevents reentrant graph mutations from waiting on their own rollback.
+  func finishRollback() {
+    defer { frozenParticipants.removeAll() }
+
+    for participant in frozenParticipants {
+      participant.finishTransactionRollback(self)
+    }
+  }
+}
+
+/// A computed node that can mark itself dirty without synchronously invoking user
+/// callbacks during transaction publication.
+///
+/// The pre-publication traversal preserves Observation's `willSet` boundary. The
+/// publication traversal then makes every cache dirty before releasing the read
+/// barrier and queues graph-tracking callbacks for delivery afterwards.
+protocol GraphTransactionInvalidatableNode: AnyObject {
+  func prepareGraphTransactionObservationWillSet(
+    _ observationDelivery: GraphTransactionObservationDelivery
+  )
+
+  func prepareGraphTransactionInvalidation(
+    _ callbackDelivery: GraphTransactionCallbackDelivery
+  )
+}
+
+/// Freezes Observation's `willSet` work from the committed dependency graph.
+///
+/// The transaction briefly drains committed readers while this object traverses the
+/// graph, then releases that barrier before invoking the captured callbacks. A
+/// synchronously delivered callback can therefore read the complete staged snapshot
+/// without blocking another thread from reading the old committed graph. Nodes
+/// registered afterwards follow the same concurrent-access boundary as a
+/// registration racing an ordinary setter after its `willSet` call.
+final class GraphTransactionObservationDelivery {
+
+  private var deliveredNodes: Set<ObjectIdentifier> = []
+  private var callbacks: [() -> Void] = []
+
+  func append(_ callback: @escaping () -> Void) {
+    callbacks.append(callback)
+  }
+
+  func prepareWillSet(for edge: Edge) {
+    guard let node = edge.to as? any GraphTransactionInvalidatableNode else {
+      return
+    }
+
+    let identifier = ObjectIdentifier(node)
+    guard deliveredNodes.insert(identifier).inserted else { return }
+    node.prepareGraphTransactionObservationWillSet(self)
+  }
+
+  func deliver() {
+    for callback in callbacks {
+      callback()
+    }
+    callbacks.removeAll()
+  }
+}
+
+/// User callbacks captured while a transaction marks its dependency graph dirty.
+///
+/// The publication barrier protects only value installation and dirty-state
+/// propagation. Delivering graph-tracking and custom-node callbacks after releasing
+/// that barrier avoids making a callback that waits for another thread's graph read
+/// deadlock the commit.
+final class GraphTransactionCallbackDelivery {
+
+  private var callbacks: [() -> Void] = []
+
+  func append(_ callback: @escaping () -> Void) {
+    callbacks.append(callback)
+  }
+
+  func prepareInvalidation(for edge: Edge) {
+    edge.isPending = true
+
+    guard let node = edge.to else { return }
+    guard let node = node as? any GraphTransactionInvalidatableNode else {
+      // StateGraph's built-in dependency targets conform to the transaction-aware
+      // invalidation path. A custom TypeErasedNode keeps its existing callback
+      // behavior as a compatibility fallback.
+      append {
+        node.potentiallyDirty = true
+      }
+      return
+    }
+
+    node.prepareGraphTransactionInvalidation(self)
+  }
+
+  func deliver() {
+    for callback in callbacks {
+      callback()
+    }
+    callbacks.removeAll()
+  }
+}
+
+/// Marks an outer committed-graph read so nested node reads keep the same
+/// publication snapshot while a writer begins its barrier.
+final class GraphTransactionReadScope: @unchecked Sendable {
+  static let shared = GraphTransactionReadScope()
+
+  private init() {
+  }
+}
+
+/// Marks one immediate writer admitted by the coordinator.
+///
+/// Nested setters on the same thread reuse this scope. A transaction started by a
+/// synchronous post-mutation callback returns the counted slot permanently; a later
+/// setter in that callback reacquires it lazily before mutating.
+final class GraphImmediateWriterScope: @unchecked Sendable {
+  var isCounted = false
+  var nodeLockDepth = 0
+
+  var canBeginTransaction: Bool {
+    nodeLockDepth == 0
+  }
+}
+
+/// The coordinator ownership held for one outer graph transaction.
+struct GraphTransactionAccess {
+  let transaction: GraphTransactionContext
+}
+
+/// Coordinates transaction writers with immediate `Stored` writes and commit reads.
+///
+/// No graph-node lock is held while this coordinator waits. The lock order is always
+/// coordinator access first, then a node lock; callbacks run after both have been
+/// released. A transaction owns the writer slot only logically, so normal readers
+/// continue during its body and are paused only for the publication phase.
+final class GraphTransactionCoordinator: @unchecked Sendable {
+
+  static let shared = GraphTransactionCoordinator()
+
+  private let condition = NSCondition()
+  private var activeTransaction: GraphTransactionContext?
+  private var activeImmediateWriterCount = 0
+  private var waitingTransactionCount = 0
+#if DEBUG
+  private var waitingImmediateWriterCount = 0
+  private var waitingPublisherCount = 0
+#endif
+  private var activeReaderCount = 0
+  private var isPublishing = false
+
+  func beginTransaction(
+    _ transaction: GraphTransactionContext
+  ) -> GraphTransactionAccess {
+    let immediateWriterScope = ThreadLocal.graphImmediateWriterScope.value
+    precondition(
+      immediateWriterScope?.canBeginTransaction != false,
+      "withGraphTransaction cannot begin while a Stored node lock is held. Start it from onDidSet or another post-mutation callback."
+    )
+
+    condition.lock()
+
+    if let immediateWriterScope, immediateWriterScope.isCounted {
+      activeImmediateWriterCount -= 1
+      immediateWriterScope.isCounted = false
+    }
+
+    waitingTransactionCount += 1
+    condition.broadcast()
+
+    while activeTransaction != nil || activeImmediateWriterCount != 0 {
+      condition.wait()
+    }
+
+    waitingTransactionCount -= 1
+    activeTransaction = transaction
+    condition.unlock()
+
+    return GraphTransactionAccess(transaction: transaction)
+  }
+
+  func beginPublishing(_ access: GraphTransactionAccess) {
+    condition.lock()
+    defer { condition.unlock() }
+
+    precondition(activeTransaction === access.transaction)
+    precondition(!isPublishing)
+    isPublishing = true
+
+#if DEBUG
+    let didWaitForReaders = activeReaderCount != 0
+    if didWaitForReaders {
+      waitingPublisherCount += 1
+      condition.broadcast()
+    }
+#endif
+    while activeReaderCount != 0 {
+      condition.wait()
+    }
+#if DEBUG
+    if didWaitForReaders {
+      waitingPublisherCount -= 1
+    }
+#endif
+  }
+
+  func finishTransaction(_ access: GraphTransactionAccess) {
+    condition.lock()
+    defer { condition.unlock() }
+
+    precondition(activeTransaction === access.transaction)
+    precondition(!isPublishing)
+
+    isPublishing = false
+    activeTransaction = nil
+    condition.broadcast()
+  }
+
+  /// Releases the short publication barrier after all source values and graph
+  /// invalidations are coherent, while the transaction continues blocking writers.
+  func finishPublishing(_ access: GraphTransactionAccess) {
+    condition.lock()
+    defer { condition.unlock() }
+
+    precondition(activeTransaction === access.transaction)
+    isPublishing = false
+    condition.broadcast()
+  }
+
+  func withImmediateWrite<Result, Failure: Error>(
+    _ body: () throws(Failure) -> Result
+  ) throws(Failure) -> Result {
+    if let immediateWriterScope = ThreadLocal.graphImmediateWriterScope.value {
+      if !immediateWriterScope.isCounted {
+        admitImmediateWriter(immediateWriterScope)
+      }
+      return try body()
+    }
+
+    let immediateWriterScope = GraphImmediateWriterScope()
+    admitImmediateWriter(immediateWriterScope)
+
+    defer {
+      finishImmediateWriter(immediateWriterScope)
+    }
+
+    return try ThreadLocal.graphImmediateWriterScope.withValue(
+      immediateWriterScope,
+      perform: body
+    )
+  }
+
+  private func admitImmediateWriter(
+    _ immediateWriterScope: GraphImmediateWriterScope
+  ) {
+    precondition(!immediateWriterScope.isCounted)
+
+    condition.lock()
+    if ThreadLocal.graphTransactionReadScope.value != nil,
+      activeTransaction != nil || waitingTransactionCount != 0
+    {
+      condition.unlock()
+      preconditionFailure(
+        "A Stored mutation from a committed graph read cannot wait for an active graph transaction. Move side effects outside Computed descriptors."
+      )
+    }
+
+#if DEBUG
+    var isCountedAsWaiting = false
+#endif
+    while activeTransaction != nil || waitingTransactionCount != 0 {
+#if DEBUG
+      if !isCountedAsWaiting {
+        isCountedAsWaiting = true
+        waitingImmediateWriterCount += 1
+        condition.broadcast()
+      }
+#endif
+      condition.wait()
+    }
+#if DEBUG
+    if isCountedAsWaiting {
+      waitingImmediateWriterCount -= 1
+    }
+#endif
+    activeImmediateWriterCount += 1
+    immediateWriterScope.isCounted = true
+    condition.unlock()
+  }
+
+  private func finishImmediateWriter(
+    _ immediateWriterScope: GraphImmediateWriterScope
+  ) {
+    condition.lock()
+    if immediateWriterScope.isCounted {
+      immediateWriterScope.isCounted = false
+      activeImmediateWriterCount -= 1
+      condition.broadcast()
+    }
+    condition.unlock()
+  }
+
+  func withReadAccess<Result, Failure: Error>(
+    _ body: () throws(Failure) -> Result
+  ) throws(Failure) -> Result {
+    if ThreadLocal.graphTransactionReadScope.value != nil {
+      return try body()
+    }
+
+    condition.lock()
+    while isPublishing {
+      condition.wait()
+    }
+    activeReaderCount += 1
+    condition.unlock()
+
+    let previousReadScope = ThreadLocal.graphTransactionReadScope.replaceValue(.shared)
+
+    defer {
+      ThreadLocal.graphTransactionReadScope.replaceValue(previousReadScope)
+      condition.lock()
+      activeReaderCount -= 1
+      if activeReaderCount == 0 {
+        condition.broadcast()
+      }
+      condition.unlock()
+    }
+
+    return try body()
+  }
+
+#if DEBUG
+  /// Waits until an immediate writer has reached the coordinator wait branch.
+  ///
+  /// This deterministic test seam verifies waiting semantics without relying on a
+  /// scheduler delay as evidence that an outside setter has attempted its write.
+  func waitForImmediateWriterToBlock(until deadline: Date) -> Bool {
+    condition.lock()
+    defer { condition.unlock() }
+
+    while waitingImmediateWriterCount == 0 {
+      guard condition.wait(until: deadline) else { return false }
+    }
+    return true
+  }
+
+  /// Waits until another outer transaction is queued behind the active one.
+  func waitForTransactionToBlock(until deadline: Date) -> Bool {
+    condition.lock()
+    defer { condition.unlock() }
+
+    while waitingTransactionCount == 0 {
+      guard condition.wait(until: deadline) else { return false }
+    }
+    return true
+  }
+
+  /// Waits until a publication barrier is blocked by an active committed reader.
+  func waitForPublisherToBlock(until deadline: Date) -> Bool {
+    condition.lock()
+    defer { condition.unlock() }
+
+    while waitingPublisherCount == 0 {
+      guard condition.wait(until: deadline) else { return false }
+    }
+    return true
+  }
+#endif
+}

--- a/Sources/StateGraph/Logger.swift
+++ b/Sources/StateGraph/Logger.swift
@@ -8,6 +8,7 @@ public enum StateGraphDiagnostics {
 
   private struct State: Sendable {
     var isSelfInvalidationWarningEnabled = true
+    var isNestedTransactionWarningEnabled = true
   }
 
   private static let state = OSAllocatedUnfairLock(initialState: State())
@@ -27,6 +28,20 @@ public enum StateGraphDiagnostics {
       state.withLock { $0.isSelfInvalidationWarningEnabled = newValue }
     }
   }
+
+  /// Controls the DEBUG diagnostic emitted when a nested graph transaction joins
+  /// an active outer transaction.
+  ///
+  /// Nested calls always join the outer transaction regardless of this setting.
+  /// The default is `true`. Logging remains disabled in non-DEBUG builds.
+  public static var isNestedTransactionWarningEnabled: Bool {
+    get {
+      state.withLock { $0.isNestedTransactionWarningEnabled }
+    }
+    set {
+      state.withLock { $0.isNestedTransactionWarningEnabled = newValue }
+    }
+  }
 }
 
 enum Log {
@@ -34,6 +49,9 @@ enum Log {
 #if DEBUG
   @TaskLocal
   static var selfInvalidationWarningObserver: (@Sendable () -> Void)?
+
+  @TaskLocal
+  static var nestedTransactionWarningObserver: (@Sendable () -> Void)?
 #endif
 
   static let generic = Logger(OSLog.makeOSLogInDebug { OSLog.init(subsystem: "state-graph", category: "generic") })
@@ -49,6 +67,22 @@ enum Log {
     tracking.warning(
       "A tracking handler invalidated its own active registration. The mutation was applied and peer registrations were notified, but this registration was not restored to the invalidated node."
     )
+  }
+
+  static func logNestedGraphTransaction(
+    _ file: StaticString,
+    _ line: UInt,
+    _ column: UInt
+  ) {
+#if DEBUG
+    guard StateGraphDiagnostics.isNestedTransactionWarningEnabled else { return }
+    nestedTransactionWarningObserver?()
+
+    let sourceLocation = "\(file):\(line):\(column)"
+    generic.debug(
+      "A nested graph transaction at \(sourceLocation, privacy: .public) joined the active transaction. It has no independent commit or rollback boundary."
+    )
+#endif
   }
 }
 

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -173,8 +173,8 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
     private let observationRegistrar = ObservationRegistrar()
   #endif
 
-  /// Graph work captured when this node first becomes potentially dirty.
-  private struct InvalidationWork {
+  /// Single-use graph work captured when this node first becomes potentially dirty.
+  private struct InvalidationWork: ~Copyable {
     let outgoingEdges: ContiguousArray<Edge>
     let trackingRegistrations: Set<TrackingRegistration>
   }

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -173,6 +173,12 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
     private let observationRegistrar = ObservationRegistrar()
   #endif
 
+  /// Graph work captured when this node first becomes potentially dirty.
+  private struct InvalidationWork {
+    let outgoingEdges: ContiguousArray<Edge>
+    let trackingRegistrations: Set<TrackingRegistration>
+  }
+
   public var potentiallyDirty: Bool {
     get {
       lock.lock()
@@ -182,21 +188,14 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
       return _potentiallyDirty
     }
     set {
-      lock.lock()
-          
-      let oldValue = _potentiallyDirty
-      _potentiallyDirty = newValue
-      
-      guard _potentiallyDirty, _potentiallyDirty != oldValue else {
+      guard newValue else {
+        lock.lock()
+        _potentiallyDirty = false
         lock.unlock()
         return
       }
 
-      let _outgoingEdges = outgoingEdges
-      let _trackingRegistrations = trackingRegistrations
-      trackingRegistrations.removeAll()
-
-      lock.unlock()
+      guard let invalidationWork = preparePotentiallyDirtyState() else { return }
 
       // Notify observers when becoming potentially dirty, even if the computed value
       // might not actually change. This is necessary for SwiftUI and other Observation
@@ -213,15 +212,31 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
       }
 #endif
 
-      for edge in _outgoingEdges {
+      for edge in invalidationWork.outgoingEdges {
         edge.to?.potentiallyDirty = true
       }
 
-      for registration in _trackingRegistrations {
+      for registration in invalidationWork.trackingRegistrations {
         registration.perform()
       }
             
     }
+  }
+
+  /// Marks this node dirty and captures callbacks while holding only its node lock.
+  private func preparePotentiallyDirtyState() -> InvalidationWork? {
+    lock.lock()
+    defer { lock.unlock() }
+
+    guard !_potentiallyDirty else { return nil }
+    _potentiallyDirty = true
+
+    let work = InvalidationWork(
+      outgoingEdges: outgoingEdges,
+      trackingRegistrations: trackingRegistrations
+    )
+    trackingRegistrations.removeAll()
+    return work
   }
 
   nonisolated(unsafe)
@@ -231,21 +246,51 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
 
   public var wrappedValue: Value {
     get {
-#if canImport(Observation)
-      if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-        observationRegistrar.access(
-          NodeObservationRoot<Computed<Value>>(),
-          keyPath: \NodeObservationRoot<Computed<Value>>.wrappedValue
-        )
+      if ThreadLocal.graphTransaction.value != nil {
+        return transactionValue()
       }
+
+      return GraphTransactionCoordinator.shared.withReadAccess {
+        committedValue()
+      }
+    }
+  }
+
+  /// Evaluates this node from the transaction's staged `Stored` values without
+  /// changing the committed cache or dependency graph.
+  ///
+  /// A transaction intentionally does not cache `Computed` results. Every read is
+  /// reevaluated so a later staged assignment is immediately visible, while rollback
+  /// cannot leave a transaction-only value or edge in the committed graph.
+  private func transactionValue() -> Value {
+    ThreadLocal.currentNode.withValue(nil) {
+      if ThreadLocal.graphTransaction.value?.recordsDependencies == true {
+        var context = Context(environment: .init())
+        return descriptor.compute(context: &context)
+      }
+
+      return ThreadLocal.registration.withValue(nil) {
+        var context = Context(environment: .init())
+        return descriptor.compute(context: &context)
+      }
+    }
+  }
+
+  private func committedValue() -> Value {
+#if canImport(Observation)
+    if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+      observationRegistrar.access(
+        NodeObservationRoot<Computed<Value>>(),
+        keyPath: \NodeObservationRoot<Computed<Value>>.wrappedValue
+      )
+    }
 #endif
 
-      recomputeIfNeeded()
+    recomputeIfNeededWithinReadAccess()
 
-      lock.lock()
-      defer { lock.unlock() }
-      return _cachedValue!
-    }
+    lock.lock()
+    defer { lock.unlock() }
+    return _cachedValue!
   }
 
   private let descriptor: any ComputedDescriptor<Value>
@@ -377,7 +422,19 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
   }
 
   public func recomputeIfNeeded() {
+    guard ThreadLocal.graphTransaction.value == nil else {
+      // Transaction reads intentionally evaluate without changing committed cache
+      // state or dependency edges.
+      return
+    }
 
+    GraphTransactionCoordinator.shared.withReadAccess {
+      recomputeIfNeededWithinReadAccess()
+    }
+  }
+
+  /// Recomputes while the caller owns one committed-graph read scope.
+  private func recomputeIfNeededWithinReadAccess() {
     lock.lock()
     defer { lock.unlock() }
 
@@ -457,6 +514,58 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
     return "Computed<\(Value.self)>(name=\(info.name.map(String.init) ?? "noname"), value=\(String(describing: cachedValue)))"
   }
   
+}
+
+extension Computed: GraphTransactionInvalidatableNode {
+
+  /// Delivers Observation's existing pre-mutation notification without making the
+  /// committed cache dirty before publication.
+  func prepareGraphTransactionObservationWillSet(
+    _ observationDelivery: GraphTransactionObservationDelivery
+  ) {
+    lock.lock()
+    guard !_potentiallyDirty else {
+      lock.unlock()
+      return
+    }
+    let outgoingEdges = self.outgoingEdges
+    lock.unlock()
+
+#if canImport(Observation)
+    if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+      observationDelivery.append { [observationRegistrar] in
+        withMainActor {
+          observationRegistrar.willSet(
+            NodeObservationRoot<Computed<Value>>(),
+            keyPath: \NodeObservationRoot<Computed<Value>>.wrappedValue
+          )
+        }
+      }
+    }
+#endif
+
+    for edge in outgoingEdges {
+      observationDelivery.prepareWillSet(for: edge)
+    }
+  }
+
+  /// Marks the committed cache dirty while deferring graph-tracking callbacks until
+  /// after transaction publication releases its global read barrier.
+  func prepareGraphTransactionInvalidation(
+    _ callbackDelivery: GraphTransactionCallbackDelivery
+  ) {
+    guard let invalidationWork = preparePotentiallyDirtyState() else { return }
+
+    for edge in invalidationWork.outgoingEdges {
+      callbackDelivery.prepareInvalidation(for: edge)
+    }
+
+    for registration in invalidationWork.trackingRegistrations {
+      callbackDelivery.append {
+        registration.perform()
+      }
+    }
+  }
 }
 
 extension Computed {

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -521,7 +521,7 @@ extension Computed: GraphTransactionInvalidatableNode {
   /// Delivers Observation's existing pre-mutation notification without making the
   /// committed cache dirty before publication.
   func prepareGraphTransactionObservationWillSet(
-    _ observationDelivery: GraphTransactionObservationDelivery
+    _ observationWillSetDelivery: GraphTransactionObservationWillSetDelivery
   ) {
     lock.lock()
     guard !_potentiallyDirty else {
@@ -533,7 +533,7 @@ extension Computed: GraphTransactionInvalidatableNode {
 
 #if canImport(Observation)
     if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-      observationDelivery.append { [observationRegistrar] in
+      observationWillSetDelivery.appendWillSetOperation { [observationRegistrar] in
         withMainActor {
           observationRegistrar.willSet(
             NodeObservationRoot<Computed<Value>>(),
@@ -545,7 +545,7 @@ extension Computed: GraphTransactionInvalidatableNode {
 #endif
 
     for edge in outgoingEdges {
-      observationDelivery.prepareWillSet(for: edge)
+      observationWillSetDelivery.prepareWillSet(for: edge)
     }
   }
 

--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -19,6 +19,57 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   nonisolated(unsafe)
   private var value: Value
 
+  /// A typed staged value owned directly by this node during an outer graph transaction.
+  ///
+  /// The wrapper is deliberately not a reference box. `Stored` values are copyable today,
+  /// but keeping the wrapper noncopyable makes its single owner explicit and lets commit
+  /// consume the staged storage before publishing.
+  private struct TransactionBuffer<Element>: ~Copyable {
+    var value: Element
+
+    init(_ value: consuming Element) {
+      self.value = value
+    }
+
+    consuming func takeValue() -> Element {
+      value
+    }
+  }
+
+  /// Typed commit state moved out of the staging buffer before publication.
+  ///
+  /// Comparators evaluate this pending `(old, new)` pair while outside readers may
+  /// still access the old committed graph. Publication later installs `newValue`
+  /// and fills in the callback work under the short read barrier.
+  private struct TransactionCommitWork {
+    let oldValue: Value
+    let newValue: Value
+    var shouldNotify = false
+    var trackingRegistrations: Set<TrackingRegistration> = []
+    var outgoingEdges: ContiguousArray<Edge> = []
+    var didSetHandler: ((Value, Value) -> Void)?
+  }
+
+  nonisolated(unsafe)
+  private var transactionBuffer: TransactionBuffer<Value>?
+
+  /// A typed value detached from a particular transaction during rollback.
+  ///
+  /// Multiple cleanup operations may overlap after their writer slots are released,
+  /// so context identity keeps their node-local values distinct without moving them
+  /// into the type-erased transaction context.
+  private struct TransactionRollbackValue {
+    let context: ObjectIdentifier
+    let value: Value
+  }
+
+  /// Rolled-back values waiting to be destroyed outside writer coordination.
+  nonisolated(unsafe)
+  private var transactionRollbackValues: [TransactionRollbackValue] = []
+
+  nonisolated(unsafe)
+  private var transactionCommitWork: TransactionCommitWork?
+
   private let shouldNotify: @Sendable (Value, Value) -> Bool
 
 #if canImport(Observation)
@@ -39,81 +90,353 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
 
   public var wrappedValue: Value {
     get {
+      if ThreadLocal.graphTransaction.value != nil {
+        return transactionValue()
+      }
+
+      return GraphTransactionCoordinator.shared.withReadAccess {
+        committedValue()
+      }
+    }
+    set {
+      if let transaction = ThreadLocal.graphTransaction.value {
+        stage(newValue, in: transaction)
+        return
+      }
+
+      GraphTransactionCoordinator.shared.withImmediateWrite {
+        setImmediately(newValue)
+      }
+    }
+  }
+
+  /// Returns the transaction-visible value without adding committed graph edges.
+  ///
+  /// Body and comparator reads remain isolated. During synchronous callback delivery,
+  /// Observation and graph-tracking passes may register directly with this leaf node.
+  private func transactionValue() -> Value {
+    let recordsDependencies =
+      ThreadLocal.graphTransaction.value?.recordsDependencies == true
+
 #if canImport(Observation)
-      if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-        observationRegistrar.access(
+    if recordsDependencies,
+      #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    {
+      observationRegistrar.access(
+        NodeObservationRoot<Stored<Value>>(),
+        keyPath: \NodeObservationRoot<Stored<Value>>.wrappedValue
+      )
+    }
+#endif
+
+    lock.lock()
+    defer { lock.unlock() }
+
+    if recordsDependencies, let registration = ThreadLocal.registration.value {
+      trackingRegistrations.insert(registration)
+    }
+
+    if transactionBuffer != nil {
+      return transactionBuffer!.value
+    }
+
+    // Comparators run before publication. Their thread-local transaction context
+    // still reads the complete pending commit while outside readers see `value`.
+    if let transactionCommitWork {
+      return transactionCommitWork.newValue
+    }
+
+    return value
+  }
+
+  /// Returns the committed value and records ordinary graph and tracking dependencies.
+  private func committedValue() -> Value {
+#if canImport(Observation)
+    if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+      observationRegistrar.access(
+        NodeObservationRoot<Stored<Value>>(),
+        keyPath: \NodeObservationRoot<Stored<Value>>.wrappedValue
+      )
+    }
+#endif
+
+    lock.lock()
+    defer { lock.unlock() }
+
+    if let currentNode = ThreadLocal.currentNode.value {
+      let edge = Edge(from: self, to: currentNode)
+      outgoingEdges.append(edge)
+      currentNode.incomingEdges.append(edge)
+    }
+
+    if let registration = ThreadLocal.registration.value {
+      trackingRegistrations.insert(registration)
+    }
+
+    return value
+  }
+
+  /// Stages an assignment in this node's typed transaction buffer.
+  private func stage(_ newValue: Value, in transaction: GraphTransactionContext) {
+    lock.lock()
+    let needsRegistration = transactionBuffer == nil
+    let discardedBuffer = transactionBuffer.take()
+    transactionBuffer = .init(newValue)
+    lock.unlock()
+
+    if needsRegistration {
+      transaction.register(self)
+    }
+
+    Self.discardTransactionBuffer(discardedBuffer)
+  }
+
+  /// Ends a staged value's lifetime outside the node lock.
+  private static func discardTransactionBuffer(
+    _ buffer: consuming TransactionBuffer<Value>?
+  ) {
+    _ = consume buffer
+  }
+
+  /// Runs the existing immediate assignment pipeline after writer coordination.
+  private func setImmediately(_ newValue: Value) {
+    guard let immediateWriterScope = ThreadLocal.graphImmediateWriterScope.value else {
+      preconditionFailure("Stored immediate mutation requires graph writer coordination.")
+    }
+
+    immediateWriterScope.nodeLockDepth += 1
+    lock.lock()
+
+    let oldValue = value
+
+    guard shouldNotify(oldValue, newValue) else {
+      value = newValue
+      let didSetHandler = self.didSetHandler
+      lock.unlock()
+      immediateWriterScope.nodeLockDepth -= 1
+      didSetHandler?(oldValue, newValue)
+      return
+    }
+
+#if canImport(Observation)
+    if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+      withMainActor { [observationRegistrar] in
+        observationRegistrar.willSet(
           NodeObservationRoot<Stored<Value>>(),
           keyPath: \NodeObservationRoot<Stored<Value>>.wrappedValue
         )
       }
+    }
+
 #endif
 
-      lock.lock()
-      defer { lock.unlock() }
+    value = newValue
 
-      if let currentNode = ThreadLocal.currentNode.value {
-        let edge = Edge(from: self, to: currentNode)
-        outgoingEdges.append(edge)
-        currentNode.incomingEdges.append(edge)
-      }
+    let outgoingEdges = self.outgoingEdges
+    let trackingRegistrations = self.trackingRegistrations
+    let didSetHandler = self.didSetHandler
+    self.trackingRegistrations.removeAll()
 
-      if let registration = ThreadLocal.registration.value {
-        trackingRegistrations.insert(registration)
-      }
+    lock.unlock()
+    immediateWriterScope.nodeLockDepth -= 1
 
-      return value
-    }
-    set {
-      lock.lock()
+    Self.publishGraphUpdates(
+      trackingRegistrations: trackingRegistrations,
+      outgoingEdges: outgoingEdges
+    )
 
-      let oldValue = value
-
-      guard shouldNotify(oldValue, newValue) else {
-        value = newValue
-        let didSetHandler = self.didSetHandler
-        lock.unlock()
-        didSetHandler?(oldValue, newValue)
-        return
-      }
+    didSetHandler?(oldValue, newValue)
 
 #if canImport(Observation)
-      if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-        withMainActor { [observationRegistrar] in
+    if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+      withMainActor { [observationRegistrar] in
+        observationRegistrar.didSet(
+          NodeObservationRoot<Stored<Value>>(),
+          keyPath: \NodeObservationRoot<Stored<Value>>.wrappedValue
+        )
+      }
+    }
+#endif
+  }
+
+  func prepareTransactionCommit() {
+    lock.lock()
+    guard let transactionBuffer = self.transactionBuffer.take() else {
+      lock.unlock()
+      return
+    }
+
+    let oldValue = value
+    let newValue = transactionBuffer.takeValue()
+    transactionCommitWork = .init(
+      oldValue: oldValue,
+      newValue: newValue
+    )
+
+    lock.unlock()
+  }
+
+  func evaluateTransactionComparator() {
+    lock.lock()
+    guard let installedWork = transactionCommitWork else {
+      lock.unlock()
+      return
+    }
+    lock.unlock()
+
+    // Every participant has moved its final value into node-local commit work.
+    // Reentrant assignments see that coherent pending graph and stage into the
+    // following commit batch.
+    let shouldNotify = shouldNotify(
+      installedWork.oldValue,
+      installedWork.newValue
+    )
+
+    lock.lock()
+    guard var transactionCommitWork else {
+      lock.unlock()
+      return
+    }
+    transactionCommitWork.shouldNotify = shouldNotify
+    self.transactionCommitWork = transactionCommitWork
+    lock.unlock()
+  }
+
+  func prepareTransactionObservationWillSet(
+    _ observationDelivery: GraphTransactionObservationDelivery
+  ) {
+    lock.lock()
+    guard transactionCommitWork?.shouldNotify == true else {
+      lock.unlock()
+      return
+    }
+    let outgoingEdges = self.outgoingEdges
+    lock.unlock()
+
+#if canImport(Observation)
+    if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+      observationDelivery.append { [observationRegistrar] in
+        withMainActor {
           observationRegistrar.willSet(
             NodeObservationRoot<Stored<Value>>(),
             keyPath: \NodeObservationRoot<Stored<Value>>.wrappedValue
           )
         }
       }
-
-      defer {
-        if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-          withMainActor { [observationRegistrar] in
-            observationRegistrar.didSet(
-              NodeObservationRoot<Stored<Value>>(),
-              keyPath: \NodeObservationRoot<Stored<Value>>.wrappedValue
-            )
-          }
-        }
-      }
+    }
 #endif
 
-      value = newValue
-
-      let outgoingEdges = self.outgoingEdges
-      let trackingRegistrations = self.trackingRegistrations
-      let didSetHandler = self.didSetHandler
-      self.trackingRegistrations.removeAll()
-
-      lock.unlock()
-
-      Self.publishGraphUpdates(
-        trackingRegistrations: trackingRegistrations,
-        outgoingEdges: outgoingEdges
-      )
-
-      didSetHandler?(oldValue, newValue)
+    for edge in outgoingEdges {
+      observationDelivery.prepareWillSet(for: edge)
     }
+  }
+
+  func publishTransactionCommit() {
+    lock.lock()
+    guard var transactionCommitWork else {
+      lock.unlock()
+      return
+    }
+
+    value = transactionCommitWork.newValue
+    transactionCommitWork.didSetHandler = didSetHandler
+    self.transactionCommitWork = transactionCommitWork
+    lock.unlock()
+  }
+
+  func prepareTransactionInvalidations(
+    _ callbackDelivery: GraphTransactionCallbackDelivery
+  ) {
+    lock.lock()
+    guard var transactionCommitWork else {
+      lock.unlock()
+      return
+    }
+
+    if transactionCommitWork.shouldNotify {
+      transactionCommitWork.trackingRegistrations = trackingRegistrations
+      transactionCommitWork.outgoingEdges = outgoingEdges
+      trackingRegistrations.removeAll()
+      self.transactionCommitWork = transactionCommitWork
+    }
+    lock.unlock()
+
+    if transactionCommitWork.shouldNotify {
+      for registration in transactionCommitWork.trackingRegistrations {
+        callbackDelivery.append {
+          registration.perform()
+        }
+      }
+
+      for edge in transactionCommitWork.outgoingEdges {
+        callbackDelivery.prepareInvalidation(for: edge)
+      }
+    }
+  }
+
+  func deliverTransactionCallbacks() {
+    lock.lock()
+    guard let transactionCommitWork = self.transactionCommitWork.take() else {
+      lock.unlock()
+      return
+    }
+    lock.unlock()
+
+    transactionCommitWork.didSetHandler?(
+      transactionCommitWork.oldValue,
+      transactionCommitWork.newValue
+    )
+
+#if canImport(Observation)
+    if transactionCommitWork.shouldNotify,
+      #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    {
+      withMainActor { [observationRegistrar] in
+        observationRegistrar.didSet(
+          NodeObservationRoot<Stored<Value>>(),
+          keyPath: \NodeObservationRoot<Stored<Value>>.wrappedValue
+        )
+      }
+    }
+#endif
+  }
+
+  func prepareTransactionRollback(_ transaction: GraphTransactionContext) {
+    lock.lock()
+    guard let transactionBuffer = transactionBuffer.take() else {
+      lock.unlock()
+      return
+    }
+    transactionRollbackValues.append(
+      .init(
+        context: ObjectIdentifier(transaction),
+        value: transactionBuffer.takeValue()
+      )
+    )
+    lock.unlock()
+  }
+
+  func finishTransactionRollback(_ transaction: GraphTransactionContext) {
+    let context = ObjectIdentifier(transaction)
+
+    lock.lock()
+    guard
+      let index = transactionRollbackValues.lastIndex(
+        where: { $0.context == context }
+      )
+    else {
+      lock.unlock()
+      return
+    }
+    let rollbackValue = transactionRollbackValues.remove(at: index)
+    lock.unlock()
+
+    Self.discardTransactionValue(rollbackValue.value)
+  }
+
+  /// Ends a rolled-back value's lifetime outside node and coordinator locks.
+  private static func discardTransactionValue(_ value: consuming Value) {
+    _ = consume value
   }
 
   /// Publishes graph invalidations captured while the node lock was held.
@@ -192,9 +515,11 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   }
 
   public var debugDescription: String {
-    lock.lock()
-    let value = self.value
-    lock.unlock()
+    let value = GraphTransactionCoordinator.shared.withReadAccess {
+      lock.lock()
+      defer { lock.unlock() }
+      return self.value
+    }
 
     let typeName = _typeName(type(of: self))
     return "\(typeName)(name=\(info.name.map(String.init) ?? "noname"), value=\(String(describing: value)))"
@@ -209,15 +534,35 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   /// - Important: The mutation executes while the same lock that protects graph
   ///   bookkeeping is held. Calling node APIs or acquiring another node's lock from
   ///   `mutation` is unsupported and can introduce lock-order deadlocks.
+  /// - Important: This method mutates committed storage even inside
+  ///   ``withGraphTransaction(_:_:_:_:)``. The transaction does not stage or roll
+  ///   back the mutation.
   ///
   /// Prefer assigning `wrappedValue`. Use this method only when the caller owns the
   /// lock ordering and intentionally does not require notifications.
   public borrowing func unsafeModify<Result, E>(
     _ mutation: (inout Value) throws(E) -> Result
   ) throws(E) -> Result where E: Error {
-    lock.lock()
-    defer { lock.unlock() }
-    return try mutation(&value)
+    if ThreadLocal.graphTransaction.value != nil {
+      lock.lock()
+      defer { lock.unlock() }
+      return try mutation(&value)
+    }
+
+    return try GraphTransactionCoordinator.shared.withImmediateWrite {
+      () throws(E) -> Result in
+      guard let immediateWriterScope = ThreadLocal.graphImmediateWriterScope.value else {
+        preconditionFailure("Stored unsafe mutation requires graph writer coordination.")
+      }
+
+      immediateWriterScope.nodeLockDepth += 1
+      lock.lock()
+      defer {
+        lock.unlock()
+        immediateWriterScope.nodeLockDepth -= 1
+      }
+      return try mutation(&value)
+    }
   }
 
   /// Use `unsafeModify(_:)`; its name makes the notification and locking risks explicit.
@@ -235,6 +580,8 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     didSetHandler = handler
   }
 }
+
+extension Stored: GraphTransactionParticipant {}
 
 extension Stored {
 

--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -40,14 +40,13 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   ///
   /// Comparators evaluate this pending `(old, new)` pair while outside readers may
   /// still access the old committed graph. Publication later installs `newValue`
-  /// and fills in the callback work under the short read barrier.
+  /// and captures graph invalidation work under the short read barrier.
   private struct TransactionCommitWork {
     let oldValue: Value
     let newValue: Value
     var shouldNotify = false
     var trackingRegistrations: Set<TrackingRegistration> = []
     var outgoingEdges: ContiguousArray<Edge> = []
-    var didSetHandler: ((Value, Value) -> Void)?
   }
 
   nonisolated(unsafe)
@@ -176,12 +175,32 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     return value
   }
 
-  /// Stages an assignment in this node's typed transaction buffer.
+  /// Stages one assignment and then runs its assignment observer.
+  ///
+  /// `onDidSet(_:)` has the same per-assignment semantics inside and outside a
+  /// transaction. The buffer is installed before the handler runs, so handler reads
+  /// observe `newValue` and any `Stored` assignments it makes join the same ambient
+  /// transaction. A later rollback discards all of those staged assignments, but it
+  /// cannot undo non-`Stored` side effects already performed by the handler.
   private func stage(_ newValue: Value, in transaction: GraphTransactionContext) {
     lock.lock()
+
+    let oldValue: Value
+    if transactionBuffer != nil {
+      oldValue = transactionBuffer!.value
+    } else if let transactionCommitWork {
+      // A synchronous Observation callback may assign while the preceding batch is
+      // still being delivered. Its transaction-visible old value is that batch's
+      // pending value, even when publication has not installed it yet.
+      oldValue = transactionCommitWork.newValue
+    } else {
+      oldValue = value
+    }
+
     let needsRegistration = transactionBuffer == nil
     let discardedBuffer = transactionBuffer.take()
     transactionBuffer = .init(newValue)
+    let didSetHandler = self.didSetHandler
     lock.unlock()
 
     if needsRegistration {
@@ -189,6 +208,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     }
 
     Self.discardTransactionBuffer(discardedBuffer)
+    didSetHandler?(oldValue, newValue)
   }
 
   /// Ends a staged value's lifetime outside the node lock.
@@ -333,14 +353,12 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
 
   func publishTransactionCommit() {
     lock.lock()
-    guard var transactionCommitWork else {
+    guard let transactionCommitWork else {
       lock.unlock()
       return
     }
 
     value = transactionCommitWork.newValue
-    transactionCommitWork.didSetHandler = didSetHandler
-    self.transactionCommitWork = transactionCommitWork
     lock.unlock()
   }
 
@@ -374,18 +392,13 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     }
   }
 
-  func deliverTransactionCallbacks() {
+  func deliverTransactionObservationDidSet() {
     lock.lock()
     guard let transactionCommitWork = self.transactionCommitWork.take() else {
       lock.unlock()
       return
     }
     lock.unlock()
-
-    transactionCommitWork.didSetHandler?(
-      transactionCommitWork.oldValue,
-      transactionCommitWork.newValue
-    )
 
 #if canImport(Observation)
     if transactionCommitWork.shouldNotify,
@@ -573,7 +586,18 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     try unsafeModify(body)
   }
 
-  /// Sets a closure to call after an assignment completes.
+  /// Sets the closure invoked after each assignment completes.
+  ///
+  /// The handler runs synchronously after the new value becomes readable and after
+  /// the node lock is released. It runs for every assignment, including assignments
+  /// that the node's comparator considers equivalent.
+  ///
+  /// Inside ``withGraphTransaction(_:_:_:_:)``, the assigned value is staged before
+  /// the handler runs. Reads made by the handler observe that staged value, and any
+  /// ordinary `Stored` assignments made by the handler join the same transaction.
+  /// Those assignments are discarded if the outer transaction rolls back. The
+  /// handler itself is not deferred, so rollback cannot undo its non-`Stored` side
+  /// effects.
   public func onDidSet(_ handler: @escaping (Value, Value) -> Void) {
     lock.lock()
     defer { lock.unlock() }

--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -303,7 +303,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   }
 
   func prepareTransactionObservationWillSet(
-    _ observationDelivery: GraphTransactionObservationDelivery
+    _ observationWillSetDelivery: GraphTransactionObservationWillSetDelivery
   ) {
     lock.lock()
     guard transactionCommitWork?.shouldNotify == true else {
@@ -315,7 +315,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
 
 #if canImport(Observation)
     if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
-      observationDelivery.append { [observationRegistrar] in
+      observationWillSetDelivery.appendWillSetOperation { [observationRegistrar] in
         withMainActor {
           observationRegistrar.willSet(
             NodeObservationRoot<Stored<Value>>(),
@@ -327,7 +327,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
 #endif
 
     for edge in outgoingEdges {
-      observationDelivery.prepareWillSet(for: edge)
+      observationWillSetDelivery.prepareWillSet(for: edge)
     }
   }
 

--- a/Sources/StateGraph/ThreadLocal.swift
+++ b/Sources/StateGraph/ThreadLocal.swift
@@ -15,19 +15,32 @@ struct ThreadLocalValue<Value>: ~Copyable, Sendable {
     self.key = key
   }
 
-  func withValue<R>(_ value: Value?, perform: () throws -> R) rethrows -> R {
-    let oldValue = Thread.current.threadDictionary[key]
+  /// Replaces the current value and returns the value that was installed before it.
+  ///
+  /// The typed-throws transaction entry point uses this primitive instead of a
+  /// throwing closure wrapper so its failure type remains unchanged.
+  @discardableResult
+  func replaceValue(_ value: Value?) -> Value? {
+    let oldValue = self.value
+    setValue(value)
+    return oldValue
+  }
+
+  private func setValue(_ value: Value?) {
     if let value {
       Thread.current.threadDictionary[key] = value
     } else {
       Thread.current.threadDictionary.removeObject(forKey: key)
     }
+  }
+
+  func withValue<R, Failure: Error>(
+    _ value: Value?,
+    perform: () throws(Failure) -> R
+  ) throws(Failure) -> R {
+    let oldValue = replaceValue(value)
     defer {
-      if let oldValue {
-        Thread.current.threadDictionary[key] = oldValue
-      } else {
-        Thread.current.threadDictionary.removeObject(forKey: key)
-      }
+      replaceValue(oldValue)
     }
     return try perform()
   }
@@ -40,5 +53,8 @@ enum ThreadLocal: Sendable {
   static let subscriptions: ThreadLocalValue<Subscriptions> = .init(key: "org.vergegroup.state-graph.subscriptions")
   static let currentNode: ThreadLocalValue<any TypeErasedNode> = .init(key: "org.vergegroup.state-graph.currentNode")
   static let currentCancellable: ThreadLocalValue<GraphTrackingCancellable> = .init(key: "org.vergegroup.state-graph.currentCancellable")
+  static let graphTransaction: ThreadLocalValue<GraphTransactionContext> = .init(key: "org.vergegroup.state-graph.transaction")
+  static let graphTransactionReadScope: ThreadLocalValue<GraphTransactionReadScope> = .init(key: "org.vergegroup.state-graph.transaction-read-scope")
+  static let graphImmediateWriterScope: ThreadLocalValue<GraphImmediateWriterScope> = .init(key: "org.vergegroup.state-graph.immediate-writer-scope")
 
 }

--- a/Tests/StateGraphTests/GraphStoredDidSetTests.swift
+++ b/Tests/StateGraphTests/GraphStoredDidSetTests.swift
@@ -50,6 +50,74 @@ struct GraphStoredDidSetTests {
     #expect(model.history[0].1 == 12)
   }
 
+  @Test func didSet_stored_mutation_joins_transaction_and_rolls_back() {
+    enum TestError: Error {
+      case rollback
+    }
+
+    final class Model {
+      @GraphStored
+      var source: Int = 0 {
+        didSet {
+          derived += source - oldValue
+        }
+      }
+
+      @GraphStored
+      var derived: Int = 0
+    }
+
+    let model = Model()
+    var didRollBack = false
+
+    do {
+      try withGraphTransaction { () throws(TestError) -> Void in
+        model.source = 2
+        model.source = 5
+
+        #expect(model.source == 5)
+        #expect(model.derived == 5)
+
+        throw .rollback
+      }
+    } catch {
+      didRollBack = true
+      // Both GraphStored assignments are staged in the same transaction.
+    }
+
+    #expect(didRollBack)
+    #expect(model.source == 0)
+    #expect(model.derived == 0)
+  }
+
+  @Test func didSet_and_onDidSet_share_transaction_assignment_semantics() {
+    final class Model {
+      @GraphStored
+      var count: Int = 0 {
+        didSet {
+          propertyObserverEvents.append("\(oldValue)->\(count)")
+        }
+      }
+
+      var propertyObserverEvents: [String] = []
+    }
+
+    let model = Model()
+    var nodeObserverEvents: [String] = []
+    model.$count.onDidSet { oldValue, newValue in
+      nodeObserverEvents.append("\(oldValue)->\(newValue)")
+    }
+
+    withGraphTransaction {
+      model.count = 1
+      model.count = 1
+      model.count = 3
+    }
+
+    #expect(model.propertyObserverEvents == ["0->1", "1->1", "1->3"])
+    #expect(nodeObserverEvents == model.propertyObserverEvents)
+  }
+
   @Test func didSet_runs_with_graphUserDefault() {
     let key = "GraphStoredDidSetTests.username"
     UserDefaults.standard.removeObject(forKey: key)

--- a/Tests/StateGraphTests/GraphTrackingGroupTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingGroupTests.swift
@@ -593,6 +593,7 @@ struct ContinuousTrackingTests {
   func observation_api() async throws {
 
     let model = Model()
+    let observedChange = TestSignal()
 
     await confirmation(expectedCount: 1) { c in
 
@@ -602,12 +603,13 @@ struct ContinuousTrackingTests {
       } onChange: {
         print(model.count1, model.count2)
         c.confirm()
+        observedChange.signal()
       }
 
       model.count1 += 1
       model.count2 += 1
 
-      try? await Task.sleep(for: .milliseconds(100))
+      #expect(await observedChange.wait(for: .seconds(5)))
 
     }
   }

--- a/Tests/StateGraphTests/GraphTransactionTests.swift
+++ b/Tests/StateGraphTests/GraphTransactionTests.swift
@@ -1,0 +1,1208 @@
+import Foundation
+import Observation
+import Testing
+
+@testable import StateGraph
+
+@Suite("Graph transactions", .serialized)
+struct GraphTransactionTests {
+
+  /// The typed failure used to verify outer transaction rollback.
+  private enum TransactionError: Error {
+    case rollback
+  }
+
+  /// A small synchronized test value for callbacks and concurrent assertions.
+  private final class LockedBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value
+
+    init(_ value: Value) {
+      self.storage = value
+    }
+
+    var value: Value {
+      lock.lock()
+      defer { lock.unlock() }
+      return storage
+    }
+
+    func update(_ body: (inout Value) -> Void) {
+      lock.lock()
+      body(&storage)
+      lock.unlock()
+    }
+  }
+
+  /// Runs a supplied action when a staged reference value is destroyed.
+  private final class DeinitAction {
+    private let action: () -> Void
+
+    init(_ action: @escaping () -> Void = {}) {
+      self.action = action
+    }
+
+    deinit {
+      action()
+    }
+  }
+
+  @Test
+  func commitsMultipleStoredValuesAndReadsStagedMutations() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+      second.wrappedValue = 2
+
+      #expect(first.wrappedValue == 1)
+      #expect(second.wrappedValue == 2)
+    }
+
+    #expect(first.wrappedValue == 1)
+    #expect(second.wrappedValue == 2)
+  }
+
+  @Test
+  func graphStoredRepeatedMutationsUseTheLatestStagedValue() {
+    final class Model {
+      @GraphStored var values: [Int] = []
+    }
+
+    let model = Model()
+
+    withGraphTransaction {
+      model.values.append(1)
+      model.values.append(2)
+
+      #expect(model.values == [1, 2])
+    }
+
+    #expect(model.values == [1, 2])
+  }
+
+  @Test
+  func outsideReaderSeesCommittedValueWhileTransactionBodyIsPaused() {
+    let node = Stored(wrappedValue: 0)
+    let transactionStarted = DispatchSemaphore(value: 0)
+    let resumeTransaction = DispatchSemaphore(value: 0)
+    let transactionFinished = DispatchSemaphore(value: 0)
+
+    let thread = Thread {
+      withGraphTransaction {
+        node.wrappedValue = 1
+        transactionStarted.signal()
+        resumeTransaction.wait()
+      }
+      transactionFinished.signal()
+    }
+    thread.start()
+
+    #expect(transactionStarted.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(node.wrappedValue == 0)
+
+    resumeTransaction.signal()
+    #expect(transactionFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(node.wrappedValue == 1)
+  }
+
+  @Test
+  func outsideWriterWaitsForTransactionCompletion() {
+    let node = Stored(wrappedValue: 0)
+    let transactionStarted = DispatchSemaphore(value: 0)
+    let resumeTransaction = DispatchSemaphore(value: 0)
+    let transactionFinished = DispatchSemaphore(value: 0)
+    let writerStarted = DispatchSemaphore(value: 0)
+    let writerFinished = DispatchSemaphore(value: 0)
+
+    let transactionThread = Thread {
+      withGraphTransaction {
+        node.wrappedValue = 1
+        transactionStarted.signal()
+        resumeTransaction.wait()
+      }
+      transactionFinished.signal()
+    }
+    transactionThread.start()
+
+    #expect(transactionStarted.wait(timeout: .now() + .seconds(1)) == .success)
+
+    DispatchQueue.global().async {
+      writerStarted.signal()
+      node.wrappedValue = 2
+      writerFinished.signal()
+    }
+
+    #expect(writerStarted.wait(timeout: .now() + .seconds(1)) == .success)
+#if DEBUG
+    #expect(
+      GraphTransactionCoordinator.shared.waitForImmediateWriterToBlock(
+        until: Date().addingTimeInterval(1)
+      )
+    )
+#endif
+    #expect(writerFinished.wait(timeout: .now()) == .timedOut)
+
+    resumeTransaction.signal()
+    #expect(transactionFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(writerFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(node.wrappedValue == 2)
+  }
+
+  @Test
+  func thrownTransactionRollsBackWithoutNotificationsOrInvalidation() {
+    let source = Stored(wrappedValue: 0)
+    let computed = Computed { _ in source.wrappedValue * 2 }
+    let didSetCount = LockedBox(0)
+    let trackingCallbackCount = LockedBox(0)
+    let observationCallbackCount = LockedBox(0)
+
+    source.onDidSet { _, _ in
+      didSetCount.update { $0 += 1 }
+    }
+
+    let registration = TrackingRegistration(
+      didChange: {
+        trackingCallbackCount.update { $0 += 1 }
+      },
+      isolation: nil
+    )
+    ThreadLocal.registration.withValue(registration) {
+      _ = source.wrappedValue
+    }
+
+    withObservationTracking {
+      _ = source.wrappedValue
+    } onChange: {
+      observationCallbackCount.update { $0 += 1 }
+    }
+
+    #expect(computed.wrappedValue == 0)
+
+    var didRollBack = false
+    do {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        source.wrappedValue = 1
+        throw .rollback
+      }
+    } catch {
+      didRollBack = true
+    }
+
+    #expect(didRollBack)
+
+    #expect(source.wrappedValue == 0)
+    #expect(computed.wrappedValue == 0)
+    #expect(didSetCount.value == 0)
+    #expect(trackingCallbackCount.value == 0)
+    #expect(observationCallbackCount.value == 0)
+  }
+
+  @Test
+  func rollbackDestroysStagedReferencesAfterReleasingWriterCoordination() {
+    let committedValue = DeinitAction()
+    let source = Stored(wrappedValue: committedValue)
+    let sideEffect = Stored(wrappedValue: 0)
+
+    do {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        source.wrappedValue = DeinitAction {
+          sideEffect.wrappedValue = 1
+        }
+        throw .rollback
+      }
+    } catch {
+      // The staged reference is destroyed during rollback.
+    }
+
+    #expect(source.wrappedValue === committedValue)
+    #expect(sideEffect.wrappedValue == 1)
+  }
+
+  @Test
+  func overlappingRollbacksKeepEachContextsTypedValuesDistinct() {
+    let first = Stored(wrappedValue: DeinitAction())
+    let second = Stored(wrappedValue: DeinitAction())
+    let firstCleanupStarted = DispatchSemaphore(value: 0)
+    let resumeFirstCleanup = DispatchSemaphore(value: 0)
+    let outerFinished = DispatchSemaphore(value: 0)
+    let innerFinished = DispatchSemaphore(value: 0)
+    let outerSecondCleanupCount = LockedBox(0)
+    let innerCleanupCount = LockedBox(0)
+
+    Thread {
+      do {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          first.wrappedValue = DeinitAction {
+            firstCleanupStarted.signal()
+            _ = resumeFirstCleanup.wait(
+              timeout: .now() + .seconds(2)
+            )
+          }
+          second.wrappedValue = DeinitAction {
+            outerSecondCleanupCount.update { $0 += 1 }
+          }
+          throw .rollback
+        }
+      } catch {
+        // The staged values are destroyed by rollback cleanup.
+      }
+      outerFinished.signal()
+    }.start()
+
+    #expect(
+      firstCleanupStarted.wait(timeout: .now() + .seconds(1)) == .success
+    )
+
+    Thread {
+      do {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          second.wrappedValue = DeinitAction {
+            innerCleanupCount.update { $0 += 1 }
+          }
+          throw .rollback
+        }
+      } catch {
+        // This rollback overlaps the first transaction's deferred cleanup.
+      }
+      innerFinished.signal()
+    }.start()
+
+    #expect(innerFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(innerCleanupCount.value == 1)
+    #expect(outerSecondCleanupCount.value == 0)
+
+    resumeFirstCleanup.signal()
+    #expect(outerFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(outerSecondCleanupCount.value == 1)
+  }
+
+  @Test
+  func replacingAStagedReferenceDestroysItOutsideTheNodeLock() {
+    let replacementFromDeinit = DeinitAction()
+    let source = Stored(wrappedValue: DeinitAction())
+    let didReenter = LockedBox(false)
+
+    withGraphTransaction {
+      source.wrappedValue = DeinitAction { [weak source] in
+        didReenter.update { $0 = true }
+        source?.wrappedValue = replacementFromDeinit
+      }
+      source.wrappedValue = DeinitAction()
+    }
+
+    #expect(didReenter.value)
+    #expect(source.wrappedValue === replacementFromDeinit)
+  }
+
+  @Test
+  func commitDefersCallbacksUntilTheTransactionBodyReturns() {
+    let source = Stored(wrappedValue: 0)
+    let didSetCount = LockedBox(0)
+    let trackingCallbackCount = LockedBox(0)
+    let observationCallbackCount = LockedBox(0)
+    let trackingDelivered = DispatchSemaphore(value: 0)
+    let observationDelivered = DispatchSemaphore(value: 0)
+
+    source.onDidSet { _, _ in
+      didSetCount.update { $0 += 1 }
+    }
+
+    let registration = TrackingRegistration(
+      didChange: {
+        trackingCallbackCount.update { $0 += 1 }
+        trackingDelivered.signal()
+      },
+      isolation: nil
+    )
+    ThreadLocal.registration.withValue(registration) {
+      _ = source.wrappedValue
+    }
+
+    withObservationTracking {
+      _ = source.wrappedValue
+    } onChange: {
+      observationCallbackCount.update { $0 += 1 }
+      observationDelivered.signal()
+    }
+
+    withGraphTransaction {
+      source.wrappedValue = 1
+
+      #expect(didSetCount.value == 0)
+      #expect(trackingCallbackCount.value == 0)
+      #expect(observationCallbackCount.value == 0)
+    }
+
+    #expect(source.wrappedValue == 1)
+    #expect(didSetCount.value == 1)
+    #expect(trackingDelivered.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(trackingCallbackCount.value == 1)
+    #expect(observationDelivered.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(observationCallbackCount.value == 1)
+  }
+
+  @Test
+  @MainActor
+  func rollbackPreservesExistingObservationAndTrackingRegistrations() async {
+    let source = Stored(wrappedValue: 0)
+    let trackingCount = LockedBox(0)
+    let observationCount = LockedBox(0)
+    let trackingDelivered = TestSignal()
+    let observationDelivered = TestSignal()
+
+    let registration = TrackingRegistration(
+      didChange: {
+        trackingCount.update { $0 += 1 }
+        trackingDelivered.signal()
+      },
+      isolation: nil
+    )
+    ThreadLocal.registration.withValue(registration) {
+      _ = source.wrappedValue
+    }
+
+    withObservationTracking {
+      _ = source.wrappedValue
+    } onChange: {
+      observationCount.update { $0 += 1 }
+      observationDelivered.signal()
+    }
+
+    #expect(throws: TransactionError.self) {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        source.wrappedValue = 1
+        throw .rollback
+      }
+    }
+
+    source.wrappedValue = 2
+
+    #expect(await trackingDelivered.wait(for: .seconds(5)))
+    #expect(await observationDelivered.wait(for: .seconds(5)))
+    #expect(trackingCount.value == 1)
+    #expect(observationCount.value == 1)
+  }
+
+  @Test
+  @MainActor
+  func transactionReadsDoNotCreateObservationOrTrackingRegistrations() {
+    let source = Stored(wrappedValue: 0)
+    let trackingCount = LockedBox(0)
+    let observationCount = LockedBox(0)
+    let registration = TrackingRegistration(
+      didChange: {
+        trackingCount.update { $0 += 1 }
+      },
+      isolation: nil
+    )
+
+    ThreadLocal.registration.withValue(registration) {
+      withGraphTransaction {
+        _ = source.wrappedValue
+      }
+    }
+
+    withObservationTracking {
+      withGraphTransaction {
+        _ = source.wrappedValue
+      }
+    } onChange: {
+      observationCount.update { $0 += 1 }
+    }
+
+    source.wrappedValue = 1
+
+    #expect(trackingCount.value == 0)
+    #expect(observationCount.value == 0)
+  }
+
+  @Test
+  @MainActor
+  func continuousGraphTrackingReregistersAfterTransactionCallbacks() async {
+    let source = Stored(wrappedValue: 0)
+    let observedValues = LockedBox<[Int]>([])
+    let observedOne = TestSignal()
+    let observedTwo = TestSignal()
+    let cancellable = withGraphTracking {
+      withGraphTrackingMap(
+        { source.wrappedValue },
+        onChange: { value in
+          observedValues.update { $0.append(value) }
+          if value == 1 {
+            observedOne.signal()
+          } else if value == 2 {
+            observedTwo.signal()
+          }
+        }
+      )
+    }
+    defer { cancellable.cancel() }
+
+    withGraphTransaction {
+      source.wrappedValue = 1
+    }
+
+    #expect(await observedOne.wait(for: .seconds(5)))
+    source.wrappedValue = 2
+
+    #expect(await observedTwo.wait(for: .seconds(5)))
+    #expect(observedValues.value == [0, 1, 2])
+  }
+
+  @Test
+  func multipleWritesCommitOnlyTheFinalValueWithTheExistingComparator() {
+    let node = Stored(wrappedValue: 0)
+    var didSetValues: [(Int, Int)] = []
+
+    node.onDidSet { oldValue, newValue in
+      didSetValues.append((oldValue, newValue))
+    }
+
+    withGraphTransaction {
+      node.wrappedValue = 1
+      node.wrappedValue = 2
+      node.wrappedValue = 2
+    }
+
+    #expect(node.wrappedValue == 2)
+    #expect(didSetValues.count == 1)
+    #expect(didSetValues[0].0 == 0)
+    #expect(didSetValues[0].1 == 2)
+  }
+
+  @Test
+  func comparatorRunsOnceWithTheCommittedOldValueAndFinalStagedValue() {
+    let comparisons = LockedBox<[(Int, Int)]>([])
+    let node = Stored(
+      wrappedValue: 0,
+      shouldNotify: { oldValue, newValue in
+        comparisons.update { $0.append((oldValue, newValue)) }
+        return oldValue != newValue
+      }
+    )
+
+    withGraphTransaction {
+      node.wrappedValue = 1
+      node.wrappedValue = 2
+      node.wrappedValue = 3
+    }
+
+    #expect(node.wrappedValue == 3)
+    #expect(comparisons.value.count == 1)
+    #expect(comparisons.value[0].0 == 0)
+    #expect(comparisons.value[0].1 == 3)
+  }
+
+  @Test
+  func comparatorReadsTheWholePendingCommit() {
+    let second = Stored(wrappedValue: 0)
+    let secondValueSeenByComparator = LockedBox<Int?>(nil)
+    let first = Stored(
+      wrappedValue: 0,
+      shouldNotify: { oldValue, newValue in
+        secondValueSeenByComparator.update {
+          $0 = second.wrappedValue
+        }
+        return oldValue != newValue
+      }
+    )
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+      second.wrappedValue = 2
+    }
+
+    #expect(secondValueSeenByComparator.value == 2)
+  }
+
+  @Test
+  func comparatorCanWaitForAnotherThreadToReadCommittedGraph() {
+    let unrelated = Stored(wrappedValue: 42)
+    let readerFinished = DispatchSemaphore(value: 0)
+    let readerCompletedBeforeComparatorReturned = LockedBox(false)
+    let node = Stored(
+      wrappedValue: 0,
+      shouldNotify: { oldValue, newValue in
+        DispatchQueue.global().async {
+          _ = unrelated.wrappedValue
+          readerFinished.signal()
+        }
+        readerCompletedBeforeComparatorReturned.update {
+          $0 = readerFinished.wait(timeout: .now() + .seconds(1)) == .success
+        }
+        return oldValue != newValue
+      }
+    )
+
+    withGraphTransaction {
+      node.wrappedValue = 1
+    }
+
+    #expect(readerCompletedBeforeComparatorReturned.value)
+  }
+
+  @Test
+  func stagedOptionalNilIsDifferentFromTheAbsenceOfAStagedValue() {
+    let optional = Stored<Int?>(wrappedValue: 1)
+    let untouched = Stored<Int?>(wrappedValue: 2)
+
+    withGraphTransaction {
+      optional.wrappedValue = nil
+
+      #expect(optional.wrappedValue == nil)
+      #expect(untouched.wrappedValue == 2)
+    }
+
+    #expect(optional.wrappedValue == nil)
+    #expect(untouched.wrappedValue == 2)
+  }
+
+  @Test
+  func nestedTransactionHasNoSavepointAndCaughtErrorKeepsItsStagedValue() {
+    let node = Stored(wrappedValue: 0)
+
+    withGraphTransaction {
+      node.wrappedValue = 1
+
+      do {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          node.wrappedValue = 2
+          throw .rollback
+        }
+      } catch TransactionError.rollback {
+      } catch {
+        Issue.record("Unexpected nested transaction error: \(error)")
+      }
+
+      #expect(node.wrappedValue == 2)
+    }
+
+    #expect(node.wrappedValue == 2)
+  }
+
+  @Test
+  func nestedErrorEscapingTheOuterTransactionRollsBackEveryParticipant() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    var didCatchRollback = false
+
+    do {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        first.wrappedValue = 1
+
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          second.wrappedValue = 2
+          throw .rollback
+        }
+      }
+    } catch let error {
+      switch error {
+      case .rollback:
+        didCatchRollback = true
+      }
+    }
+
+    #expect(didCatchRollback)
+    #expect(first.wrappedValue == 0)
+    #expect(second.wrappedValue == 0)
+  }
+
+#if DEBUG
+  @Test
+  func nestedTransactionDiagnosticCanBeDisabled() {
+    let previousValue = StateGraphDiagnostics.isNestedTransactionWarningEnabled
+    defer {
+      StateGraphDiagnostics.isNestedTransactionWarningEnabled = previousValue
+    }
+
+    let warningCount = LockedBox(0)
+
+    Log.$nestedTransactionWarningObserver.withValue({
+      warningCount.update { $0 += 1 }
+    }) {
+      StateGraphDiagnostics.isNestedTransactionWarningEnabled = true
+      withGraphTransaction {
+        withGraphTransaction {}
+      }
+
+      StateGraphDiagnostics.isNestedTransactionWarningEnabled = false
+      withGraphTransaction {
+        withGraphTransaction {}
+      }
+    }
+
+    #expect(warningCount.value == 1)
+  }
+#endif
+
+  @Test
+  func firstSynchronousCallbackSeesEveryFinalCommittedValue() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    var secondValueObservedByFirstCallback: Int?
+
+    first.onDidSet { _, _ in
+      secondValueObservedByFirstCallback = second.wrappedValue
+    }
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+      second.wrappedValue = 2
+    }
+
+    #expect(secondValueObservedByFirstCallback == 2)
+  }
+
+  @Test
+  @MainActor
+  func firstObservationCallbackReadsTheFinalComputedValue() async {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    let total = Computed { _ in
+      first.wrappedValue + second.wrappedValue
+    }
+    let observedTotal = LockedBox<Int?>(nil)
+    let callbackDelivered = TestSignal()
+
+    #expect(total.wrappedValue == 0)
+
+    withObservationTracking {
+      _ = first.wrappedValue
+    } onChange: {
+      observedTotal.update { $0 = total.wrappedValue }
+      callbackDelivered.signal()
+    }
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+      second.wrappedValue = 2
+    }
+
+    #expect(await callbackDelivered.wait(for: .seconds(5)))
+    #expect(observedTotal.value == 3)
+  }
+
+  @Test
+  @MainActor
+  func observationWillSetPrecedesCommittedPublication() {
+    let source = Stored(wrappedValue: 0)
+    let willSetStarted = DispatchSemaphore(value: 0)
+    let lateRegistrationFinished = DispatchSemaphore(value: 0)
+    let lateObservedValue = LockedBox<Int?>(nil)
+    let lateChangeCount = LockedBox(0)
+    let didCompleteLateRegistration = LockedBox(false)
+
+    DispatchQueue.global().async {
+      guard willSetStarted.wait(timeout: .now() + .seconds(1)) == .success else {
+        lateRegistrationFinished.signal()
+        return
+      }
+
+      withObservationTracking {
+        lateObservedValue.update { $0 = source.wrappedValue }
+      } onChange: {
+        lateChangeCount.update { $0 += 1 }
+      }
+      lateRegistrationFinished.signal()
+    }
+
+    withObservationTracking {
+      _ = source.wrappedValue
+    } onChange: {
+      willSetStarted.signal()
+      didCompleteLateRegistration.update {
+        $0 = lateRegistrationFinished.wait(
+          timeout: .now() + .seconds(1)
+        ) == .success
+      }
+    }
+
+    withGraphTransaction {
+      source.wrappedValue = 1
+    }
+
+    #expect(didCompleteLateRegistration.value)
+    #expect(lateObservedValue.value == 0)
+    #expect(lateChangeCount.value == 0)
+    #expect(source.wrappedValue == 1)
+  }
+
+  @Test
+  @MainActor
+  func computedObservationWillSetPrecedesCommittedPublication() {
+    let source = Stored(wrappedValue: 0)
+    let computed = Computed { _ in source.wrappedValue }
+    let willSetStarted = DispatchSemaphore(value: 0)
+    let lateRegistrationFinished = DispatchSemaphore(value: 0)
+    let lateObservedValue = LockedBox<Int?>(nil)
+    let lateChangeCount = LockedBox(0)
+    let didCompleteLateRegistration = LockedBox(false)
+
+    #expect(computed.wrappedValue == 0)
+
+    DispatchQueue.global().async {
+      guard willSetStarted.wait(timeout: .now() + .seconds(1)) == .success else {
+        lateRegistrationFinished.signal()
+        return
+      }
+
+      withObservationTracking {
+        lateObservedValue.update { $0 = computed.wrappedValue }
+      } onChange: {
+        lateChangeCount.update { $0 += 1 }
+      }
+      lateRegistrationFinished.signal()
+    }
+
+    withObservationTracking {
+      _ = computed.wrappedValue
+    } onChange: {
+      willSetStarted.signal()
+      didCompleteLateRegistration.update {
+        $0 = lateRegistrationFinished.wait(
+          timeout: .now() + .seconds(1)
+        ) == .success
+      }
+    }
+
+    withGraphTransaction {
+      source.wrappedValue = 1
+    }
+
+    #expect(didCompleteLateRegistration.value)
+    #expect(lateObservedValue.value == 0)
+    #expect(lateChangeCount.value == 0)
+    #expect(computed.wrappedValue == 1)
+  }
+
+#if DEBUG
+  @Test
+  @MainActor
+  func observationSnapshotWaitsForAnInFlightComputedRead() async {
+    let source = Stored(wrappedValue: 0)
+    let descriptorStarted = TestSignal()
+    let resumeDescriptor = DispatchSemaphore(value: 0)
+    let shouldPauseDescriptor = LockedBox(true)
+    let initialObservedValue = LockedBox<Int?>(nil)
+    let observationChangeCount = LockedBox(0)
+    let observerReadFinished = TestSignal()
+    let transactionFinished = TestSignal()
+    let observationDelivered = TestSignal()
+
+    let computed = Computed { _ in
+      var shouldPause = false
+      shouldPauseDescriptor.update {
+        shouldPause = $0
+        $0 = false
+      }
+      if shouldPause {
+        descriptorStarted.signal()
+        _ = resumeDescriptor.wait(timeout: .now() + .seconds(2))
+      }
+      return source.wrappedValue
+    }
+
+    Thread {
+      withObservationTracking {
+        initialObservedValue.update { $0 = computed.wrappedValue }
+      } onChange: {
+        observationChangeCount.update { $0 += 1 }
+        observationDelivered.signal()
+      }
+      observerReadFinished.signal()
+    }.start()
+
+    #expect(await descriptorStarted.wait(for: .seconds(5)))
+
+    Thread {
+      withGraphTransaction {
+        source.wrappedValue = 1
+      }
+      transactionFinished.signal()
+    }.start()
+
+    #expect(
+      GraphTransactionCoordinator.shared.waitForPublisherToBlock(
+        until: Date().addingTimeInterval(1)
+      )
+    )
+
+    resumeDescriptor.signal()
+
+    #expect(await observerReadFinished.wait(for: .seconds(5)))
+    #expect(await transactionFinished.wait(for: .seconds(5)))
+    #expect(await observationDelivered.wait(for: .seconds(5)))
+    #expect(initialObservedValue.value == 0)
+    #expect(observationChangeCount.value == 1)
+    #expect(computed.wrappedValue == 1)
+  }
+#endif
+
+  @Test
+  @MainActor
+  func observationCallbackCanWaitForAnotherThreadToReadTheCommittedGraph() async {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    let callbackReadFinished = DispatchSemaphore(value: 0)
+    let callbackDidFinishWaiting = LockedBox(false)
+    let callbackDelivered = TestSignal()
+
+    withObservationTracking {
+      _ = first.wrappedValue
+    } onChange: {
+      DispatchQueue.global().async {
+        _ = second.wrappedValue
+        callbackReadFinished.signal()
+      }
+      callbackDidFinishWaiting.update {
+        $0 = callbackReadFinished.wait(
+          timeout: .now() + .seconds(1)
+        ) == .success
+      }
+      callbackDelivered.signal()
+    }
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+      second.wrappedValue = 2
+    }
+
+    #expect(await callbackDelivered.wait(for: .seconds(5)))
+    #expect(callbackDidFinishWaiting.value)
+  }
+
+  @Test
+  func computedReadsUseStagedDependenciesWithoutLeakingCommittedCacheOrEdges() {
+    let toggle = Stored(wrappedValue: false)
+    let first = Stored(wrappedValue: 1)
+    let second = Stored(wrappedValue: 2)
+    let computeCount = LockedBox(0)
+    let selected = Computed { _ in
+      computeCount.update { $0 += 1 }
+      if toggle.wrappedValue {
+        return second.wrappedValue
+      }
+      return first.wrappedValue
+    }
+
+    #expect(selected.wrappedValue == 1)
+    #expect(computeCount.value == 1)
+
+    var didRollBack = false
+    do {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        toggle.wrappedValue = true
+        #expect(selected.wrappedValue == 2)
+        second.wrappedValue = 3
+        #expect(selected.wrappedValue == 3)
+        throw .rollback
+      }
+    } catch {
+      didRollBack = true
+    }
+
+    #expect(didRollBack)
+
+    #expect(selected.wrappedValue == 1)
+    #expect(computeCount.value == 3)
+
+    second.wrappedValue = 4
+
+    #expect(selected.wrappedValue == 1)
+    #expect(computeCount.value == 3)
+
+    first.wrappedValue = 5
+
+    #expect(selected.wrappedValue == 5)
+    #expect(computeCount.value == 4)
+  }
+
+  @Test
+  func deallocatedParticipantIsSkippedAtCommit() {
+    weak var weakNode: Stored<Int>?
+
+    withGraphTransaction {
+      var node: Stored<Int>? = Stored(wrappedValue: 0)
+      weakNode = node
+      node?.wrappedValue = 1
+      node = nil
+    }
+
+    #expect(weakNode == nil)
+  }
+
+  @Test
+  func callbackTriggeredMutationDoesNotDeadlock() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    let finished = DispatchSemaphore(value: 0)
+
+    first.onDidSet { _, _ in
+      second.wrappedValue = 2
+    }
+
+    let thread = Thread {
+      withGraphTransaction {
+        first.wrappedValue = 1
+      }
+      finished.signal()
+    }
+    thread.start()
+
+    #expect(finished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(first.wrappedValue == 1)
+    #expect(second.wrappedValue == 2)
+  }
+
+  @Test
+  func callbackMutationUsesOneLatestTransactionSnapshot() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    let third = Stored(wrappedValue: 0)
+    let secondValueReadByFirstCallback = LockedBox<Int?>(nil)
+    let secondTransitions = LockedBox<
+      [(oldValue: Int, newValue: Int, observedSecond: Int, observedThird: Int)]
+    >([])
+
+    first.onDidSet { _, _ in
+      second.wrappedValue = 2
+      third.wrappedValue = 3
+      secondValueReadByFirstCallback.update { $0 = second.wrappedValue }
+    }
+    second.onDidSet { oldValue, newValue in
+      secondTransitions.update {
+        $0.append(
+          (
+            oldValue,
+            newValue,
+            second.wrappedValue,
+            third.wrappedValue
+          )
+        )
+      }
+    }
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+      second.wrappedValue = 1
+      third.wrappedValue = 1
+    }
+
+    let transitions = secondTransitions.value
+    #expect(secondValueReadByFirstCallback.value == 2)
+    #expect(second.wrappedValue == 2)
+    #expect(transitions.count == 2)
+    #expect(transitions[0].oldValue == 0)
+    #expect(transitions[0].newValue == 1)
+    #expect(transitions[0].observedSecond == 2)
+    #expect(transitions[0].observedThird == 3)
+    #expect(transitions[1].oldValue == 1)
+    #expect(transitions[1].newValue == 2)
+    #expect(transitions[1].observedSecond == 2)
+    #expect(transitions[1].observedThird == 3)
+  }
+
+  @Test
+  func concurrentReadersObserveOnlyWholeComputedSnapshots() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    let total = Computed { _ in first.wrappedValue + second.wrappedValue }
+    let observedPartialCommit = LockedBox(false)
+
+    DispatchQueue.concurrentPerform(iterations: 200) { index in
+      if index.isMultiple(of: 3) {
+        withGraphTransaction {
+          first.wrappedValue = index
+          second.wrappedValue = -index
+        }
+      } else {
+        let value = total.wrappedValue
+        if value != 0 {
+          observedPartialCommit.update { $0 = true }
+        }
+      }
+    }
+
+    #expect(observedPartialCommit.value == false)
+    #expect(total.wrappedValue == 0)
+  }
+
+  @Test
+  func ordinaryOnDidSetCanRunATransactionWithoutDeadlocking() {
+    let source = Stored(wrappedValue: 0)
+    let nested = Stored(wrappedValue: 0)
+    let finished = DispatchSemaphore(value: 0)
+
+    source.onDidSet { _, _ in
+      withGraphTransaction {
+        nested.wrappedValue = 1
+      }
+    }
+
+    let thread = Thread {
+      source.wrappedValue = 1
+      finished.signal()
+    }
+    thread.start()
+
+    #expect(finished.wait(timeout: .now() + .seconds(5)) == .success)
+    #expect(source.wrappedValue == 1)
+    #expect(nested.wrappedValue == 1)
+  }
+
+  @Test
+  func onDidSetTransactionWaitsForContendingWriterAfterNodeUnlock() {
+    let secondComparatorEntered = DispatchSemaphore(value: 0)
+    let releaseSecondComparator = DispatchSemaphore(value: 0)
+    let firstCallbackEntered = DispatchSemaphore(value: 0)
+    let allowFirstCallbackTransaction = DispatchSemaphore(value: 0)
+    let writersFinished = DispatchSemaphore(value: 0)
+    let nested = Stored(wrappedValue: 0)
+    let source = Stored(
+      wrappedValue: 0,
+      shouldNotify: { oldValue, newValue in
+        if newValue == 2 {
+          secondComparatorEntered.signal()
+          releaseSecondComparator.wait()
+        }
+        return oldValue != newValue
+      }
+    )
+
+    source.onDidSet { _, newValue in
+      guard newValue == 1 else { return }
+      firstCallbackEntered.signal()
+      allowFirstCallbackTransaction.wait()
+      withGraphTransaction {
+        nested.wrappedValue = 1
+      }
+    }
+
+    DispatchQueue.global().async {
+      source.wrappedValue = 1
+      writersFinished.signal()
+    }
+
+    #expect(firstCallbackEntered.wait(timeout: .now() + .seconds(1)) == .success)
+
+    DispatchQueue.global().async {
+      source.wrappedValue = 2
+      writersFinished.signal()
+    }
+
+    #expect(secondComparatorEntered.wait(timeout: .now() + .seconds(1)) == .success)
+    allowFirstCallbackTransaction.signal()
+    releaseSecondComparator.signal()
+
+    #expect(writersFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(writersFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(source.wrappedValue == 2)
+    #expect(nested.wrappedValue == 1)
+  }
+
+  @Test
+  func callbackCanWaitForTransactionQueuedBehindItsCompletedTransaction() {
+    let firstTransactionStarted = DispatchSemaphore(value: 0)
+    let releaseFirstTransaction = DispatchSemaphore(value: 0)
+    let secondTransactionCallStarted = DispatchSemaphore(value: 0)
+    let secondTransactionFinished = DispatchSemaphore(value: 0)
+    let sourceWriterFinished = DispatchSemaphore(value: 0)
+    let callbackObservedSecondCompletion = LockedBox(false)
+    let source = Stored(wrappedValue: 0)
+    let firstTarget = Stored(wrappedValue: 0)
+    let secondTarget = Stored(wrappedValue: 0)
+
+    source.onDidSet { _, _ in
+      withGraphTransaction {
+        firstTransactionStarted.signal()
+        releaseFirstTransaction.wait()
+        firstTarget.wrappedValue = 1
+      }
+
+      callbackObservedSecondCompletion.update {
+        $0 = secondTransactionFinished.wait(
+          timeout: .now() + .seconds(1)
+        ) == .success
+      }
+    }
+
+    DispatchQueue.global().async {
+      source.wrappedValue = 1
+      sourceWriterFinished.signal()
+    }
+
+    #expect(firstTransactionStarted.wait(timeout: .now() + .seconds(1)) == .success)
+
+    DispatchQueue.global().async {
+      secondTransactionCallStarted.signal()
+      withGraphTransaction {
+        secondTarget.wrappedValue = 1
+      }
+      secondTransactionFinished.signal()
+    }
+
+    #expect(
+      secondTransactionCallStarted.wait(timeout: .now() + .seconds(1)) == .success
+    )
+#if DEBUG
+    #expect(
+      GraphTransactionCoordinator.shared.waitForTransactionToBlock(
+        until: Date().addingTimeInterval(1)
+      )
+    )
+#endif
+    releaseFirstTransaction.signal()
+
+    #expect(sourceWriterFinished.wait(timeout: .now() + .seconds(2)) == .success)
+    #expect(callbackObservedSecondCompletion.value)
+    #expect(firstTarget.wrappedValue == 1)
+    #expect(secondTarget.wrappedValue == 1)
+  }
+
+  @Test
+  func concurrentImmediateWriterCallbacksCanBothStartTransactions() {
+    let firstSource = Stored(wrappedValue: 0)
+    let secondSource = Stored(wrappedValue: 0)
+    let firstNested = Stored(wrappedValue: 0)
+    let secondNested = Stored(wrappedValue: 0)
+    let callbacksReady = DispatchSemaphore(value: 0)
+    let startTransactions = DispatchSemaphore(value: 0)
+    let writersFinished = DispatchSemaphore(value: 0)
+
+    firstSource.onDidSet { _, _ in
+      callbacksReady.signal()
+      startTransactions.wait()
+      withGraphTransaction {
+        firstNested.wrappedValue = 1
+      }
+    }
+    secondSource.onDidSet { _, _ in
+      callbacksReady.signal()
+      startTransactions.wait()
+      withGraphTransaction {
+        secondNested.wrappedValue = 1
+      }
+    }
+
+    DispatchQueue.global().async {
+      firstSource.wrappedValue = 1
+      writersFinished.signal()
+    }
+    DispatchQueue.global().async {
+      secondSource.wrappedValue = 1
+      writersFinished.signal()
+    }
+
+    #expect(callbacksReady.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(callbacksReady.wait(timeout: .now() + .seconds(1)) == .success)
+    startTransactions.signal()
+    startTransactions.signal()
+
+    #expect(writersFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(writersFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(firstNested.wrappedValue == 1)
+    #expect(secondNested.wrappedValue == 1)
+  }
+}

--- a/Tests/StateGraphTests/GraphTransactionTests.swift
+++ b/Tests/StateGraphTests/GraphTransactionTests.swift
@@ -34,6 +34,37 @@ struct GraphTransactionTests {
     }
   }
 
+  /// A one-shot gate for deliberately pausing synchronous graph work on an OS thread.
+  ///
+  /// Use this only when a synchronous transaction body, comparator, or callback must
+  /// remain active while another thread reaches a deterministic state. Async test
+  /// control flow must use `TestSignal` or `TestCountdown` so it suspends instead of
+  /// blocking a cooperative-executor thread.
+  private final class TestThreadGate: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var isOpen = false
+
+    /// Releases every current or future waiter.
+    func open() {
+      condition.lock()
+      isOpen = true
+      condition.broadcast()
+      condition.unlock()
+    }
+
+    /// Blocks the current OS thread until the gate opens or the deadline expires.
+    @discardableResult
+    func wait(until deadline: Date) -> Bool {
+      condition.lock()
+      defer { condition.unlock() }
+
+      while !isOpen {
+        guard condition.wait(until: deadline) else { return isOpen }
+      }
+      return true
+    }
+  }
+
   /// Runs a supplied action when a staged reference value is destroyed.
   private final class DeinitAction {
     private let action: () -> Void
@@ -83,70 +114,78 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func outsideReaderSeesCommittedValueWhileTransactionBodyIsPaused() {
+  func outsideReaderSeesCommittedValueWhileTransactionBodyIsPaused() async {
     let node = Stored(wrappedValue: 0)
-    let transactionStarted = DispatchSemaphore(value: 0)
-    let resumeTransaction = DispatchSemaphore(value: 0)
-    let transactionFinished = DispatchSemaphore(value: 0)
+    let transactionStarted = TestSignal()
+    let resumeTransaction = TestThreadGate()
+    let transactionFinished = TestSignal()
 
     let thread = Thread {
       withGraphTransaction {
         node.wrappedValue = 1
         transactionStarted.signal()
-        resumeTransaction.wait()
+        resumeTransaction.wait(until: Date().addingTimeInterval(5))
       }
       transactionFinished.signal()
     }
     thread.start()
 
-    #expect(transactionStarted.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await transactionStarted.wait(for: .seconds(5)))
     #expect(node.wrappedValue == 0)
 
-    resumeTransaction.signal()
-    #expect(transactionFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    resumeTransaction.open()
+    #expect(await transactionFinished.wait(for: .seconds(5)))
     #expect(node.wrappedValue == 1)
   }
 
   @Test
-  func outsideWriterWaitsForTransactionCompletion() {
+  func outsideWriterWaitsForTransactionCompletion() async {
     let node = Stored(wrappedValue: 0)
-    let transactionStarted = DispatchSemaphore(value: 0)
-    let resumeTransaction = DispatchSemaphore(value: 0)
-    let transactionFinished = DispatchSemaphore(value: 0)
-    let writerStarted = DispatchSemaphore(value: 0)
-    let writerFinished = DispatchSemaphore(value: 0)
+    let transactionStarted = TestSignal()
+    let resumeTransaction = TestThreadGate()
+    let transactionFinished = TestSignal()
+    let writerStarted = TestSignal()
+    let writerFinished = TestSignal()
+    let writerDidFinish = LockedBox(false)
 
     let transactionThread = Thread {
       withGraphTransaction {
         node.wrappedValue = 1
         transactionStarted.signal()
-        resumeTransaction.wait()
+        resumeTransaction.wait(until: Date().addingTimeInterval(5))
       }
       transactionFinished.signal()
     }
     transactionThread.start()
 
-    #expect(transactionStarted.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await transactionStarted.wait(for: .seconds(5)))
 
-    DispatchQueue.global().async {
+    Thread {
       writerStarted.signal()
       node.wrappedValue = 2
+      writerDidFinish.update { $0 = true }
       writerFinished.signal()
-    }
+    }.start()
 
-    #expect(writerStarted.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await writerStarted.wait(for: .seconds(5)))
 #if DEBUG
-    #expect(
-      GraphTransactionCoordinator.shared.waitForImmediateWriterToBlock(
+    let writerBlocked = TestSignal()
+    let didObserveBlockedWriter = LockedBox(false)
+    Thread {
+      let didBlock = GraphTransactionCoordinator.shared.waitForImmediateWriterToBlock(
         until: Date().addingTimeInterval(1)
       )
-    )
+      didObserveBlockedWriter.update { $0 = didBlock }
+      writerBlocked.signal()
+    }.start()
+    #expect(await writerBlocked.wait(for: .seconds(5)))
+    #expect(didObserveBlockedWriter.value)
 #endif
-    #expect(writerFinished.wait(timeout: .now()) == .timedOut)
+    #expect(!writerDidFinish.value)
 
-    resumeTransaction.signal()
-    #expect(transactionFinished.wait(timeout: .now() + .seconds(1)) == .success)
-    #expect(writerFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    resumeTransaction.open()
+    #expect(await transactionFinished.wait(for: .seconds(5)))
+    #expect(await writerFinished.wait(for: .seconds(5)))
     #expect(node.wrappedValue == 2)
   }
 
@@ -221,13 +260,13 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func overlappingRollbacksKeepEachContextsTypedValuesDistinct() {
+  func overlappingRollbacksKeepEachContextsTypedValuesDistinct() async {
     let first = Stored(wrappedValue: DeinitAction())
     let second = Stored(wrappedValue: DeinitAction())
-    let firstCleanupStarted = DispatchSemaphore(value: 0)
-    let resumeFirstCleanup = DispatchSemaphore(value: 0)
-    let outerFinished = DispatchSemaphore(value: 0)
-    let innerFinished = DispatchSemaphore(value: 0)
+    let firstCleanupStarted = TestSignal()
+    let resumeFirstCleanup = TestThreadGate()
+    let outerFinished = TestSignal()
+    let innerFinished = TestSignal()
     let outerSecondCleanupCount = LockedBox(0)
     let innerCleanupCount = LockedBox(0)
 
@@ -236,8 +275,8 @@ struct GraphTransactionTests {
         try withGraphTransaction { () throws(TransactionError) -> Void in
           first.wrappedValue = DeinitAction {
             firstCleanupStarted.signal()
-            _ = resumeFirstCleanup.wait(
-              timeout: .now() + .seconds(2)
+            resumeFirstCleanup.wait(
+              until: Date().addingTimeInterval(5)
             )
           }
           second.wrappedValue = DeinitAction {
@@ -251,9 +290,7 @@ struct GraphTransactionTests {
       outerFinished.signal()
     }.start()
 
-    #expect(
-      firstCleanupStarted.wait(timeout: .now() + .seconds(1)) == .success
-    )
+    #expect(await firstCleanupStarted.wait(for: .seconds(5)))
 
     Thread {
       do {
@@ -269,12 +306,12 @@ struct GraphTransactionTests {
       innerFinished.signal()
     }.start()
 
-    #expect(innerFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await innerFinished.wait(for: .seconds(5)))
     #expect(innerCleanupCount.value == 1)
     #expect(outerSecondCleanupCount.value == 0)
 
-    resumeFirstCleanup.signal()
-    #expect(outerFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    resumeFirstCleanup.open()
+    #expect(await outerFinished.wait(for: .seconds(5)))
     #expect(outerSecondCleanupCount.value == 1)
   }
 
@@ -297,13 +334,14 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func commitDefersCallbacksUntilTheTransactionBodyReturns() {
+  @MainActor
+  func commitDefersCallbacksUntilTheTransactionBodyReturns() async {
     let source = Stored(wrappedValue: 0)
     let didSetCount = LockedBox(0)
     let trackingCallbackCount = LockedBox(0)
     let observationCallbackCount = LockedBox(0)
-    let trackingDelivered = DispatchSemaphore(value: 0)
-    let observationDelivered = DispatchSemaphore(value: 0)
+    let trackingDelivered = TestSignal()
+    let observationDelivered = TestSignal()
 
     source.onDidSet { _, _ in
       didSetCount.update { $0 += 1 }
@@ -337,9 +375,9 @@ struct GraphTransactionTests {
 
     #expect(source.wrappedValue == 1)
     #expect(didSetCount.value == 1)
-    #expect(trackingDelivered.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await trackingDelivered.wait(for: .seconds(5)))
     #expect(trackingCallbackCount.value == 1)
-    #expect(observationDelivered.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await observationDelivered.wait(for: .seconds(5)))
     #expect(observationCallbackCount.value == 1)
   }
 
@@ -518,28 +556,36 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func comparatorCanWaitForAnotherThreadToReadCommittedGraph() {
+  func comparatorCanWaitForAnotherThreadToReadCommittedGraph() async {
     let unrelated = Stored(wrappedValue: 42)
-    let readerFinished = DispatchSemaphore(value: 0)
+    let readerFinished = TestThreadGate()
+    let transactionFinished = TestSignal()
     let readerCompletedBeforeComparatorReturned = LockedBox(false)
     let node = Stored(
       wrappedValue: 0,
       shouldNotify: { oldValue, newValue in
-        DispatchQueue.global().async {
+        Thread {
           _ = unrelated.wrappedValue
-          readerFinished.signal()
-        }
+          readerFinished.open()
+        }.start()
+
+        // Waiting is the behavior under test. The comparator itself runs on the
+        // explicitly created transaction thread rather than a test executor.
         readerCompletedBeforeComparatorReturned.update {
-          $0 = readerFinished.wait(timeout: .now() + .seconds(1)) == .success
+          $0 = readerFinished.wait(until: Date().addingTimeInterval(5))
         }
         return oldValue != newValue
       }
     )
 
-    withGraphTransaction {
-      node.wrappedValue = 1
-    }
+    Thread {
+      withGraphTransaction {
+        node.wrappedValue = 1
+      }
+      transactionFinished.signal()
+    }.start()
 
+    #expect(await transactionFinished.wait(for: .seconds(5)))
     #expect(readerCompletedBeforeComparatorReturned.value)
   }
 
@@ -688,15 +734,15 @@ struct GraphTransactionTests {
   @MainActor
   func observationWillSetPrecedesCommittedPublication() {
     let source = Stored(wrappedValue: 0)
-    let willSetStarted = DispatchSemaphore(value: 0)
-    let lateRegistrationFinished = DispatchSemaphore(value: 0)
+    let willSetStarted = TestThreadGate()
+    let lateRegistrationFinished = TestThreadGate()
     let lateObservedValue = LockedBox<Int?>(nil)
     let lateChangeCount = LockedBox(0)
     let didCompleteLateRegistration = LockedBox(false)
 
-    DispatchQueue.global().async {
-      guard willSetStarted.wait(timeout: .now() + .seconds(1)) == .success else {
-        lateRegistrationFinished.signal()
+    Thread {
+      guard willSetStarted.wait(until: Date().addingTimeInterval(5)) else {
+        lateRegistrationFinished.open()
         return
       }
 
@@ -705,17 +751,21 @@ struct GraphTransactionTests {
       } onChange: {
         lateChangeCount.update { $0 += 1 }
       }
-      lateRegistrationFinished.signal()
-    }
+      lateRegistrationFinished.open()
+    }.start()
 
     withObservationTracking {
       _ = source.wrappedValue
     } onChange: {
-      willSetStarted.signal()
+      willSetStarted.open()
+
+      // This synchronous gate is the behavior under test: the Observation
+      // `willSet` callback must remain active while another OS thread registers
+      // against the old committed snapshot.
       didCompleteLateRegistration.update {
         $0 = lateRegistrationFinished.wait(
-          timeout: .now() + .seconds(1)
-        ) == .success
+          until: Date().addingTimeInterval(5)
+        )
       }
     }
 
@@ -734,17 +784,17 @@ struct GraphTransactionTests {
   func computedObservationWillSetPrecedesCommittedPublication() {
     let source = Stored(wrappedValue: 0)
     let computed = Computed { _ in source.wrappedValue }
-    let willSetStarted = DispatchSemaphore(value: 0)
-    let lateRegistrationFinished = DispatchSemaphore(value: 0)
+    let willSetStarted = TestThreadGate()
+    let lateRegistrationFinished = TestThreadGate()
     let lateObservedValue = LockedBox<Int?>(nil)
     let lateChangeCount = LockedBox(0)
     let didCompleteLateRegistration = LockedBox(false)
 
     #expect(computed.wrappedValue == 0)
 
-    DispatchQueue.global().async {
-      guard willSetStarted.wait(timeout: .now() + .seconds(1)) == .success else {
-        lateRegistrationFinished.signal()
+    Thread {
+      guard willSetStarted.wait(until: Date().addingTimeInterval(5)) else {
+        lateRegistrationFinished.open()
         return
       }
 
@@ -753,17 +803,21 @@ struct GraphTransactionTests {
       } onChange: {
         lateChangeCount.update { $0 += 1 }
       }
-      lateRegistrationFinished.signal()
-    }
+      lateRegistrationFinished.open()
+    }.start()
 
     withObservationTracking {
       _ = computed.wrappedValue
     } onChange: {
-      willSetStarted.signal()
+      willSetStarted.open()
+
+      // This synchronous gate is the behavior under test: the Observation
+      // `willSet` callback must remain active while another OS thread registers
+      // against the old committed snapshot.
       didCompleteLateRegistration.update {
         $0 = lateRegistrationFinished.wait(
-          timeout: .now() + .seconds(1)
-        ) == .success
+          until: Date().addingTimeInterval(5)
+        )
       }
     }
 
@@ -783,7 +837,7 @@ struct GraphTransactionTests {
   func observationSnapshotWaitsForAnInFlightComputedRead() async {
     let source = Stored(wrappedValue: 0)
     let descriptorStarted = TestSignal()
-    let resumeDescriptor = DispatchSemaphore(value: 0)
+    let resumeDescriptor = TestThreadGate()
     let shouldPauseDescriptor = LockedBox(true)
     let initialObservedValue = LockedBox<Int?>(nil)
     let observationChangeCount = LockedBox(0)
@@ -799,7 +853,7 @@ struct GraphTransactionTests {
       }
       if shouldPause {
         descriptorStarted.signal()
-        _ = resumeDescriptor.wait(timeout: .now() + .seconds(2))
+        resumeDescriptor.wait(until: Date().addingTimeInterval(5))
       }
       return source.wrappedValue
     }
@@ -823,13 +877,20 @@ struct GraphTransactionTests {
       transactionFinished.signal()
     }.start()
 
-    #expect(
-      GraphTransactionCoordinator.shared.waitForPublisherToBlock(
+    let publisherWaitFinished = TestSignal()
+    let didObserveBlockedPublisher = LockedBox(false)
+    Thread {
+      let didBlock = GraphTransactionCoordinator.shared.waitForPublisherToBlock(
         until: Date().addingTimeInterval(1)
       )
-    )
+      didObserveBlockedPublisher.update { $0 = didBlock }
+      publisherWaitFinished.signal()
+    }.start()
 
-    resumeDescriptor.signal()
+    #expect(await publisherWaitFinished.wait(for: .seconds(5)))
+    #expect(didObserveBlockedPublisher.value)
+
+    resumeDescriptor.open()
 
     #expect(await observerReadFinished.wait(for: .seconds(5)))
     #expect(await transactionFinished.wait(for: .seconds(5)))
@@ -845,21 +906,24 @@ struct GraphTransactionTests {
   func observationCallbackCanWaitForAnotherThreadToReadTheCommittedGraph() async {
     let first = Stored(wrappedValue: 0)
     let second = Stored(wrappedValue: 0)
-    let callbackReadFinished = DispatchSemaphore(value: 0)
+    let callbackReadFinished = TestThreadGate()
     let callbackDidFinishWaiting = LockedBox(false)
     let callbackDelivered = TestSignal()
 
     withObservationTracking {
       _ = first.wrappedValue
     } onChange: {
-      DispatchQueue.global().async {
+      Thread {
         _ = second.wrappedValue
-        callbackReadFinished.signal()
-      }
+        callbackReadFinished.open()
+      }.start()
+
+      // Waiting is the behavior under test: this synchronous Observation
+      // callback must be able to wait for an outside committed-graph reader.
       callbackDidFinishWaiting.update {
         $0 = callbackReadFinished.wait(
-          timeout: .now() + .seconds(1)
-        ) == .success
+          until: Date().addingTimeInterval(5)
+        )
       }
       callbackDelivered.signal()
     }
@@ -934,10 +998,10 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func callbackTriggeredMutationDoesNotDeadlock() {
+  func callbackTriggeredMutationDoesNotDeadlock() async {
     let first = Stored(wrappedValue: 0)
     let second = Stored(wrappedValue: 0)
-    let finished = DispatchSemaphore(value: 0)
+    let finished = TestSignal()
 
     first.onDidSet { _, _ in
       second.wrappedValue = 2
@@ -951,7 +1015,7 @@ struct GraphTransactionTests {
     }
     thread.start()
 
-    #expect(finished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await finished.wait(for: .seconds(5)))
     #expect(first.wrappedValue == 1)
     #expect(second.wrappedValue == 2)
   }
@@ -1030,10 +1094,10 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func ordinaryOnDidSetCanRunATransactionWithoutDeadlocking() {
+  func ordinaryOnDidSetCanRunATransactionWithoutDeadlocking() async {
     let source = Stored(wrappedValue: 0)
     let nested = Stored(wrappedValue: 0)
-    let finished = DispatchSemaphore(value: 0)
+    let finished = TestSignal()
 
     source.onDidSet { _, _ in
       withGraphTransaction {
@@ -1047,25 +1111,30 @@ struct GraphTransactionTests {
     }
     thread.start()
 
-    #expect(finished.wait(timeout: .now() + .seconds(5)) == .success)
+    #expect(await finished.wait(for: .seconds(5)))
     #expect(source.wrappedValue == 1)
     #expect(nested.wrappedValue == 1)
   }
 
   @Test
-  func onDidSetTransactionWaitsForContendingWriterAfterNodeUnlock() {
-    let secondComparatorEntered = DispatchSemaphore(value: 0)
-    let releaseSecondComparator = DispatchSemaphore(value: 0)
-    let firstCallbackEntered = DispatchSemaphore(value: 0)
-    let allowFirstCallbackTransaction = DispatchSemaphore(value: 0)
-    let writersFinished = DispatchSemaphore(value: 0)
+  func onDidSetTransactionWaitsForContendingWriterAfterNodeUnlock() async {
+    let secondComparatorEntered = TestSignal()
+    let releaseSecondComparator = TestThreadGate()
+    let firstCallbackEntered = TestSignal()
+    let allowFirstCallbackTransaction = TestThreadGate()
+    let writersFinished = TestCountdown(count: 2)
     let nested = Stored(wrappedValue: 0)
     let source = Stored(
       wrappedValue: 0,
       shouldNotify: { oldValue, newValue in
         if newValue == 2 {
           secondComparatorEntered.signal()
-          releaseSecondComparator.wait()
+
+          // Holding this comparator open is the behavior under test. Its setter
+          // runs on an explicitly created OS thread.
+          releaseSecondComparator.wait(
+            until: Date().addingTimeInterval(5)
+          )
         }
         return oldValue != newValue
       }
@@ -1074,41 +1143,45 @@ struct GraphTransactionTests {
     source.onDidSet { _, newValue in
       guard newValue == 1 else { return }
       firstCallbackEntered.signal()
-      allowFirstCallbackTransaction.wait()
+
+      // Holding this callback open lets the second writer enter its comparator
+      // before the callback begins its transaction.
+      allowFirstCallbackTransaction.wait(
+        until: Date().addingTimeInterval(5)
+      )
       withGraphTransaction {
         nested.wrappedValue = 1
       }
     }
 
-    DispatchQueue.global().async {
+    Thread {
       source.wrappedValue = 1
       writersFinished.signal()
-    }
+    }.start()
 
-    #expect(firstCallbackEntered.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await firstCallbackEntered.wait(for: .seconds(5)))
 
-    DispatchQueue.global().async {
+    Thread {
       source.wrappedValue = 2
       writersFinished.signal()
-    }
+    }.start()
 
-    #expect(secondComparatorEntered.wait(timeout: .now() + .seconds(1)) == .success)
-    allowFirstCallbackTransaction.signal()
-    releaseSecondComparator.signal()
+    #expect(await secondComparatorEntered.wait(for: .seconds(5)))
+    allowFirstCallbackTransaction.open()
+    releaseSecondComparator.open()
 
-    #expect(writersFinished.wait(timeout: .now() + .seconds(1)) == .success)
-    #expect(writersFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await writersFinished.wait(for: .seconds(5)))
     #expect(source.wrappedValue == 2)
     #expect(nested.wrappedValue == 1)
   }
 
   @Test
-  func callbackCanWaitForTransactionQueuedBehindItsCompletedTransaction() {
-    let firstTransactionStarted = DispatchSemaphore(value: 0)
-    let releaseFirstTransaction = DispatchSemaphore(value: 0)
-    let secondTransactionCallStarted = DispatchSemaphore(value: 0)
-    let secondTransactionFinished = DispatchSemaphore(value: 0)
-    let sourceWriterFinished = DispatchSemaphore(value: 0)
+  func callbackCanWaitForTransactionQueuedBehindItsCompletedTransaction() async {
+    let firstTransactionStarted = TestSignal()
+    let releaseFirstTransaction = TestThreadGate()
+    let secondTransactionCallStarted = TestSignal()
+    let secondTransactionFinished = TestThreadGate()
+    let sourceWriterFinished = TestSignal()
     let callbackObservedSecondCompletion = LockedBox(false)
     let source = Stored(wrappedValue: 0)
     let firstTarget = Stored(wrappedValue: 0)
@@ -1117,91 +1190,103 @@ struct GraphTransactionTests {
     source.onDidSet { _, _ in
       withGraphTransaction {
         firstTransactionStarted.signal()
-        releaseFirstTransaction.wait()
+
+        // Keep the first transaction active until the competing transaction is
+        // deterministically queued behind it.
+        releaseFirstTransaction.wait(
+          until: Date().addingTimeInterval(5)
+        )
         firstTarget.wrappedValue = 1
       }
 
+      // Waiting after the first transaction returns is the behavior under test:
+      // the queued transaction must be able to complete while this callback remains
+      // on its explicitly created OS thread.
       callbackObservedSecondCompletion.update {
         $0 = secondTransactionFinished.wait(
-          timeout: .now() + .seconds(1)
-        ) == .success
+          until: Date().addingTimeInterval(5)
+        )
       }
     }
 
-    DispatchQueue.global().async {
+    Thread {
       source.wrappedValue = 1
       sourceWriterFinished.signal()
-    }
+    }.start()
 
-    #expect(firstTransactionStarted.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await firstTransactionStarted.wait(for: .seconds(5)))
 
-    DispatchQueue.global().async {
+    Thread {
       secondTransactionCallStarted.signal()
       withGraphTransaction {
         secondTarget.wrappedValue = 1
       }
-      secondTransactionFinished.signal()
-    }
+      secondTransactionFinished.open()
+    }.start()
 
-    #expect(
-      secondTransactionCallStarted.wait(timeout: .now() + .seconds(1)) == .success
-    )
+    #expect(await secondTransactionCallStarted.wait(for: .seconds(5)))
 #if DEBUG
-    #expect(
-      GraphTransactionCoordinator.shared.waitForTransactionToBlock(
+    let transactionWaitFinished = TestSignal()
+    let didObserveQueuedTransaction = LockedBox(false)
+    Thread {
+      let didBlock = GraphTransactionCoordinator.shared.waitForTransactionToBlock(
         until: Date().addingTimeInterval(1)
       )
-    )
+      didObserveQueuedTransaction.update { $0 = didBlock }
+      transactionWaitFinished.signal()
+    }.start()
+    #expect(await transactionWaitFinished.wait(for: .seconds(5)))
+    #expect(didObserveQueuedTransaction.value)
 #endif
-    releaseFirstTransaction.signal()
+    releaseFirstTransaction.open()
 
-    #expect(sourceWriterFinished.wait(timeout: .now() + .seconds(2)) == .success)
+    #expect(await sourceWriterFinished.wait(for: .seconds(5)))
     #expect(callbackObservedSecondCompletion.value)
     #expect(firstTarget.wrappedValue == 1)
     #expect(secondTarget.wrappedValue == 1)
   }
 
   @Test
-  func concurrentImmediateWriterCallbacksCanBothStartTransactions() {
+  func concurrentImmediateWriterCallbacksCanBothStartTransactions() async {
     let firstSource = Stored(wrappedValue: 0)
     let secondSource = Stored(wrappedValue: 0)
     let firstNested = Stored(wrappedValue: 0)
     let secondNested = Stored(wrappedValue: 0)
-    let callbacksReady = DispatchSemaphore(value: 0)
-    let startTransactions = DispatchSemaphore(value: 0)
-    let writersFinished = DispatchSemaphore(value: 0)
+    let callbacksReady = TestCountdown(count: 2)
+    let startTransactions = TestThreadGate()
+    let writersFinished = TestCountdown(count: 2)
 
     firstSource.onDidSet { _, _ in
       callbacksReady.signal()
-      startTransactions.wait()
+
+      // Both callbacks must remain active on their OS threads before either one
+      // attempts to acquire the transaction writer slot.
+      startTransactions.wait(until: Date().addingTimeInterval(5))
       withGraphTransaction {
         firstNested.wrappedValue = 1
       }
     }
     secondSource.onDidSet { _, _ in
       callbacksReady.signal()
-      startTransactions.wait()
+      startTransactions.wait(until: Date().addingTimeInterval(5))
       withGraphTransaction {
         secondNested.wrappedValue = 1
       }
     }
 
-    DispatchQueue.global().async {
+    Thread {
       firstSource.wrappedValue = 1
       writersFinished.signal()
-    }
-    DispatchQueue.global().async {
+    }.start()
+    Thread {
       secondSource.wrappedValue = 1
       writersFinished.signal()
-    }
+    }.start()
 
-    #expect(callbacksReady.wait(timeout: .now() + .seconds(1)) == .success)
-    #expect(callbacksReady.wait(timeout: .now() + .seconds(1)) == .success)
-    startTransactions.signal()
-    startTransactions.signal()
+    #expect(await callbacksReady.wait(for: .seconds(5)))
+    startTransactions.open()
 
-    #expect(writersFinished.wait(timeout: .now() + .seconds(1)) == .success)
-    #expect(writersFinished.wait(timeout: .now() + .seconds(1)) == .success)
+    #expect(await writersFinished.wait(for: .seconds(5)))
     #expect(firstNested.wrappedValue == 1)
     #expect(secondNested.wrappedValue == 1)
   }

--- a/Tests/StateGraphTests/GraphTransactionTests.swift
+++ b/Tests/StateGraphTests/GraphTransactionTests.swift
@@ -172,7 +172,7 @@ struct GraphTransactionTests {
     let writerBlocked = TestSignal()
     let didObserveBlockedWriter = LockedBox(false)
     Thread {
-      let didBlock = GraphTransactionCoordinator.shared.waitForImmediateWriterToBlock(
+      let didBlock = GraphTransactionCoordinator.shared.__testing__waitForImmediateWriterToBlock(
         until: Date().addingTimeInterval(1)
       )
       didObserveBlockedWriter.update { $0 = didBlock }
@@ -190,15 +190,19 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func thrownTransactionRollsBackWithoutNotificationsOrInvalidation() {
+  func thrownTransactionRollsBackAssignmentsWithoutGraphNotifications() {
     let source = Stored(wrappedValue: 0)
-    let computed = Computed { _ in source.wrappedValue * 2 }
+    let derived = Stored(wrappedValue: 0)
+    let computed = Computed { _ in
+      source.wrappedValue * 2 + derived.wrappedValue
+    }
     let didSetCount = LockedBox(0)
     let trackingCallbackCount = LockedBox(0)
     let observationCallbackCount = LockedBox(0)
 
-    source.onDidSet { _, _ in
+    source.onDidSet { _, newValue in
       didSetCount.update { $0 += 1 }
+      derived.wrappedValue += newValue
     }
 
     let registration = TrackingRegistration(
@@ -209,10 +213,12 @@ struct GraphTransactionTests {
     )
     ThreadLocal.registration.withValue(registration) {
       _ = source.wrappedValue
+      _ = derived.wrappedValue
     }
 
     withObservationTracking {
       _ = source.wrappedValue
+      _ = derived.wrappedValue
     } onChange: {
       observationCallbackCount.update { $0 += 1 }
     }
@@ -223,6 +229,10 @@ struct GraphTransactionTests {
     do {
       try withGraphTransaction { () throws(TransactionError) -> Void in
         source.wrappedValue = 1
+
+        #expect(source.wrappedValue == 1)
+        #expect(derived.wrappedValue == 1)
+
         throw .rollback
       }
     } catch {
@@ -232,8 +242,9 @@ struct GraphTransactionTests {
     #expect(didRollBack)
 
     #expect(source.wrappedValue == 0)
+    #expect(derived.wrappedValue == 0)
     #expect(computed.wrappedValue == 0)
-    #expect(didSetCount.value == 0)
+    #expect(didSetCount.value == 1)
     #expect(trackingCallbackCount.value == 0)
     #expect(observationCallbackCount.value == 0)
   }
@@ -335,7 +346,7 @@ struct GraphTransactionTests {
 
   @Test
   @MainActor
-  func commitDefersCallbacksUntilTheTransactionBodyReturns() async {
+  func transactionRunsOnDidSetDuringBodyAndDefersGraphCallbacksUntilCommit() async {
     let source = Stored(wrappedValue: 0)
     let didSetCount = LockedBox(0)
     let trackingCallbackCount = LockedBox(0)
@@ -368,7 +379,7 @@ struct GraphTransactionTests {
     withGraphTransaction {
       source.wrappedValue = 1
 
-      #expect(didSetCount.value == 0)
+      #expect(didSetCount.value == 1)
       #expect(trackingCallbackCount.value == 0)
       #expect(observationCallbackCount.value == 0)
     }
@@ -490,7 +501,7 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func multipleWritesCommitOnlyTheFinalValueWithTheExistingComparator() {
+  func multipleWritesPreserveOnDidSetAssignmentsAndCommitOnlyTheFinalValue() {
     let node = Stored(wrappedValue: 0)
     var didSetValues: [(Int, Int)] = []
 
@@ -505,9 +516,13 @@ struct GraphTransactionTests {
     }
 
     #expect(node.wrappedValue == 2)
-    #expect(didSetValues.count == 1)
+    #expect(didSetValues.count == 3)
     #expect(didSetValues[0].0 == 0)
-    #expect(didSetValues[0].1 == 2)
+    #expect(didSetValues[0].1 == 1)
+    #expect(didSetValues[1].0 == 1)
+    #expect(didSetValues[1].1 == 2)
+    #expect(didSetValues[2].0 == 2)
+    #expect(didSetValues[2].1 == 2)
   }
 
   @Test
@@ -684,7 +699,7 @@ struct GraphTransactionTests {
 #endif
 
   @Test
-  func firstSynchronousCallbackSeesEveryFinalCommittedValue() {
+  func onDidSetReadsTheSequentialTransactionSnapshot() {
     let first = Stored(wrappedValue: 0)
     let second = Stored(wrappedValue: 0)
     var secondValueObservedByFirstCallback: Int?
@@ -695,10 +710,13 @@ struct GraphTransactionTests {
 
     withGraphTransaction {
       first.wrappedValue = 1
+
+      #expect(secondValueObservedByFirstCallback == 0)
+
       second.wrappedValue = 2
     }
 
-    #expect(secondValueObservedByFirstCallback == 2)
+    #expect(secondValueObservedByFirstCallback == 0)
   }
 
   @Test
@@ -728,6 +746,48 @@ struct GraphTransactionTests {
 
     #expect(await callbackDelivered.wait(for: .seconds(5)))
     #expect(observedTotal.value == 3)
+  }
+
+  @Test
+  @MainActor
+  func synchronousObservationMutationsDrainFollowingCommitBatches() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    let third = Stored(wrappedValue: 0)
+    let firstChangeCount = LockedBox(0)
+    let secondChangeCount = LockedBox(0)
+
+    withObservationTracking {
+      _ = first.wrappedValue
+    } onChange: {
+      firstChangeCount.update { $0 += 1 }
+
+      // `first` has not been published yet, but the committing thread reads its
+      // pending value and stages this assignment in the following commit batch.
+      #expect(first.wrappedValue == 1)
+      second.wrappedValue = 2
+    }
+
+    withObservationTracking {
+      _ = second.wrappedValue
+    } onChange: {
+      secondChangeCount.update { $0 += 1 }
+
+      // Committing `second` proves that the batch drain must iterate rather than
+      // handle only one callback-generated batch.
+      #expect(second.wrappedValue == 2)
+      third.wrappedValue = 3
+    }
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+    }
+
+    #expect(first.wrappedValue == 1)
+    #expect(second.wrappedValue == 2)
+    #expect(third.wrappedValue == 3)
+    #expect(firstChangeCount.value == 1)
+    #expect(secondChangeCount.value == 1)
   }
 
   @Test
@@ -880,7 +940,7 @@ struct GraphTransactionTests {
     let publisherWaitFinished = TestSignal()
     let didObserveBlockedPublisher = LockedBox(false)
     Thread {
-      let didBlock = GraphTransactionCoordinator.shared.waitForPublisherToBlock(
+      let didBlock = GraphTransactionCoordinator.shared.__testing__waitForPublisherToBlock(
         until: Date().addingTimeInterval(1)
       )
       didObserveBlockedPublisher.update { $0 = didBlock }
@@ -1021,7 +1081,7 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func callbackMutationUsesOneLatestTransactionSnapshot() {
+  func onDidSetMutationJoinsTheCurrentTransactionInAssignmentOrder() {
     let first = Stored(wrappedValue: 0)
     let second = Stored(wrappedValue: 0)
     let third = Stored(wrappedValue: 0)
@@ -1050,21 +1110,26 @@ struct GraphTransactionTests {
 
     withGraphTransaction {
       first.wrappedValue = 1
+
+      #expect(second.wrappedValue == 2)
+      #expect(third.wrappedValue == 3)
+
       second.wrappedValue = 1
       third.wrappedValue = 1
     }
 
     let transitions = secondTransitions.value
     #expect(secondValueReadByFirstCallback.value == 2)
-    #expect(second.wrappedValue == 2)
+    #expect(second.wrappedValue == 1)
+    #expect(third.wrappedValue == 1)
     #expect(transitions.count == 2)
     #expect(transitions[0].oldValue == 0)
-    #expect(transitions[0].newValue == 1)
+    #expect(transitions[0].newValue == 2)
     #expect(transitions[0].observedSecond == 2)
-    #expect(transitions[0].observedThird == 3)
-    #expect(transitions[1].oldValue == 1)
-    #expect(transitions[1].newValue == 2)
-    #expect(transitions[1].observedSecond == 2)
+    #expect(transitions[0].observedThird == 0)
+    #expect(transitions[1].oldValue == 2)
+    #expect(transitions[1].newValue == 1)
+    #expect(transitions[1].observedSecond == 1)
     #expect(transitions[1].observedThird == 3)
   }
 
@@ -1229,7 +1294,7 @@ struct GraphTransactionTests {
     let transactionWaitFinished = TestSignal()
     let didObserveQueuedTransaction = LockedBox(false)
     Thread {
-      let didBlock = GraphTransactionCoordinator.shared.waitForTransactionToBlock(
+      let didBlock = GraphTransactionCoordinator.shared.__testing__waitForTransactionToBlock(
         until: Date().addingTimeInterval(1)
       )
       didObserveQueuedTransaction.update { $0 = didBlock }

--- a/Tests/StateGraphTests/TestSignal.swift
+++ b/Tests/StateGraphTests/TestSignal.swift
@@ -62,3 +62,39 @@ final class TestSignal: @unchecked Sendable {
     waiter?.resume(returning: false)
   }
 }
+
+/// An asynchronous countdown used when a test must observe several completions.
+///
+/// Producers call ``signal()`` from synchronous callbacks or worker threads. The
+/// test task awaits ``wait(for:)``, which suspends rather than blocking a
+/// cooperative-executor thread.
+final class TestCountdown: @unchecked Sendable {
+
+  private let remaining: OSAllocatedUnfairLock<Int>
+  private let completion = TestSignal()
+
+  init(count: Int) {
+    precondition(count > 0)
+    self.remaining = .init(initialState: count)
+  }
+
+  /// Decrements the remaining completion count.
+  ///
+  /// Calls after the countdown reaches zero have no effect.
+  func signal() {
+    let didFinish = remaining.withLock { remaining in
+      guard remaining > 0 else { return false }
+      remaining -= 1
+      return remaining == 0
+    }
+
+    if didFinish {
+      completion.signal()
+    }
+  }
+
+  /// Suspends until every producer signals or the timeout expires.
+  func wait(for timeout: Duration) async -> Bool {
+    await completion.wait(for: timeout)
+  }
+}


### PR DESCRIPTION
## Summary

- add the synchronous, typed-throws `withGraphTransaction {}` API at the StateGraph `Stored` layer
- stage values in node-local typed buffers and join nested calls into one outer commit/rollback boundary
- coordinate outside writers while allowing committed reads during the transaction body
- publish multi-node commits atomically, preserving the existing comparator, Observation, graph invalidation, tracking, and `onDidSet` pipelines
- evaluate `Computed` values transaction-locally without leaking cache entries or dependency edges
- document nesting, callback batching, thread-local behavior, rollback limits for reference side effects, and external persistence boundaries
- merge current `main`, including #125's restored value-semantic `EntityStore`

## Design

The ambient context contains only weak participant commands; every `Stored<Value>` owns its own typed transaction buffer. Commit freezes a stable participant snapshot, evaluates comparators against committed-old/final-staged values, captures Observation `willSet` work behind a short reader drain, publishes every value and dirty state behind a second short barrier, and then delivers the existing callbacks outside node locks.

Mutations made synchronously by callbacks are staged into a following batch owned by the same outer transaction and are drained before the API returns. Rollback detaches node-local typed values while writer coordination is held, then destroys them after releasing that slot so arbitrary reference `deinit` work can safely reenter the graph.

A value-semantic `EntityStore` held in `Stored` or `@GraphStored` participates like any other Stored value. EntityStore-specific, database, and normalization transaction APIs remain unchanged. In-place mutation of a reference entity is an external side effect and cannot be rolled back.

`GraphUserDefault` persistence, database and normalization-specific transaction APIs, async/task-local propagation, and rollback of external side effects are intentionally outside this change.

## Follow-up hardening

- replace the CI-failing MainActor callback wait with continuation-backed test signals
- remove `DispatchSemaphore` from `GraphTransactionTests`; async test control now suspends, while only deliberate synchronous OS-thread barriers use a documented `NSCondition` gate
- fail closed if a future internal dependency node does not implement the two-phase invalidation required for atomic publication
- replace a fixed-duration Observation test sleep that could race another MainActor test during full parallel execution

## Validation

- `swift test --no-parallel --filter GraphTransactionTests` — 35/35 passed
- focused transaction suite with `--parallel --skip-build`, 20 consecutive runs — all passed
- `swift test --sanitize=thread --filter GraphTransactionTests` — 35/35 passed with no Thread Sanitizer report
- `swift test --no-parallel` — XCTest 17/17 and Swift Testing 176/176 passed
- full `swift test --parallel --skip-build`, 3 consecutive runs — all passed
- `swift build -c release` — passed (only pre-existing GraphTracking isolation-conversion warnings)
- `git diff --check` — passed

## Review notes

Independent final reviews covered lock ordering, ownership and rollback destruction, callback reentrancy, Computed cache/edge isolation, documentation, semaphore usage, and implementation complexity. After addressing the findings above, no P0-P2 issues remain.

The two publication barriers, separate Observation/post-publication callback queues, callback-owned next batch, and context-keyed rollback storage each protect a distinct required ordering or lifetime boundary. Removing any of them would reintroduce a demonstrated partial-visibility, callback, or reentrant-destruction race.

The main residual performance risk is that ordinary `Stored` access now passes through a shared coordinator and each commit uses two short reader drains. Correctness is covered by deterministic, repeated parallel, and Thread Sanitizer tests, but a representative application benchmark would still be useful before treating hot-path overhead as characterized.
