### PR TITLE
Restore EntityStore value semantics

### DIFF
--- a/Development/Development/PostView.swift
+++ b/Development/Development/PostView.swift
@@ -127,21 +127,19 @@ final class Comment: TypedIdentifiable, Sendable {
   }
 }
 
-/// Related entity stores that share one consistency boundary.
+/// Graph-owned entity collections used by the normalization demo.
 final class NormalizedStore: ComputedEnvironmentKey, Sendable {
 
   typealias Value = NormalizedStore
 
-  let users: EntityStore<User>
-  let posts: EntityStore<Post>
-  let comments: EntityStore<Comment>
+  @GraphStored
+  var users: EntityStore<User> = .init()
 
-  init() {
-    let coordinator = EntityStoreCoordinator()
-    self.users = .init(coordinator: coordinator)
-    self.posts = .init(coordinator: coordinator)
-    self.comments = .init(coordinator: coordinator)
-  }
+  @GraphStored
+  var posts: EntityStore<Post> = .init()
+
+  @GraphStored
+  var comments: EntityStore<Comment> = .init()
 }
 
 // MARK: Service

--- a/Documentation/Design-Notes/Stored-Mutation.md
+++ b/Documentation/Design-Notes/Stored-Mutation.md
@@ -1,0 +1,97 @@
+# Stored Value Mutation
+
+## Status
+
+Open design issue. This note describes current behavior and the constraints for
+a future mutation API; it is not a public API proposal.
+
+## Current Behavior
+
+`Stored` exposes its value through a getter and setter. Swift therefore
+materializes a nested mutation such as:
+
+```swift
+state.entities.add(entity)
+```
+
+as a read, a mutation of a temporary value, and a writeback. This preserves the
+normal `Stored` setter pipeline, including comparison, graph invalidation,
+Observation, tracking callbacks, and `onDidSet`.
+
+For a copy-on-write value such as `Dictionary`, materializing the temporary can
+make its backing storage appear shared. Its first mutation may then copy the
+backing buffer even when the `Stored` node is the only semantic owner. That
+first copy is required whenever another live value really does share the
+buffer; preserving value semantics is more important than eliminating every
+copy. The optimization target is avoiding copies introduced only by the
+getter/writeback mechanism and avoiding repeated copies within one logical
+mutation.
+
+The getter and setter do not together form one atomic read-modify-write
+operation. Two writers can read the same committed value, independently mutate
+their temporaries, and then overwrite each other. The last setter wins. A type
+stored inside `Stored` should not introduce its own reference-semantic
+coordinator merely to work around this Core-level limitation.
+
+Swift also performs the property writeback when a nested mutating method
+throws. The value may be logically unchanged, but a non-Equatable `Stored`
+still treats that writeback as an assignment and can publish its normal
+notifications. For example, `EntityStore.updateOrCreate` guarantees that it
+does not replace or insert a dictionary entry when its closure throws; it
+cannot guarantee that an enclosing `@GraphStored` property suppresses the
+unwinding writeback.
+
+## Why a Generic `_modify` Accessor Is Not the Answer
+
+An earlier `Stored` implementation yielded its value from `_modify` while
+holding the node lock. Swift can keep that accessor active for the full
+duration of a mutating call, including a mutating `async` method. Code that
+accesses the node again during that interval can deadlock. The regression is
+covered by `DeadlockTests` and was fixed in
+[PR #56](https://github.com/VergeGroup/swift-state-graph/pull/56).
+
+A graph node also must not execute invalidation or user callbacks while holding
+its value lock. Consequently, restoring a generic lock-holding `_modify`
+accessor is not an acceptable optimization.
+
+`unsafeModify(_:)` remains an intentionally low-level escape hatch. It bypasses
+the normal mutation pipeline and does not provide the semantics required by a
+general-purpose mutation API.
+
+## Desired Stored-Level API
+
+A future API should provide a synchronous, nonescaping mutation scope owned by
+`Stored`, rather than by individual container types. Its design must satisfy
+all of the following:
+
+- The mutation closure cannot suspend or escape.
+- Normal setters and scoped mutations participate in the same writer
+  coordination, so concurrent read-modify-write operations do not lose
+  updates.
+- The value is mutated without an avoidable getter/writeback copy. A real
+  shared copy-on-write buffer may still copy on its first mutation.
+- Repeated mutations inside one scope reuse the same mutable value.
+- Comparison, graph invalidation, Observation, tracking callbacks, and
+  `onDidSet` retain their documented ordering and occur after exclusive value
+  access ends.
+- No graph or user callback runs while a node lock or writer-coordination lock
+  is held.
+- Callback-triggered reentrant mutation cannot deadlock.
+- Throwing-closure behavior, including whether a failed mutation is published
+  or rolled back, is explicit and covered for both value and reference types.
+- Reads and computed dependencies continue to observe a coherent documented
+  value throughout the mutation.
+- Stress tests cover competing setters, scoped mutations, readers, and
+  reentrant callbacks.
+
+## Current Guidance
+
+Keep mutable application state, including value-semantic `EntityStore`
+instances, in `Stored` or `@GraphStored`. Prefer an operation that performs a
+whole batch in one method call when possible. Applications that permit
+concurrent mutation of the same property must currently serialize the complete
+read-modify-write operation at the owning actor or queue.
+
+This issue concerns in-memory `Stored` mutation. It does not require
+`EntityStore` to have reference semantics, and it is not a database transaction
+or rollback mechanism for external side effects.

--- a/Sources/StateGraph/Documentation.docc/Data-Normalization.md
+++ b/Sources/StateGraph/Documentation.docc/Data-Normalization.md
@@ -25,11 +25,10 @@ Data normalization involves storing entities in separate collections while maint
 ```swift
 import StateGraphNormalization
 
-// Creating related entity stores with one consistency boundary
-let coordinator = EntityStoreCoordinator()
-let userStore = EntityStore<User>(coordinator: coordinator)
-let postStore = EntityStore<Post>(coordinator: coordinator)
-let commentStore = EntityStore<Comment>(coordinator: coordinator)
+// Creating entity stores for different types
+var userStore = EntityStore<User>()
+var postStore = EntityStore<Post>()
+var commentStore = EntityStore<Comment>()
 
 // Adding entities
 userStore.add(user)
@@ -56,6 +55,12 @@ let count = userStore.count
 // Removing entities
 userStore.delete(userId)
 ```
+
+`EntityStore` is a value type. Mutating a copy's collection does not change the
+original collection, although reference-type entities remain shared unless you
+clone them separately. When an entity collection is shared application state,
+keep the `EntityStore` in a `@GraphStored` property so reads participate in
+dependency tracking and successful writebacks invalidate dependents.
 
 ### EntityStore Operations
 
@@ -119,22 +124,25 @@ let user = userStore.get(by: userId)
 
 ## NormalizedStore
 
-`NormalizedStore` acts as a central repository for managing multiple entity types. `EntityStore` has reference semantics and publishes its own graph updates, so store properties do not need `@GraphStored`. Give related stores one shared `EntityStoreCoordinator` to serialize operations across their tables:
+`NormalizedStore` acts as a central repository for managing multiple entity
+types. Because `EntityStore` has value semantics, the repository owns each
+entity collection in a `@GraphStored` property. Reading a collection from a
+computed value establishes a graph dependency, and mutating it writes the
+updated value back through the graph:
 
 ```swift
 final class NormalizedStore: Sendable {
-  let users: EntityStore<User>
-  let posts: EntityStore<Post>
-  let comments: EntityStore<Comment>
-  let tags: EntityStore<Tag>
+  @GraphStored
+  var users: EntityStore<User> = .init()
 
-  init() {
-    let coordinator = EntityStoreCoordinator()
-    self.users = .init(coordinator: coordinator)
-    self.posts = .init(coordinator: coordinator)
-    self.comments = .init(coordinator: coordinator)
-    self.tags = .init(coordinator: coordinator)
-  }
+  @GraphStored
+  var posts: EntityStore<Post> = .init()
+
+  @GraphStored
+  var comments: EntityStore<Comment> = .init()
+
+  @GraphStored
+  var tags: EntityStore<Tag> = .init()
 }
 
 // Create a single store instance for your app
@@ -510,5 +518,10 @@ userIds.forEach { userId in
   }
 }
 ```
+
+Each mutating call writes the updated `EntityStore` back to its owner. Prefer
+the bulk operations when the input is already available as a sequence. If
+multiple threads can mutate the same owning property, serialize those
+read-modify-write operations at the ownership boundary.
 
 Swift State Graph's normalization module provides a powerful foundation for building applications with complex data relationships while maintaining the benefits of reactive programming.

--- a/Sources/StateGraphNormalization/StateGraphNormalization.swift
+++ b/Sources/StateGraphNormalization/StateGraphNormalization.swift
@@ -1,256 +1,133 @@
 @_exported import StateGraph
 @_exported import TypedIdentifier
 
-import Foundation
 import TypedIdentifier
 
-/// Serializes access across a related set of entity stores.
+/// A value-semantic collection of entities indexed by typed identifiers.
 ///
-/// Give every ``EntityStore`` in one database the same coordinator to protect
-/// canonical entity lookup and mutation across tables. The lock is recursive
-/// because an entity import may synchronously access another coordinated store.
-public final class EntityStoreCoordinator: Sendable {
-
-  fileprivate let lock = NSRecursiveLock()
-
-  public init() {}
-}
-
-/// A uniquely owned canonical entity table.
+/// `EntityStore` deliberately contains only entity storage. It does not
+/// coordinate concurrent access or publish graph updates by itself. Store it in
+/// a ``Stored`` node, usually through ``GraphStored``, when reads and
+/// mutations should participate in a state graph.
 ///
-/// `EntityTable` is deliberately unsynchronized. ``EntityStore`` acquires its
-/// coordinator before beginning every borrow or exclusive access to this value.
-/// Keeping the dictionary inline avoids both an escaping copy and a second heap
-/// storage object.
-private struct EntityTable<T: TypedIdentifiable & Sendable>: ~Copyable {
+/// Like other Swift value types, copying an entity store creates an independent
+/// logical collection. The underlying dictionary uses copy-on-write storage.
+/// Copying a store does not clone reference-type entities contained in it.
+public struct EntityStore<T: TypedIdentifiable & Sendable>: Sendable {
 
   private var entities: [T.TypedID: T]
-  private var revision: UInt64 = 0
-
-  init(entities: consuming [T.TypedID: T]) {
-    self.entities = entities
-  }
-
-  borrowing func get(by id: T.TypedID) -> T? {
-    entities[id]
-  }
-
-  borrowing func getAll() -> [T] {
-    Array(entities.values)
-  }
-
-  borrowing func filter(_ predicate: (T) -> Bool) -> [T] {
-    entities.values.filter(predicate)
-  }
-
-  var isEmpty: Bool {
-    entities.isEmpty
-  }
-
-  var count: Int {
-    entities.count
-  }
-
-  borrowing func contains(_ id: T.TypedID) -> Bool {
-    entities[id] != nil
-  }
-
-  mutating func set(_ entity: T?, for id: T.TypedID) {
-    entities[id] = entity
-  }
-
-  @discardableResult
-  mutating func advanceRevision() -> UInt64 {
-    revision &+= 1
-    return revision
-  }
-}
-
-/// A graph-observable canonical entity collection.
-///
-/// `EntityStore` has reference semantics and owns one noncopyable entity table.
-/// Every table access begins after the supplied ``EntityStoreCoordinator`` is
-/// locked. Successful mutations update the table in place, end their exclusive
-/// access, and then publish one graph update.
-public final class EntityStore<T: TypedIdentifiable & Sendable>: Sendable {
-
-  private let coordinator: EntityStoreCoordinator
-  private let graphRevision: Stored<UInt64>
-
-  /// Mutable table storage guarded by `coordinator`.
-  ///
-  /// Every access must begin inside ``withLock(_:)``. The unsafe annotation is
-  /// limited to this property so `EntityStore` keeps checked `Sendable`
-  /// conformance for all other state.
-  nonisolated(unsafe) private var table: EntityTable<T>
 
   /// Creates an entity store.
   ///
-  /// - Parameters:
-  ///   - entities: The initial canonical entities, keyed by typed identifier.
-  ///   - coordinator: The coordinator shared by related entity stores.
-  ///     Omitting it creates an independently coordinated store.
-  public init(
-    entities: consuming [T.TypedID: T] = [:],
-    coordinator: EntityStoreCoordinator = .init()
-  ) {
-    self.coordinator = coordinator
-    self.graphRevision = .init(name: "EntityStore.revision", wrappedValue: 0)
-    self.table = .init(entities: entities)
+  /// - Parameter entities: The initial entities, keyed by typed identifier.
+  public init(entities: consuming [T.TypedID: T] = [:]) {
+    self.entities = entities
   }
 
+  /// Returns the entity associated with `id`.
   public func get(by id: T.TypedID) -> T? {
-    withLock {
-      trackAccess()
-      return table.get(by: id)
-    }
+    entities[id]
   }
 
-  /// Returns an independent snapshot of the current canonical entities.
+  /// Returns a snapshot of all entities in the store.
+  ///
+  /// The returned array has independent collection storage. Reference-type
+  /// entities in that array are not cloned.
   public func getAll() -> [T] {
-    withLock {
-      trackAccess()
-      return table.getAll()
+    Array(entities.values)
+  }
+
+  /// Inserts an entity, replacing an existing entity with the same identifier.
+  public mutating func add(_ entity: T) {
+    entities[entity.id] = entity
+  }
+
+  /// Inserts entities, replacing existing entities with matching identifiers.
+  public mutating func add(_ newEntities: some Sequence<T>) {
+    for entity in newEntities {
+      entities[entity.id] = entity
     }
   }
 
-  public func add(_ entity: T) {
-    mutate {
-      table.set(entity, for: entity.id)
-    }
+  /// Mutates the entity associated with `id`, when present.
+  ///
+  /// For a reference-type entity, this operation does not clone the referenced
+  /// object before passing it to `block`.
+  public mutating func modify(_ id: T.TypedID, _ block: (inout T) -> Void) {
+    guard var entity = entities[id] else { return }
+    block(&entity)
+    entities[id] = entity
   }
 
-  public func add(_ newEntities: some Sequence<T>) {
-    mutate {
-      for entity in newEntities {
-        table.set(entity, for: entity.id)
-      }
-    }
-  }
-
-  public func modify(_ id: T.TypedID, _ block: (inout T) -> Void) {
-    mutate {
-      guard var entity = table.get(by: id) else { return }
-      block(&entity)
-      table.set(entity, for: id)
-    }
-  }
-
+  /// Returns the entities that satisfy `predicate`.
   public func filter(_ predicate: (T) -> Bool) -> [T] {
-    withLock {
-      trackAccess()
-      return table.filter(predicate)
-    }
+    entities.values.filter(predicate)
   }
 
-  public func update(_ entity: T) {
-    mutate {
-      table.set(entity, for: entity.id)
-    }
+  /// Replaces the entity with the same identifier.
+  public mutating func update(_ entity: T) {
+    entities[entity.id] = entity
   }
 
-  public func delete(_ id: T.TypedID) {
-    mutate {
-      table.set(nil, for: id)
-    }
+  /// Removes the entity associated with `id`.
+  public mutating func delete(_ id: T.TypedID) {
+    entities.removeValue(forKey: id)
   }
 
+  /// A Boolean value that indicates whether the store contains no entities.
   public var isEmpty: Bool {
-    withLock {
-      trackAccess()
-      return table.isEmpty
-    }
+    entities.isEmpty
   }
 
+  /// The number of entities in the store.
   public var count: Int {
-    withLock {
-      trackAccess()
-      return table.count
-    }
+    entities.count
   }
 
+  /// Returns whether the store contains an entity associated with `id`.
   public func contains(_ id: T.TypedID) -> Bool {
-    withLock {
-      trackAccess()
-      return table.contains(id)
-    }
+    entities[id] != nil
   }
 
+  /// Accesses the entity associated with `id`.
   public subscript(_ id: T.TypedID) -> T? {
     get {
-      withLock {
-        trackAccess()
-        return table.get(by: id)
-      }
+      entities[id]
     }
     set {
-      mutate {
-        table.set(newValue, for: id)
-      }
+      entities[id] = newValue
     }
   }
 
-  /// Atomically updates an existing canonical entity or creates and inserts it.
+  /// Updates an existing entity or creates and inserts one.
   ///
-  /// The coordinator remains locked while `update` or `create` executes, so
-  /// concurrent calls for the same identifier converge on one stored entity.
-  /// A successful operation publishes one store update. If either closure
-  /// throws, the entity table is not mutated and the store does not publish an
-  /// update.
+  /// The dictionary entry is replaced or inserted only after the selected
+  /// closure returns successfully. If either closure throws, the entry itself
+  /// is not changed.
   ///
   /// The rollback guarantee follows `T`'s semantics. Mutations already applied
-  /// to a reference-type entity are not reverted when `update` throws.
+  /// through reference storage in an entity are not reverted when `update`
+  /// throws.
   ///
   /// - Parameters:
-  ///   - id: The identifier used to find an existing canonical entity.
+  ///   - id: The identifier used to find an existing entity.
   ///   - update: Updates the existing entity in place.
   ///   - create: Creates the entity when the identifier is not present.
-  /// - Returns: The updated or newly inserted canonical entity.
+  /// - Returns: The updated or newly inserted entity.
   @discardableResult
-  public func updateOrCreate<ResultError: Error>(
+  public mutating func updateOrCreate<ResultError: Error>(
     id: T.TypedID,
     update: (inout T) throws(ResultError) -> Void,
     create: () throws(ResultError) -> T
   ) throws(ResultError) -> T {
-    try mutate { () throws(ResultError) -> T in
-      if var entity = table.get(by: id) {
-        try update(&entity)
-        table.set(entity, for: id)
-        return entity
-      }
-
-      let entity = try create()
-      table.set(entity, for: entity.id)
+    if var entity = entities[id] {
+      try update(&entity)
+      entities[id] = entity
       return entity
     }
-  }
 
-  @discardableResult
-  private func withLock<Result, Failure: Error>(
-    _ body: () throws(Failure) -> Result
-  ) throws(Failure) -> Result {
-    coordinator.lock.lock()
-    defer { coordinator.lock.unlock() }
-    return try body()
-  }
-
-  @discardableResult
-  private func mutate<Result, Failure: Error>(
-    _ body: () throws(Failure) -> Result
-  ) throws(Failure) -> Result {
-    try withLock { () throws(Failure) -> Result in
-      let result = try body()
-      publishMutation()
-      return result
-    }
-  }
-
-  private func trackAccess() {
-    _ = graphRevision.wrappedValue
-  }
-
-  private func publishMutation() {
-    let revision = table.advanceRevision()
-    graphRevision.wrappedValue = revision
+    let entity = try create()
+    entities[entity.id] = entity
+    return entity
   }
 }

--- a/Tests/StateGraphNormalizationTests/NormalizationTests.swift
+++ b/Tests/StateGraphNormalizationTests/NormalizationTests.swift
@@ -1,7 +1,6 @@
 import Testing
 @testable import StateGraphNormalization
 import StateGraph
-import Dispatch
 import Foundation
 import os
 
@@ -133,27 +132,14 @@ final class NormalizedStore: ComputedEnvironmentKey, Sendable {
   
   typealias Value = NormalizedStore
 
-  let users: EntityStore<User>
-  let posts: EntityStore<Post>
-  let comments: EntityStore<Comment>
+  @GraphStored
+  var users: EntityStore<User> = .init()
 
-  init() {
-    let coordinator = EntityStoreCoordinator()
-    self.users = .init(coordinator: coordinator)
-    self.posts = .init(coordinator: coordinator)
-    self.comments = .init(coordinator: coordinator)
-  }
-}
+  @GraphStored
+  var posts: EntityStore<Post> = .init()
 
-private final class ConcurrentEntity: TypedIdentifiable, Sendable {
-
-  typealias TypedIdentifierRawValue = Int
-
-  let typedID: TypedID
-
-  init(id: Int) {
-    self.typedID = .init(id)
-  }
+  @GraphStored
+  var comments: EntityStore<Comment> = .init()
 }
 
 private struct ValueEntity: TypedIdentifiable, Sendable {
@@ -173,170 +159,92 @@ private enum MutationError: Error {
   case expected
 }
 
-private actor ConcurrentStartGate {
+/// Owns a value-semantic entity store at the StateGraph mutation boundary.
+private final class ValueStoreOwner: Sendable {
 
-  private let participantCount: Int
-  private var continuations: [CheckedContinuation<Void, Never>] = []
-
-  init(participantCount: Int) {
-    self.participantCount = participantCount
-  }
-
-  func wait() async {
-    if continuations.count + 1 == participantCount {
-      let continuations = self.continuations
-      self.continuations.removeAll()
-      continuations.forEach { $0.resume() }
-      return
-    }
-
-    await withCheckedContinuation { continuation in
-      continuations.append(continuation)
-    }
-  }
-}
-
-/// A one-shot signal that lets synchronous store callbacks resume async test code.
-///
-/// Waiting suspends the test task, which avoids exhausting cooperative-executor threads
-/// when synchronization tests run in parallel with the rest of the package.
-private final class TestSignal: @unchecked Sendable {
-
-  private struct State {
-    var isSignaled = false
-    var waiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
-  }
-
-  private let state = OSAllocatedUnfairLock(initialState: State())
-
-  func signal() {
-    let waiters = state.withLock { state in
-      guard !state.isSignaled else { return [CheckedContinuation<Bool, Never>]() }
-
-      state.isSignaled = true
-      let waiters = Array(state.waiters.values)
-      state.waiters.removeAll()
-      return waiters
-    }
-
-    waiters.forEach { $0.resume(returning: true) }
-  }
-
-  func wait(for timeout: Duration) async -> Bool {
-    let id = UUID()
-
-    return await withCheckedContinuation { continuation in
-      let isAlreadySignaled = state.withLock { state in
-        guard !state.isSignaled else { return true }
-        state.waiters[id] = continuation
-        return false
-      }
-
-      guard !isAlreadySignaled else {
-        continuation.resume(returning: true)
-        return
-      }
-
-      Task.detached { [self] in
-        try? await Task.sleep(for: timeout)
-        let waiter = state.withLock { state in
-          state.waiters.removeValue(forKey: id)
-        }
-        waiter?.resume(returning: false)
-      }
-    }
-  }
+  @GraphStored
+  var entities: EntityStore<ValueEntity> = .init()
 }
 
 @Suite
 struct NormalizationTests {
 
-  @Test func concurrentDistinctIDInsertionsAreNotLost() async {
-    let participantCount = 250
-    let gate = ConcurrentStartGate(participantCount: participantCount)
-    let store = EntityStore<ConcurrentEntity>()
+  @Test func copiedStoresMutateIndependently() {
+    var original = EntityStore<ValueEntity>()
+    original.add(.init(id: 1, value: 1))
 
-    await withTaskGroup(of: Void.self) { group in
-      for id in 0..<participantCount {
-        group.addTask {
-          await gate.wait()
-          store.add(.init(id: id))
-        }
-      }
+    var copy = original
+    copy.modify(.init(1)) { entity in
+      entity.value = 2
     }
+    copy.add(.init(id: 2, value: 2))
 
-    #expect(store.count == participantCount)
-    for id in 0..<participantCount {
-      #expect(store.contains(.init(id)))
-    }
+    #expect(original.get(by: .init(1))?.value == 1)
+    #expect(!original.contains(.init(2)))
+    #expect(copy.get(by: .init(1))?.value == 2)
+    #expect(copy.contains(.init(2)))
   }
 
-  @Test func concurrentSameIDUpdatesReturnOneCanonicalReference() async {
-    let participantCount = 100
-    let gate = ConcurrentStartGate(participantCount: participantCount)
-    let store = EntityStore<ConcurrentEntity>()
+  @Test func crudAndBatchOperations() {
+    var store = EntityStore<ValueEntity>()
 
-    let returnedEntities = await withTaskGroup(
-      of: ConcurrentEntity.self,
-      returning: [ConcurrentEntity].self
-    ) { group in
-      for _ in 0..<participantCount {
-        group.addTask {
-          await gate.wait()
-          return store.updateOrCreate(
-            id: .init(1),
-            update: { _ in },
-            create: { .init(id: 1) }
-          )
-        }
-      }
+    #expect(store.isEmpty)
 
-      return await group.reduce(into: []) { result, entity in
-        result.append(entity)
-      }
+    store.add(.init(id: 1, value: 1))
+    store.add([
+      .init(id: 2, value: 2),
+      .init(id: 3, value: 3),
+    ])
+
+    #expect(store.count == 3)
+    #expect(store.contains(.init(1)))
+    #expect(store.get(by: .init(2))?.value == 2)
+    #expect(store[.init(3)]?.value == 3)
+
+    store.modify(.init(1)) { entity in
+      entity.value = 10
     }
+    store.update(.init(id: 2, value: 20))
+    store[.init(3)] = .init(id: 3, value: 30)
 
-    let canonicalEntity = try! #require(store.get(by: .init(1)))
-    #expect(returnedEntities.allSatisfy { $0 === canonicalEntity })
+    #expect(store.get(by: .init(1))?.value == 10)
+    #expect(store.get(by: .init(2))?.value == 20)
+    #expect(store.get(by: .init(3))?.value == 30)
+    #expect(store.filter { $0.value >= 20 }.count == 2)
+
+    store.delete(.init(2))
+
+    #expect(!store.contains(.init(2)))
+    #expect(store.count == 2)
   }
 
-  @Test func batchMutationPublishesOneGraphUpdate() async {
-    let store = EntityStore<ValueEntity>()
-    let observedCounts = OSAllocatedUnfairLock(initialState: [Int]())
-
-    await confirmation(expectedCount: 2) { updates in
-      let stream = withStateGraphTrackingStream(apply: { store.count })
-      let trackingTask = Task {
-        for await count in stream {
-          observedCounts.withLock { $0.append(count) }
-          updates.confirm()
-          if count == 2 {
-            break
-          }
-        }
-      }
-
-      store.add([
-        .init(id: 1, value: 1),
-        .init(id: 2, value: 2),
-      ])
-      await trackingTask.value
-    }
-
-    #expect(observedCounts.withLock { $0 } == [0, 2])
-  }
-
-  @Test func failedValueUpdateDoesNotCommitOrPublish() {
-    let store = EntityStore<ValueEntity>(
+  @Test func updateOrCreateUpdatesOrInserts() {
+    var store = EntityStore<ValueEntity>(
       entities: [.init(1): .init(id: 1, value: 1)]
     )
-    let computationCount = OSAllocatedUnfairLock(initialState: 0)
-    let value = Computed { _ in
-      computationCount.withLock { $0 += 1 }
-      return store.get(by: .init(1))?.value
-    }
 
-    #expect(value.wrappedValue == 1)
+    let updated = store.updateOrCreate(
+      id: .init(1),
+      update: { $0.value = 2 },
+      create: { .init(id: 1, value: 999) }
+    )
+    let created = store.updateOrCreate(
+      id: .init(2),
+      update: { $0.value = 999 },
+      create: { .init(id: 2, value: 3) }
+    )
+
+    #expect(updated.value == 2)
+    #expect(created.value == 3)
+    #expect(store.get(by: .init(1))?.value == 2)
+    #expect(store.get(by: .init(2))?.value == 3)
+  }
+
+  @Test func failedValueUpdateDoesNotCommit() {
+    var store = EntityStore<ValueEntity>(
+      entities: [.init(1): .init(id: 1, value: 1)]
+    )
+
     #expect(throws: MutationError.self) {
       try store.updateOrCreate(
         id: .init(1),
@@ -351,135 +259,55 @@ struct NormalizationTests {
     }
 
     #expect(store.get(by: .init(1))?.value == 1)
-    #expect(value.wrappedValue == 1)
-    #expect(computationCount.withLock { $0 } == 1)
-  }
 
-  @Test func sharedCoordinatorSupportsNestedStoreMutation() {
-    let coordinator = EntityStoreCoordinator()
-    let parentStore = EntityStore<ValueEntity>(coordinator: coordinator)
-    let childStore = EntityStore<ValueEntity>(coordinator: coordinator)
-
-    parentStore.updateOrCreate(
-      id: .init(1),
-      update: { _ in },
-      create: {
-        childStore.add(.init(id: 2, value: 2))
-        return .init(id: 1, value: 1)
-      }
-    )
-
-    #expect(parentStore.contains(.init(1)))
-    #expect(childStore.contains(.init(2)))
-  }
-
-  @Test func readWaitsForCoordinatedMutation() async {
-    let coordinator = EntityStoreCoordinator()
-    let store = EntityStore<ValueEntity>(
-      entities: [.init(1): .init(id: 1, value: 1)],
-      coordinator: coordinator
-    )
-    let mutationStarted = TestSignal()
-    let allowMutationToFinish = DispatchSemaphore(value: 0)
-    let readStarted = TestSignal()
-    let readFinished = TestSignal()
-    let work = DispatchGroup()
-    let workFinished = TestSignal()
-    let readValue = OSAllocatedUnfairLock<Int?>(initialState: nil)
-
-    work.enter()
-    DispatchQueue.global().async {
-      store.updateOrCreate(
-        id: .init(1),
-        update: { entity in
-          entity.value = 2
-          mutationStarted.signal()
-          _ = allowMutationToFinish.wait(timeout: .now() + .seconds(5))
-        },
-        create: { .init(id: 1, value: 2) }
+    #expect(throws: MutationError.self) {
+      try store.updateOrCreate(
+        id: .init(2),
+        update: { _ throws(MutationError) in },
+        create: { () throws(MutationError) -> ValueEntity in
+          throw .expected
+        }
       )
-      work.leave()
     }
 
-    #expect(await mutationStarted.wait(for: .seconds(5)))
-
-    work.enter()
-    DispatchQueue.global().async {
-      readStarted.signal()
-      readValue.withLock { $0 = store.get(by: .init(1))?.value }
-      readFinished.signal()
-      work.leave()
-    }
-
-    work.notify(queue: .global()) {
-      workFinished.signal()
-    }
-
-    #expect(await readStarted.wait(for: .seconds(5)))
-    #expect(await !readFinished.wait(for: .milliseconds(100)))
-
-    allowMutationToFinish.signal()
-
-    #expect(await readFinished.wait(for: .seconds(5)))
-    #expect(await workFinished.wait(for: .seconds(5)))
-    #expect(readValue.withLock { $0 } == 2)
+    #expect(!store.contains(.init(2)))
   }
 
-  @Test func sharedCoordinatorBlocksReadsAcrossStores() async {
-    let coordinator = EntityStoreCoordinator()
-    let mutatingStore = EntityStore<ValueEntity>(
-      entities: [.init(1): .init(id: 1, value: 1)],
-      coordinator: coordinator
-    )
-    let readingStore = EntityStore<ValueEntity>(
-      entities: [.init(2): .init(id: 2, value: 2)],
-      coordinator: coordinator
-    )
-    let mutationStarted = TestSignal()
-    let allowMutationToFinish = DispatchSemaphore(value: 0)
-    let readStarted = TestSignal()
-    let readFinished = TestSignal()
-    let work = DispatchGroup()
-    let workFinished = TestSignal()
-
-    work.enter()
-    DispatchQueue.global().async {
-      mutatingStore.updateOrCreate(
-        id: .init(1),
-        update: { _ in
-          mutationStarted.signal()
-          _ = allowMutationToFinish.wait(timeout: .now() + .seconds(5))
-        },
-        create: { .init(id: 1, value: 1) }
-      )
-      work.leave()
+  @Test func graphStoredOwnerInvalidatesComputed() {
+    let owner = ValueStoreOwner()
+    let computationCount = OSAllocatedUnfairLock(initialState: 0)
+    let count = Computed { _ in
+      computationCount.withLock { $0 += 1 }
+      return owner.entities.count
     }
 
-    #expect(await mutationStarted.wait(for: .seconds(5)))
+    #expect(count.wrappedValue == 0)
 
-    work.enter()
-    DispatchQueue.global().async {
-      readStarted.signal()
-      _ = readingStore.get(by: .init(2))
-      readFinished.signal()
-      work.leave()
+    owner.entities.add(.init(id: 1, value: 1))
+
+    #expect(count.wrappedValue == 1)
+    #expect(computationCount.withLock { $0 } == 2)
+  }
+
+  @Test func batchMutationInvalidatesGraphTracking() async {
+    let owner = ValueStoreOwner()
+    let stream = withStateGraphTrackingStream {
+      owner.entities.count
     }
+    var iterator = stream.makeAsyncIterator()
 
-    work.notify(queue: .global()) {
-      workFinished.signal()
-    }
+    #expect(await iterator.next() == 0)
 
-    #expect(await readStarted.wait(for: .seconds(5)))
-    #expect(await !readFinished.wait(for: .milliseconds(100)))
+    owner.entities.add([
+      .init(id: 1, value: 1),
+      .init(id: 2, value: 2),
+    ])
 
-    allowMutationToFinish.signal()
-
-    #expect(await readFinished.wait(for: .seconds(5)))
-    #expect(await workFinished.wait(for: .seconds(5)))
+    #expect(await iterator.next() == 2)
   }
 
   @Test func getAllReturnsIndependentSnapshot() {
-    let store = EntityStore<ValueEntity>()
+    var store = EntityStore<ValueEntity>()
     store.add(.init(id: 1, value: 1))
 
     let snapshot = store.getAll()


### PR DESCRIPTION
## Summary

- restore `EntityStore` as a value-semantic `struct` backed directly by `Dictionary`
- remove `EntityStoreCoordinator`, internal locking/revision state, and EntityStore-owned graph publication
- keep the useful current `updateOrCreate` API and `[T]` snapshot returned by `getAll()`
- move graph ownership in the normalization demo and documentation back to `@GraphStored`
- replace Coordinator-specific concurrency tests with value-semantics, CRUD, rollback, Computed, and GraphTracking coverage
- add an internal design note for the remaining Stored-level COW and read-modify-write problem

## Why

`EntityStore` is an entity collection, not a concurrency or graph-publication coordinator. Its class-based implementation mixed those responsibilities into the normalization layer. Restoring the original value-semantic shape makes the ownership boundary explicit: applications place an `EntityStore` in `Stored` / `@GraphStored` when it is shared graph state, while copy optimization and concurrent read-modify-write coordination remain Core-level concerns.

## Migration impact

This intentionally changes the public ownership model:

- directly mutated local stores must be declared with `var`
- graph-owned stores should be held in `@GraphStored`
- `EntityStoreCoordinator` is removed
- direct shared concurrent mutation, same-ID convergence, read blocking, and cross-store serialization are no longer `EntityStore` guarantees

The design note also records current getter/writeback behavior: nested mutations can incur copy-on-write work, competing read-modify-write operations can lose updates unless serialized by the owner, and a throwing nested mutation can still trigger an enclosing non-Equatable `@GraphStored` writeback notification even when the dictionary entry was not committed.

## Validation

- `swift test --filter NormalizationTests --no-parallel` (9 tests)
- focused suite repeated in parallel 5 times
- `swift test --no-parallel` (141 tests)
- `swift build -c release`
- Development scheme compile-only Simulator build (iPhone 17)
- `git diff --check`
- independent simplicity/API review with no P0-P3 findings

This branch is based directly on `main` and does not depend on the ambient transaction PR.