### PR TITLE
Remove deprecated Stored.withLock

### DIFF
--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -220,14 +220,6 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     return try mutation(&value)
   }
 
-  /// Use `unsafeModify(_:)`; its name makes the notification and locking risks explicit.
-  @available(*, deprecated, renamed: "unsafeModify")
-  public borrowing func withLock<Result, E>(
-    _ body: (inout Value) throws(E) -> Result
-  ) throws(E) -> Result where E: Error {
-    try unsafeModify(body)
-  }
-
   /// Sets a closure to call after an assignment completes.
   public func onDidSet(_ handler: @escaping (Value, Value) -> Void) {
     lock.lock()


### PR DESCRIPTION
## Summary

- Remove the deprecated `Stored.withLock(_:)` forwarding API.
- Keep `Stored.unsafeModify(_:)` as the explicit API for bypassing assignment notifications and graph invalidation.
- Leave unrelated lock primitive `withLock` APIs unchanged.

## Motivation

`Stored.withLock(_:)` was renamed and deprecated in 0.25.0 because the old name did not communicate that this mutation bypasses StateGraph and Observation notifications and executes under the node lock. The compatibility alias is no longer used inside this repository and now adds an ambiguous mutation API alongside `unsafeModify(_:)`.

This is a source-breaking API removal. External callers should replace `stored.withLock { ... }` with `stored.unsafeModify { ... }`. It is appropriate for a minor release rather than a patch release.

## Validation

- `swift test --no-parallel` (17 XCTest tests and 141 Swift Testing tests passed)
- `git diff --check`
