### PR TITLE
Add borrowed Stored projections and graph-read lifetime deferral

### DIFF
--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -463,10 +463,48 @@ final class GraphTransactionCallbackDelivery {
 /// Marks an outer committed-graph read so nested node reads keep the same
 /// publication snapshot while a writer begins its barrier.
 final class GraphTransactionReadScope: @unchecked Sendable {
-  static let shared = GraphTransactionReadScope()
 
-  private init() {
+  /// Actions are appended and drained by the one thread that owns this scope.
+  private var deferredActions: [() -> Void] = []
+
+  func append(_ action: @escaping () -> Void) {
+    deferredActions.append(action)
   }
+
+  func finish() {
+    let actions = deferredActions
+    deferredActions = []
+
+    for action in actions {
+      action()
+    }
+  }
+}
+
+/// Defers work until the current committed graph read has released its barrier.
+///
+/// A `Computed` evaluation and all of its nested node reads share one committed
+/// graph read scope. When called from that scope, `action` runs after the scope's
+/// thread-local marker, reader admission, and node locks have been released. This
+/// is useful for ending the lifetime of values whose `deinit` may read the graph.
+///
+/// Graph transactions do not use the committed read scope. When no such scope is
+/// active, the function returns the original action without ending the lifetime of
+/// its captures. The caller can then transfer that action to another safe execution
+/// context.
+///
+/// - Parameter action: Work to perform after the current read completes.
+/// - Returns: `nil` when `action` was deferred, or the unconsumed action when no
+///   committed graph read is active.
+public func deferUntilGraphReadCompletes(
+  _ action: @escaping () -> Void
+) -> (() -> Void)? {
+  guard let scope = ThreadLocal.graphTransactionReadScope.value else {
+    return action
+  }
+
+  scope.append(action)
+  return nil
 }
 
 /// Marks one immediate writer admitted by the coordinator.
@@ -824,7 +862,8 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     activeReaderCount += 1
     condition.unlock()
 
-    let previousReadScope = ThreadLocal.graphTransactionReadScope.replaceValue(.shared)
+    let readScope = GraphTransactionReadScope()
+    let previousReadScope = ThreadLocal.graphTransactionReadScope.replaceValue(readScope)
 
     defer {
       ThreadLocal.graphTransactionReadScope.replaceValue(previousReadScope)
@@ -836,6 +875,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
         condition.broadcast()
       }
       condition.unlock()
+      readScope.finish()
     }
 
     return try body()

--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -89,12 +89,8 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
 
   public var wrappedValue: Value {
     get {
-      if ThreadLocal.graphTransaction.value != nil {
-        return transactionValue()
-      }
-
-      return GraphTransactionCoordinator.shared.withReadAccess {
-        committedValue()
+      withBorrowedValue { value in
+        value
       }
     }
     set {
@@ -109,11 +105,39 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     }
   }
 
-  /// Returns the transaction-visible value without adding committed graph edges.
+  /// Projects the current value without first copying its complete storage.
+  ///
+  /// The projection observes the same transaction-visible value and records the
+  /// same StateGraph, Observation, and tracking dependencies as ``wrappedValue``.
+  /// It is useful for selecting a small result from a large copy-on-write value
+  /// such as a dictionary-backed entity store.
+  ///
+  /// The closure runs synchronously while this node's lock is held. It must only
+  /// inspect `value` and derive its result. Calling node APIs, acquiring another
+  /// node's lock, or escaping the borrowed value itself is unsupported.
+  ///
+  /// - Parameter projection: A synchronous projection over the borrowed value.
+  /// - Returns: The result produced by `projection`.
+  public borrowing func withBorrowedValue<Result, Failure: Error>(
+    _ projection: (borrowing Value) throws(Failure) -> Result
+  ) throws(Failure) -> Result {
+    if ThreadLocal.graphTransaction.value != nil {
+      return try withBorrowedTransactionValue(projection)
+    }
+
+    return try GraphTransactionCoordinator.shared.withReadAccess {
+      () throws(Failure) -> Result in
+      try withBorrowedCommittedValue(projection)
+    }
+  }
+
+  /// Projects the transaction-visible value without adding committed graph edges.
   ///
   /// Body and comparator reads remain isolated. During synchronous callback delivery,
   /// Observation and graph-tracking passes may register directly with this leaf node.
-  private func transactionValue() -> Value {
+  private func withBorrowedTransactionValue<Result, Failure: Error>(
+    _ projection: (borrowing Value) throws(Failure) -> Result
+  ) throws(Failure) -> Result {
     let recordsDependencies =
       ThreadLocal.graphTransaction.value?.recordsDependencies == true
 
@@ -136,20 +160,22 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     }
 
     if transactionBuffer != nil {
-      return transactionBuffer!.value
+      return try projection(transactionBuffer!.value)
     }
 
     // Comparators run before publication. Their thread-local transaction context
     // still reads the complete pending commit while outside readers see `value`.
     if let transactionCommitWork {
-      return transactionCommitWork.newValue
+      return try projection(transactionCommitWork.newValue)
     }
 
-    return value
+    return try projection(value)
   }
 
-  /// Returns the committed value and records ordinary graph and tracking dependencies.
-  private func committedValue() -> Value {
+  /// Projects the committed value and records ordinary graph and tracking dependencies.
+  private func withBorrowedCommittedValue<Result, Failure: Error>(
+    _ projection: (borrowing Value) throws(Failure) -> Result
+  ) throws(Failure) -> Result {
 #if canImport(Observation)
     if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
       observationRegistrar.access(
@@ -172,7 +198,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
       trackingRegistrations.insert(registration)
     }
 
-    return value
+    return try projection(value)
   }
 
   /// Stages one assignment and then runs its assignment observer.

--- a/Tests/StateGraphTests/StoredBorrowedValueTests.swift
+++ b/Tests/StateGraphTests/StoredBorrowedValueTests.swift
@@ -1,0 +1,314 @@
+import Foundation
+import Testing
+import os
+
+@testable import StateGraph
+
+@Suite("Stored borrowed value access", .serialized)
+struct StoredBorrowedValueTests {
+
+  private enum ProjectionError: Error {
+    case rejected
+  }
+
+  @Test
+  func projectionTracksCommittedDependencies() {
+    let source = Stored(wrappedValue: [1: "First"])
+    let invocationCount = OSAllocatedUnfairLock(initialState: 0)
+    let selectedValue = Computed { _ in
+      invocationCount.withLock { $0 += 1 }
+      return source.withBorrowedValue { $0[1] }
+    }
+
+    #expect(selectedValue.wrappedValue == "First")
+    #expect(invocationCount.withLock { $0 } == 1)
+
+    source.wrappedValue[1] = "Second"
+
+    #expect(selectedValue.wrappedValue == "Second")
+    #expect(invocationCount.withLock { $0 } == 2)
+  }
+
+  @Test
+  func projectionReadsTransactionVisibleValue() {
+    let source = Stored(wrappedValue: [1: "Committed"])
+
+    withGraphTransaction {
+      source.wrappedValue[1] = "Staged"
+      #expect(source.withBorrowedValue { $0[1] } == "Staged")
+    }
+
+    #expect(source.withBorrowedValue { $0[1] } == "Staged")
+  }
+
+  @Test
+  func throwingProjectionReleasesTheNodeLock() {
+    let source = Stored(wrappedValue: 0)
+
+    #expect(throws: ProjectionError.rejected) {
+      try source.withBorrowedValue { _ throws(ProjectionError) -> Int in
+        throw .rejected
+      }
+    }
+
+    source.wrappedValue = 1
+    #expect(source.wrappedValue == 1)
+  }
+
+  @Test
+  func throwingProjectionStillFinishesDeferredReadWork() {
+    let source = Stored(wrappedValue: 0)
+    let invocationCount = OSAllocatedUnfairLock(initialState: 0)
+
+    #expect(throws: ProjectionError.rejected) {
+      try source.withBorrowedValue { _ throws(ProjectionError) -> Int in
+        let returnedAction = deferUntilGraphReadCompletes {
+          invocationCount.withLock { $0 += 1 }
+        }
+        #expect(returnedAction == nil)
+        throw .rejected
+      }
+    }
+
+    #expect(invocationCount.withLock { $0 } == 1)
+  }
+
+#if DEBUG
+  @Test
+  func deferredActionRunsAfterNodeLockAndReadAdmissionAreReleased() async {
+    let source = Stored(wrappedValue: 0)
+    let transactionStaged = TestSignal()
+    let resumeTransactionCommit = TestThreadGate()
+    let projectionStarted = TestSignal()
+    let resumeProjection = TestThreadGate()
+    let readerFinished = TestSignal()
+    let transactionFinished = TestSignal()
+    let publisherCheckFinished = TestSignal()
+    let deferredActionFinished = TestSignal()
+    let deferredReadFinished = TestThreadGate()
+
+    let transactionGatePassed = OSAllocatedUnfairLock<Bool?>(initialState: nil)
+    let projectionGatePassed = OSAllocatedUnfairLock<Bool?>(initialState: nil)
+    let didDefer = OSAllocatedUnfairLock<Bool?>(initialState: nil)
+    let didObserveBlockedPublisher = OSAllocatedUnfairLock<Bool?>(initialState: nil)
+    let deferredWorkerFinished = OSAllocatedUnfairLock<Bool?>(initialState: nil)
+    let deferredReadValue = OSAllocatedUnfairLock<Int?>(initialState: nil)
+    let shouldPauseProjection = OSAllocatedUnfairLock(initialState: true)
+    let computedBox = WeakObjectBox<Computed<Int>>()
+
+    let computed = Computed { _ in
+      let value = source.withBorrowedValue { $0 }
+      let shouldPause = shouldPauseProjection.withLock { value in
+        guard value else { return false }
+        value = false
+        return true
+      }
+
+      if shouldPause {
+        let returnedAction = deferUntilGraphReadCompletes {
+          Thread {
+            deferredReadValue.withLock {
+              $0 = computedBox.value?.wrappedValue
+            }
+            deferredReadFinished.open()
+          }.start()
+
+          let didFinish = deferredReadFinished.wait(
+            until: Date().addingTimeInterval(5)
+          )
+          deferredWorkerFinished.withLock { $0 = didFinish }
+          deferredActionFinished.signal()
+        }
+        let wasDeferred = returnedAction == nil
+        didDefer.withLock { $0 = wasDeferred }
+        projectionStarted.signal()
+
+        let didResume = resumeProjection.wait(
+          until: Date().addingTimeInterval(5)
+        )
+        projectionGatePassed.withLock { $0 = didResume }
+      }
+
+      return value
+    }
+    computedBox.value = computed
+
+    Thread {
+      withGraphTransaction {
+        source.wrappedValue = 1
+        transactionStaged.signal()
+
+        let didResume = resumeTransactionCommit.wait(
+          until: Date().addingTimeInterval(5)
+        )
+        transactionGatePassed.withLock { $0 = didResume }
+      }
+      transactionFinished.signal()
+    }.start()
+
+    #expect(await transactionStaged.wait(for: .seconds(5)))
+
+    Thread {
+      _ = computed.wrappedValue
+      readerFinished.signal()
+    }.start()
+
+    #expect(await projectionStarted.wait(for: .seconds(5)))
+    resumeTransactionCommit.open()
+
+    Thread {
+      let didBlock = GraphTransactionCoordinator.shared.__testing__waitForPublisherToBlock(
+        until: Date().addingTimeInterval(5)
+      )
+      didObserveBlockedPublisher.withLock { $0 = didBlock }
+      publisherCheckFinished.signal()
+    }.start()
+
+    #expect(await publisherCheckFinished.wait(for: .seconds(5)))
+    #expect(didObserveBlockedPublisher.withLock { $0 } == true)
+
+    resumeProjection.open()
+
+    #expect(await transactionFinished.wait(for: .seconds(5)))
+    #expect(await deferredActionFinished.wait(for: .seconds(5)))
+    #expect(await readerFinished.wait(for: .seconds(5)))
+    #expect(transactionGatePassed.withLock { $0 } == true)
+    #expect(projectionGatePassed.withLock { $0 } == true)
+    #expect(didDefer.withLock { $0 } == true)
+    #expect(deferredWorkerFinished.withLock { $0 } == true)
+    // A transaction has separate Observation-willSet and value-publication
+    // barriers. The deferred read may enter between them, but must complete with
+    // one whole committed snapshot after the original read and node locks unwind.
+    #expect(deferredReadValue.withLock { value in
+      value == 0 || value == 1
+    })
+  }
+#endif
+
+  @Test
+  func unavailableDeferralReturnsTheActionWithoutRunningIt() {
+    let didRun = OSAllocatedUnfairLock(initialState: false)
+
+    var returnedAction = deferUntilGraphReadCompletes {
+      didRun.withLock { $0 = true }
+    }
+
+    #expect(returnedAction != nil)
+    #expect(!didRun.withLock { $0 })
+
+    returnedAction?()
+    returnedAction = nil
+
+    #expect(didRun.withLock { $0 })
+  }
+
+  @Test
+  func unavailableDeferralPreservesASoleOwnedNonSendableCapture() {
+    let deinitCount = OSAllocatedUnfairLock(initialState: 0)
+
+    var returnedAction = deferUntilGraphReadCompletes({
+      let probe = NonSendableDeinitProbe {
+        deinitCount.withLock { $0 += 1 }
+      }
+      return { _ = probe }
+    }())
+
+    #expect(returnedAction != nil)
+    #expect(deinitCount.withLock { $0 } == 0)
+
+    returnedAction?()
+    #expect(deinitCount.withLock { $0 } == 0)
+
+    returnedAction = nil
+    #expect(deinitCount.withLock { $0 } == 1)
+  }
+
+  @Test
+  func transactionDeferralTransfersCaptureBeyondTheBorrowedNodeLock() {
+    let source = Stored(wrappedValue: 0)
+    let deinitCount = OSAllocatedUnfairLock(initialState: 0)
+    let valueReadFromDeinit = OSAllocatedUnfairLock<Int?>(initialState: nil)
+    var returnedAction: (() -> Void)?
+
+    withGraphTransaction {
+      source.wrappedValue = 1
+      returnedAction = source.withBorrowedValue { _ in
+        deferUntilGraphReadCompletes({
+          let probe = NonSendableDeinitProbe {
+            valueReadFromDeinit.withLock {
+              $0 = source.wrappedValue
+            }
+            deinitCount.withLock { $0 += 1 }
+          }
+          return { _ = probe }
+        }())
+      }
+
+      #expect(returnedAction != nil)
+      #expect(deinitCount.withLock { $0 } == 0)
+    }
+
+    #expect(source.wrappedValue == 1)
+    #expect(deinitCount.withLock { $0 } == 0)
+
+    returnedAction?()
+    returnedAction = nil
+
+    #expect(deinitCount.withLock { $0 } == 1)
+    #expect(valueReadFromDeinit.withLock { $0 } == 1)
+  }
+}
+
+private final class TestThreadGate: @unchecked Sendable {
+
+  private let condition = NSCondition()
+  private var isOpen = false
+
+  func open() {
+    condition.lock()
+    isOpen = true
+    condition.broadcast()
+    condition.unlock()
+  }
+
+  func wait(until deadline: Date) -> Bool {
+    condition.lock()
+    defer { condition.unlock() }
+
+    while !isOpen {
+      guard condition.wait(until: deadline) else {
+        return isOpen
+      }
+    }
+
+    return true
+  }
+}
+
+private final class NonSendableDeinitProbe {
+
+  private let onDeinit: () -> Void
+
+  init(onDeinit: @escaping () -> Void) {
+    self.onDeinit = onDeinit
+  }
+
+  deinit {
+    onDeinit()
+  }
+}
+
+private final class WeakObjectBox<Value: AnyObject & Sendable>: @unchecked Sendable {
+
+  private let lock = OSAllocatedUnfairLock<Void>()
+  nonisolated(unsafe) private weak var storedValue: Value?
+
+  var value: Value? {
+    get {
+      lock.withLock { storedValue }
+    }
+    set {
+      lock.withLock { storedValue = newValue }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add `Stored.withBorrowedValue` for transaction-visible, dependency-tracked projections without copying an entire stored collection
- add `deferUntilGraphReadCompletes` to transfer capture destruction beyond committed read and node-lock lifetimes
- preserve action ownership outside committed read scopes so callers can hand work to a safe fallback executor
- characterize committed, transactional, throwing, publication-barrier, and sole-owned capture behavior

## Motivation

Pairs `UnaryQuery` selects one canonical entity from `Stored<EntityStore<T>>`. It needs to avoid copying the whole dictionary-backed store and must not release replaced entity references while a graph or computed lock is active. These APIs are additive and keep that policy in StateGraph rather than relying on a consumer-global release queue.

## Verification

- `swift test --filter StoredBorrowedValueTests` (8 tests)
- `swift test` (188 tests / 35 suites)
- `swift build -c release`
- final read-only review with GPT-5.6 Sol Extra High: no findings

## Notes

- graph transactions do not use committed read scopes; the deferral API returns the unconsumed closure for caller-owned fallback execution
- rollback semantics are unchanged
- validation was run on macOS; Linux was source-reviewed but not executed in this environment