### PR TITLE
Preserve pending invalidation when a source is released

### DIFF
--- a/Sources/StateGraph/NodeStore.swift
+++ b/Sources/StateGraph/NodeStore.swift
@@ -15,15 +15,21 @@ public actor NodeStore {
     nodes.removeAll()
   }
 
-  /// Registers a node without making DEBUG instrumentation extend its lifetime.
+  /// Schedules a weak node registration without extending the node's lifetime.
   ///
-  /// The provider is resolved only after entering the actor. A node released while
-  /// the registration task is waiting therefore disappears normally.
-  func register(
-    nodeProvider: @Sendable () -> (any TypeErasedNode)?
-  ) {
-    guard isEnabled, let node = nodeProvider() else { return }
-    nodes.append(.init(node))
+  /// The weak reference is created synchronously before the actor hop. A node
+  /// released while the registration task is waiting therefore disappears normally.
+  nonisolated func register(_ node: any TypeErasedNode) {
+    let weakNode = WeakNode(node)
+
+    Task {
+      await register(weakNode: weakNode)
+    }
+  }
+
+  private func register(weakNode: WeakNode) {
+    guard isEnabled else { return }
+    nodes.append(weakNode)
     compact()  
   }
 
@@ -65,7 +71,7 @@ public actor NodeStore {
 
 }
 
-private struct WeakNode: Equatable {
+private struct WeakNode: Equatable, Sendable {
 
   static func == (lhs: WeakNode, rhs: WeakNode) -> Bool {
     return lhs.value === rhs.value

--- a/Sources/StateGraph/NodeStore.swift
+++ b/Sources/StateGraph/NodeStore.swift
@@ -15,8 +15,14 @@ public actor NodeStore {
     nodes.removeAll()
   }
 
-  func register(node: any TypeErasedNode) {
-    guard isEnabled else { return }
+  /// Registers a node without making DEBUG instrumentation extend its lifetime.
+  ///
+  /// The provider is resolved only after entering the actor. A node released while
+  /// the registration task is waiting therefore disappears normally.
+  func register(
+    nodeProvider: @Sendable () -> (any TypeErasedNode)?
+  ) {
+    guard isEnabled, let node = nodeProvider() else { return }
     nodes.append(.init(node))
     compact()  
   }

--- a/Sources/StateGraph/Primitives/Node.swift
+++ b/Sources/StateGraph/Primitives/Node.swift
@@ -33,15 +33,14 @@ extension TypeErasedNode {
     lock.unlock()
   }
 
-  /// Removes an incoming edge while holding the owning node's lock.
-  func removeIncomingEdge(_ edge: Edge) {
-    // A dirty target still needs this edge's pending bit to decide whether to
-    // recompute after the source has finished deinitializing.
-    guard !edge.isPending else { return }
-
-    lock.lock()
-    incomingEdges.removeAll(where: { $0 === edge })
-    lock.unlock()
+  /// Publishes the release of an incoming edge's source to its target.
+  ///
+  /// The target retains the detached edge as a pending tombstone until its next
+  /// read. This matters even when the source had no pending value change because
+  /// a weak source read may switch to a fallback when the source disappears.
+  func sourceDidRelease(_ edge: Edge) {
+    edge.isPending = true
+    potentiallyDirty = true
   }
 }
 

--- a/Sources/StateGraph/Primitives/Node.swift
+++ b/Sources/StateGraph/Primitives/Node.swift
@@ -35,6 +35,10 @@ extension TypeErasedNode {
 
   /// Removes an incoming edge while holding the owning node's lock.
   func removeIncomingEdge(_ edge: Edge) {
+    // A dirty target still needs this edge's pending bit to decide whether to
+    // recompute after the source has finished deinitializing.
+    guard !edge.isPending else { return }
+
     lock.lock()
     incomingEdges.removeAll(where: { $0 === edge })
     lock.unlock()

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -452,15 +452,14 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
 
     if !_potentiallyDirty && _cachedValue != nil { return }
 
-    incomingEdges.removeAll(where: { $0.from == nil })
-
     for edge in incomingEdges {
       edge.from?.recomputeIfNeeded()
     }
 
     let hasPendingIncomingEdge = incomingEdges.contains {
-      $0.from != nil && $0.isPending
+      $0.isPending
     }
+    incomingEdges.removeAll(where: { $0.from == nil })
 
     if hasPendingIncomingEdge || _cachedValue == nil {
 

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -330,9 +330,7 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
     self.lock = .init()
 
 #if DEBUG
-    Task { [weak self] in
-      await NodeStore.shared.register { [weak self] in self }
-    }
+    NodeStore.shared.register(self)
 #endif
   }
   
@@ -362,9 +360,7 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
     self.lock = .init()
 
 #if DEBUG
-    Task { [weak self] in
-      await NodeStore.shared.register { [weak self] in self }
-    }
+    NodeStore.shared.register(self)
 #endif
   }
 
@@ -394,9 +390,7 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
     self.lock = .init()
    
 #if DEBUG
-    Task { [weak self] in
-      await NodeStore.shared.register { [weak self] in self }
-    }
+    NodeStore.shared.register(self)
 #endif
   }
   

--- a/Sources/StateGraph/Primitives/StateGraph.swift
+++ b/Sources/StateGraph/Primitives/StateGraph.swift
@@ -331,8 +331,7 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
 
 #if DEBUG
     Task { [weak self] in
-      guard let self else { return }
-      await NodeStore.shared.register(node: self)
+      await NodeStore.shared.register { [weak self] in self }
     }
 #endif
   }
@@ -364,8 +363,7 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
 
 #if DEBUG
     Task { [weak self] in
-      guard let self else { return }
-      await NodeStore.shared.register(node: self)
+      await NodeStore.shared.register { [weak self] in self }
     }
 #endif
   }
@@ -397,8 +395,7 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
    
 #if DEBUG
     Task { [weak self] in
-      guard let self else { return }
-      await NodeStore.shared.register(node: self)
+      await NodeStore.shared.register { [weak self] in self }
     }
 #endif
   }
@@ -417,7 +414,7 @@ public final class Computed<Value: SendableMetatype>: Node, Observable, CustomDe
     }
 
     for edge in outgoingEdges {
-      edge.to?.removeIncomingEdge(edge)
+      edge.to?.sourceDidRelease(edge)
     }
   }
 

--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -505,9 +505,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     self.shouldNotify = shouldNotify
 
 #if DEBUG
-    Task { [weak self] in
-      await NodeStore.shared.register { [weak self] in self }
-    }
+    NodeStore.shared.register(self)
 #endif
   }
 

--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -506,8 +506,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
 
 #if DEBUG
     Task { [weak self] in
-      guard let self else { return }
-      await NodeStore.shared.register(node: self)
+      await NodeStore.shared.register { [weak self] in self }
     }
 #endif
   }
@@ -519,7 +518,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     lock.unlock()
 
     for edge in outgoingEdges {
-      edge.to?.removeIncomingEdge(edge)
+      edge.to?.sourceDidRelease(edge)
     }
   }
 

--- a/Tests/StateGraphTests/NodeLifecycleTests.swift
+++ b/Tests/StateGraphTests/NodeLifecycleTests.swift
@@ -1,6 +1,8 @@
-import StateGraph
+import Observation
 import Testing
 import os.lock
+
+@testable import StateGraph
 
 @Suite("Node Lifecycle Tests")
 struct NodeLifecycleTests {
@@ -57,6 +59,85 @@ struct NodeLifecycleTests {
 
     #expect(weakSource == nil)
     #expect(downstream.wrappedValue == 2)
+  }
+
+  @Test("Releasing an unchanged source invalidates a weak downstream read")
+  func releasingUnchangedSourceInvalidatesWeakDownstreamRead() {
+    var source: Stored<Int>? = Stored(wrappedValue: 1)
+    let downstream = Computed { [weak source] _ in
+      source?.wrappedValue ?? 0
+    }
+
+    #expect(downstream.wrappedValue == 1)
+
+    source = nil
+
+    #expect(downstream.wrappedValue == 0)
+  }
+
+  @Test("Releasing a dirty computed source preserves downstream invalidation")
+  func releasingDirtyComputedSourcePreservesDownstreamInvalidation() {
+    let source = Stored(wrappedValue: 1)
+    var intermediate: Computed<Int>? = Computed { _ in
+      source.wrappedValue
+    }
+    let downstream = Computed { [weak intermediate] _ in
+      intermediate?.wrappedValue ?? source.wrappedValue
+    }
+
+    #expect(downstream.wrappedValue == 1)
+
+    source.wrappedValue = 2
+    intermediate = nil
+
+    #expect(downstream.wrappedValue == 2)
+  }
+
+  @Test("Releasing a computed source during transaction willSet preserves invalidation")
+  @MainActor
+  func releasingComputedSourceDuringTransactionWillSetPreservesInvalidation() {
+    let source = Stored(wrappedValue: 1)
+    let intermediateHolder = OSAllocatedUnfairLock<Computed<Int>?>(
+      uncheckedState: nil
+    )
+    weak var weakIntermediate: Computed<Int>?
+    let downstream: Computed<Int> = {
+      let intermediate = Computed { _ in
+        source.wrappedValue
+      }
+      weakIntermediate = intermediate
+      intermediateHolder.withLock { $0 = intermediate }
+
+      return Computed { [weak intermediate] _ in
+        intermediate?.wrappedValue ?? source.wrappedValue
+      }
+    }()
+
+    #expect(downstream.wrappedValue == 1)
+
+    withObservationTracking {
+      _ = source.wrappedValue
+    } onChange: {
+      intermediateHolder.withLock { $0 = nil }
+    }
+
+    withGraphTransaction {
+      source.wrappedValue = 2
+    }
+
+    let intermediateWasReleased = weakIntermediate == nil
+    let downstreamWasDirty = downstream.potentiallyDirty
+    let incomingEdgeCount = downstream.incomingEdges.count
+    let sourceWasDetached = downstream.incomingEdges.first?.from == nil
+    let edgeWasPending = downstream.incomingEdges.first?.isPending == true
+    let resolvedValue = downstream.wrappedValue
+
+    #expect(intermediateWasReleased)
+    #expect(downstreamWasDirty)
+    #expect(incomingEdgeCount == 1)
+    #expect(sourceWasDetached)
+    #expect(edgeWasPending)
+    #expect(resolvedValue == 2)
   }
 }
 

--- a/Tests/StateGraphTests/NodeLifecycleTests.swift
+++ b/Tests/StateGraphTests/NodeLifecycleTests.swift
@@ -8,15 +8,14 @@ import os.lock
 struct NodeLifecycleTests {
 
   @Test
-  func releasingUpstreamComputedRemovesDownstreamEdge() async {
-    let trigger = Stored(wrappedValue: 0)
-    var upstream: Computed<Int>? = Computed { _ in 10 }
+  func releasingUpstreamComputedUsesDownstreamFallback() async {
+    var upstream: Computed<String>? = Computed { _ in "upstream" }
     weak let weakUpstream = upstream
     let downstream = Computed { [weak upstream] _ in
-      (upstream?.wrappedValue ?? 0) + trigger.wrappedValue
+      return upstream?.wrappedValue ?? "fallback"
     }
 
-    #expect(downstream.wrappedValue == 10)
+    #expect(downstream.wrappedValue == "upstream")
 
     upstream = nil
 
@@ -25,9 +24,7 @@ struct NodeLifecycleTests {
     }
 
     #expect(weakUpstream == nil)
-
-    trigger.wrappedValue = 1
-    #expect(downstream.wrappedValue == 1)
+    #expect(downstream.wrappedValue == "fallback")
   }
 
   @Test(
@@ -37,71 +34,71 @@ struct NodeLifecycleTests {
   func releasingChangedSourcePreservesPendingInvalidation(
     usesTransaction: Bool
   ) {
-    var source: Stored<Int>? = Stored(wrappedValue: 1)
+    var source: Stored<String>? = Stored(wrappedValue: "initial")
     weak let weakSource = source
     let reader = WeakStoredFallbackReader(source: source.unsafelyUnwrapped)
     let downstream = Computed { _ in
       reader.value
     }
 
-    #expect(downstream.wrappedValue == 1)
+    #expect(downstream.wrappedValue == "initial")
 
     if usesTransaction {
       withGraphTransaction {
-        source.unsafelyUnwrapped.wrappedValue = 2
+        source.unsafelyUnwrapped.wrappedValue = "updated"
       }
     } else {
-      source.unsafelyUnwrapped.wrappedValue = 2
+      source.unsafelyUnwrapped.wrappedValue = "updated"
     }
 
-    #expect(reader.value == 2)
+    #expect(reader.value == "updated")
     source = nil
 
     #expect(weakSource == nil)
-    #expect(downstream.wrappedValue == 2)
+    #expect(downstream.wrappedValue == "updated")
   }
 
   @Test("Releasing an unchanged source invalidates a weak downstream read")
   func releasingUnchangedSourceInvalidatesWeakDownstreamRead() {
-    var source: Stored<Int>? = Stored(wrappedValue: 1)
+    var source: Stored<String>? = Stored(wrappedValue: "source")
     let downstream = Computed { [weak source] _ in
-      source?.wrappedValue ?? 0
+      source?.wrappedValue ?? "fallback"
     }
 
-    #expect(downstream.wrappedValue == 1)
+    #expect(downstream.wrappedValue == "source")
 
     source = nil
 
-    #expect(downstream.wrappedValue == 0)
+    #expect(downstream.wrappedValue == "fallback")
   }
 
   @Test("Releasing a dirty computed source preserves downstream invalidation")
   func releasingDirtyComputedSourcePreservesDownstreamInvalidation() {
-    let source = Stored(wrappedValue: 1)
-    var intermediate: Computed<Int>? = Computed { _ in
+    let source = Stored(wrappedValue: "initial")
+    var intermediate: Computed<String>? = Computed { _ in
       source.wrappedValue
     }
     let downstream = Computed { [weak intermediate] _ in
       intermediate?.wrappedValue ?? source.wrappedValue
     }
 
-    #expect(downstream.wrappedValue == 1)
+    #expect(downstream.wrappedValue == "initial")
 
-    source.wrappedValue = 2
+    source.wrappedValue = "updated"
     intermediate = nil
 
-    #expect(downstream.wrappedValue == 2)
+    #expect(downstream.wrappedValue == "updated")
   }
 
   @Test("Releasing a computed source during transaction willSet preserves invalidation")
   @MainActor
   func releasingComputedSourceDuringTransactionWillSetPreservesInvalidation() {
-    let source = Stored(wrappedValue: 1)
-    let intermediateHolder = OSAllocatedUnfairLock<Computed<Int>?>(
+    let source = Stored(wrappedValue: "initial")
+    let intermediateHolder = OSAllocatedUnfairLock<Computed<String>?>(
       uncheckedState: nil
     )
-    weak var weakIntermediate: Computed<Int>?
-    let downstream: Computed<Int> = {
+    weak var weakIntermediate: Computed<String>?
+    let downstream: Computed<String> = {
       let intermediate = Computed { _ in
         source.wrappedValue
       }
@@ -113,7 +110,7 @@ struct NodeLifecycleTests {
       }
     }()
 
-    #expect(downstream.wrappedValue == 1)
+    #expect(downstream.wrappedValue == "initial")
 
     withObservationTracking {
       _ = source.wrappedValue
@@ -122,7 +119,7 @@ struct NodeLifecycleTests {
     }
 
     withGraphTransaction {
-      source.wrappedValue = 2
+      source.wrappedValue = "updated"
     }
 
     let intermediateWasReleased = weakIntermediate == nil
@@ -137,17 +134,17 @@ struct NodeLifecycleTests {
     #expect(incomingEdgeCount == 1)
     #expect(sourceWasDetached)
     #expect(edgeWasPending)
-    #expect(resolvedValue == 2)
+    #expect(resolvedValue == "updated")
   }
 }
 
 /// Reads through a weak source while preserving the last live result as a fallback.
 private final class WeakStoredFallbackReader: @unchecked Sendable {
 
-  private weak var source: Stored<Int>?
-  private let fallback: OSAllocatedUnfairLock<Int>
+  private weak var source: Stored<String>?
+  private let fallback: OSAllocatedUnfairLock<String>
 
-  var value: Int {
+  var value: String {
     guard let source else {
       return fallback.withLock { $0 }
     }
@@ -157,7 +154,7 @@ private final class WeakStoredFallbackReader: @unchecked Sendable {
     return value
   }
 
-  init(source: Stored<Int>) {
+  init(source: Stored<String>) {
     self.source = source
     self.fallback = .init(initialState: source.wrappedValue)
   }

--- a/Tests/StateGraphTests/NodeLifecycleTests.swift
+++ b/Tests/StateGraphTests/NodeLifecycleTests.swift
@@ -1,5 +1,6 @@
 import StateGraph
 import Testing
+import os.lock
 
 @Suite("Node Lifecycle Tests")
 struct NodeLifecycleTests {
@@ -25,5 +26,58 @@ struct NodeLifecycleTests {
 
     trigger.wrappedValue = 1
     #expect(downstream.wrappedValue == 1)
+  }
+
+  @Test(
+    "Releasing a changed source preserves its pending downstream invalidation",
+    arguments: [false, true]
+  )
+  func releasingChangedSourcePreservesPendingInvalidation(
+    usesTransaction: Bool
+  ) {
+    var source: Stored<Int>? = Stored(wrappedValue: 1)
+    weak let weakSource = source
+    let reader = WeakStoredFallbackReader(source: source.unsafelyUnwrapped)
+    let downstream = Computed { _ in
+      reader.value
+    }
+
+    #expect(downstream.wrappedValue == 1)
+
+    if usesTransaction {
+      withGraphTransaction {
+        source.unsafelyUnwrapped.wrappedValue = 2
+      }
+    } else {
+      source.unsafelyUnwrapped.wrappedValue = 2
+    }
+
+    #expect(reader.value == 2)
+    source = nil
+
+    #expect(weakSource == nil)
+    #expect(downstream.wrappedValue == 2)
+  }
+}
+
+/// Reads through a weak source while preserving the last live result as a fallback.
+private final class WeakStoredFallbackReader: @unchecked Sendable {
+
+  private weak var source: Stored<Int>?
+  private let fallback: OSAllocatedUnfairLock<Int>
+
+  var value: Int {
+    guard let source else {
+      return fallback.withLock { $0 }
+    }
+
+    let value = source.wrappedValue
+    fallback.withLock { $0 = value }
+    return value
+  }
+
+  init(source: Stored<Int>) {
+    self.source = source
+    self.fallback = .init(initialState: source.wrappedValue)
   }
 }


### PR DESCRIPTION
## Summary

- publish source deinitialization as a pending invalidation instead of dropping the dependency edge
- let `Computed` consume the detached pending tombstone before rebuilding its dependencies
- keep asynchronous DEBUG `NodeStore` registration from extending node lifetime
- characterize unchanged release, immediate chained invalidation, and release during transaction `willSet`

## Relation to #130

This PR is independently mergeable into `main`. It complements #130's borrowed-read and lifetime work for the Pairs `UnaryQuery` integration, but does not require #130's APIs.

## Verification

- `swift test --filter NodeLifecycleTests` (5/5 passed)
- `swift test --no-parallel --filter 'GraphTransactionTests|NodeLifecycleTests'` (41/41 passed)
- `swift test --no-parallel --quiet` (184 tests / 34 suites passed)
- `git diff --check`

## Review follow-up

- Addressed the standard review finding that `Computed -> Computed` invalidation can exist before the outgoing edge becomes pending.
- Added deterministic coverage for both an immediate write and a synchronous transaction `willSet` release.
