### PR TITLE
Prevent graph tracking cancellation deadlocks

### DIFF
--- a/Sources/StateGraph/Observation/GraphTrackingHandler.swift
+++ b/Sources/StateGraph/Observation/GraphTrackingHandler.swift
@@ -1,0 +1,91 @@
+/// Coordinates the lifetime and serialized execution of a graph tracking handler.
+///
+/// Cancellation and execution use separate synchronization domains:
+///
+/// - The lifetime state decides whether a new invocation may start and releases
+///   the stored handler when cancellation wins.
+/// - The execution gate serializes complete group/map passes, including child
+///   cleanup and the map projection/filter/delivery pipeline.
+///
+/// Cancellation is cooperative and non-waiting. An invocation that already captured
+/// the active handler is allowed to finish, while later invocations observe
+/// `.cancelled` and return without executing user code.
+///
+/// `@unchecked Sendable` applies to this container's synchronized shared state, not
+/// to the handler's captures. The continuous tracking caller remains responsible for
+/// executing an admitted handler in its requested actor-isolation context.
+final class GraphTrackingHandler: @unchecked Sendable {
+
+  /// The mutually exclusive lifetime states of the stored handler.
+  ///
+  /// Transitioning to `.cancelled` removes the handler from shared storage so an
+  /// inactive subscription does not retain the handler's captures.
+  private enum State {
+    case active(ClosureBox<Void>)
+    case cancelled
+  }
+
+  private let state: OSAllocatedUnfairLock<State>
+  private let executionGate = OSAllocatedUnfairLock<Void>()
+
+  init(_ handler: @escaping () -> Void) {
+    self.state = OSAllocatedUnfairLock(
+      uncheckedState: .active(ClosureBox(handler))
+    )
+  }
+
+  /// Whether cancellation has prevented future handler invocations.
+  var isCancelled: Bool {
+    state.withLock { state in
+      switch state {
+      case .active:
+        false
+      case .cancelled:
+        true
+      }
+    }
+  }
+
+  /// Prevents future invocations without waiting for an admitted invocation.
+  ///
+  /// The moved handler keeps its captures alive outside the state lock. An admitted
+  /// invocation may hold another snapshot until that invocation finishes.
+  func cancel() {
+    var releasedHandler = state.withLockUnchecked { state -> ClosureBox<Void>? in
+      switch state {
+      case .active(let handler):
+        state = .cancelled
+        return handler
+      case .cancelled:
+        return nil
+      }
+    }
+
+    withExtendedLifetime(releasedHandler) {}
+    releasedHandler = nil
+  }
+
+  /// Serializes one complete tracking pass if cancellation has not won admission.
+  ///
+  /// Capturing the active handler is the invocation's admission point relative to
+  /// ``cancel()``. The body may synchronously cancel this handler because cancellation
+  /// does not acquire the execution gate and no lifetime lock is held while the body runs.
+  ///
+  /// - Parameter body: Work that performs child cleanup, installs the current
+  ///   cancellable, and invokes the admitted handler.
+  func executeIfActive(_ body: (ClosureBox<Void>) -> Void) {
+    executionGate.withLockUnchecked {
+      let handler = state.withLockUnchecked { state -> ClosureBox<Void>? in
+        switch state {
+        case .active(let handler):
+          handler
+        case .cancelled:
+          nil
+        }
+      }
+
+      guard let handler else { return }
+      body(handler)
+    }
+  }
+}

--- a/Sources/StateGraph/Observation/withGraphTracking.swift
+++ b/Sources/StateGraph/Observation/withGraphTracking.swift
@@ -59,6 +59,10 @@
  - The returned `AnyCancellable` manages all subscriptions created within the scope
  - Subscriptions are automatically cancelled when the cancellable is deallocated
  - Use `cancellable.cancel()` for explicit cleanup
+ - Cancellation prevents later group/map handler invocations and releases stored
+   handler captures when they are no longer used by an admitted invocation
+ - An invocation that already started may finish after `cancel()` returns;
+   cancellation does not wait for in-flight handler completion
 
  - Parameter scope: A closure where you set up your node observations
  - Returns: An `AnyCancellable` that manages all subscriptions created within the scope

--- a/Sources/StateGraph/Observation/withGraphTrackingGroup.swift
+++ b/Sources/StateGraph/Observation/withGraphTrackingGroup.swift
@@ -104,40 +104,39 @@ public func withGraphTrackingGroup(
     return
   }
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
-    uncheckedState: ClosureBox(handler)
-  )
+  let trackingHandler = GraphTrackingHandler(handler)
 
   // Create a cancellable for this scope that manages nested tracking
   let scopeCancellable = GraphTrackingCancellable {
-    _handlerBox.withLock { $0 = nil }
+    trackingHandler.cancel()
   }
 
-  withContinuousStateGraphTracking(
-    apply: {
-      // Cancel all children before re-executing (cleans up nested subscriptions)
-      scopeCancellable.cancelChildren()
-
-      // Set this scope's cancellable as the current parent for nested tracking
-      // Nested groups/maps will register with this parent via addChild()
-      ThreadLocal.currentCancellable.withValue(scopeCancellable) {
-        _handlerBox.withLock {
-          $0?()
-        }
-      }
-    },
-    didChange: {
-      guard !_handlerBox.withLock({ $0 == nil }) else { return .stop }
-      return .next
-    },
-    isolation: isolation
-  )
-
-  // Register with parent or root subscriptions
+  // Register before the initial invocation. A child created after its parent was
+  // cancelled is cancelled immediately and never executes its initial handler.
   if let parent = parentCancellable {
     parent.addChild(scopeCancellable)
   } else {
     subscriptions!.append(AnyCancellable(scopeCancellable))
   }
+
+  withContinuousStateGraphTracking(
+    apply: {
+      trackingHandler.executeIfActive { handler in
+        // Cancel all children before re-executing (cleans up nested subscriptions)
+        scopeCancellable.cancelChildren()
+
+        // Set this scope's cancellable as the current parent for nested tracking
+        // Nested groups/maps will register with this parent via addChild()
+        ThreadLocal.currentCancellable.withValue(scopeCancellable) {
+          handler()
+        }
+      }
+    },
+    didChange: {
+      guard !trackingHandler.isCancelled else { return .stop }
+      return .next
+    },
+    isolation: isolation
+  )
 
 }

--- a/Sources/StateGraph/Observation/withGraphTrackingMap.swift
+++ b/Sources/StateGraph/Observation/withGraphTrackingMap.swift
@@ -143,45 +143,45 @@ public func withGraphTrackingMap<Projection>(
 
   var filter = filter
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
-    uncheckedState: ClosureBox({
-      let result = applier()
-      let filtered = filter.send(value: result)
-      if let filtered {
-        onChange(filtered)
-      }
-    })
-  )
+  let trackingHandler = GraphTrackingHandler {
+    let result = applier()
+    let filtered = filter.send(value: result)
+    if let filtered {
+      onChange(filtered)
+    }
+  }
 
   // Create a cancellable for this scope that manages nested tracking
   let scopeCancellable = GraphTrackingCancellable {
-    _handlerBox.withLock { $0 = nil }
+    trackingHandler.cancel()
   }
 
-  withContinuousStateGraphTracking(
-    apply: {
-      // Cancel all children before re-executing (cleans up nested subscriptions)
-      scopeCancellable.cancelChildren()
-
-      // Set this scope's cancellable as the current parent for nested tracking
-      // Nested groups/maps will register with this parent via addChild()
-      ThreadLocal.currentCancellable.withValue(scopeCancellable) {
-        _handlerBox.withLock { $0?() }
-      }
-    },
-    didChange: {
-      guard !_handlerBox.withLock({ $0 == nil }) else { return .stop }
-      return .next
-    },
-    isolation: isolation
-  )
-
-  // Register with parent cancellable (nested) or root subscriptions (top-level)
+  // Register before the initial invocation so a cancelled parent can reject it.
   if let parent = parentCancellable {
     parent.addChild(scopeCancellable)
   } else {
     subscriptions!.append(AnyCancellable(scopeCancellable))
   }
+
+  withContinuousStateGraphTracking(
+    apply: {
+      trackingHandler.executeIfActive { handler in
+        // Cancel all children before re-executing (cleans up nested subscriptions)
+        scopeCancellable.cancelChildren()
+
+        // Set this scope's cancellable as the current parent for nested tracking
+        // Nested groups/maps will register with this parent via addChild()
+        ThreadLocal.currentCancellable.withValue(scopeCancellable) {
+          handler()
+        }
+      }
+    },
+    didChange: {
+      guard !trackingHandler.isCancelled else { return .stop }
+      return .next
+    },
+    isolation: isolation
+  )
 
 }
 
@@ -317,51 +317,51 @@ public func withGraphTrackingMap<Dependency: AnyObject, Projection>(
 
   var filter = filter
 
-  let _handlerBox = OSAllocatedUnfairLock<ClosureBox<Void>?>(
-    uncheckedState: ClosureBox({
-      guard let dependency = weakDependency else {
-        return
-      }
-      let result = map(dependency)
-      let filtered = filter.send(value: result)
-      if let filtered {
-        onChange(filtered)
-      }
-    })
-  )
+  let trackingHandler = GraphTrackingHandler {
+    guard let dependency = weakDependency else {
+      return
+    }
+    let result = map(dependency)
+    let filtered = filter.send(value: result)
+    if let filtered {
+      onChange(filtered)
+    }
+  }
 
   // Create a cancellable for this scope that manages nested tracking
   let scopeCancellable = GraphTrackingCancellable {
-    _handlerBox.withLock { $0 = nil }
+    trackingHandler.cancel()
   }
 
-  withContinuousStateGraphTracking(
-    apply: {
-      guard weakDependency != nil else {
-        _handlerBox.withLock { $0 = nil }
-        return
-      }
-      // Cancel all children before re-executing (cleans up nested subscriptions)
-      scopeCancellable.cancelChildren()
-
-      // Set this scope's cancellable as the current parent for nested tracking
-      // Nested groups/maps will register with this parent via addChild()
-      ThreadLocal.currentCancellable.withValue(scopeCancellable) {
-        _handlerBox.withLock { $0?() }
-      }
-    },
-    didChange: {
-      guard !_handlerBox.withLock({ $0 == nil }) else { return .stop }
-      guard weakDependency != nil else { return .stop }
-      return .next
-    },
-    isolation: isolation
-  )
-
-  // Register with parent cancellable (nested) or root subscriptions (top-level)
+  // Register before the initial invocation so a cancelled parent can reject it.
   if let parent = parentCancellable {
     parent.addChild(scopeCancellable)
   } else {
     subscriptions!.append(AnyCancellable(scopeCancellable))
   }
+
+  withContinuousStateGraphTracking(
+    apply: {
+      trackingHandler.executeIfActive { handler in
+        guard weakDependency != nil else {
+          trackingHandler.cancel()
+          return
+        }
+        // Cancel all children before re-executing (cleans up nested subscriptions)
+        scopeCancellable.cancelChildren()
+
+        // Set this scope's cancellable as the current parent for nested tracking
+        // Nested groups/maps will register with this parent via addChild()
+        ThreadLocal.currentCancellable.withValue(scopeCancellable) {
+          handler()
+        }
+      }
+    },
+    didChange: {
+      guard !trackingHandler.isCancelled else { return .stop }
+      guard weakDependency != nil else { return .stop }
+      return .next
+    },
+    isolation: isolation
+  )
 }

--- a/Tests/StateGraphTests/GraphTrackingCancellationTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingCancellationTests.swift
@@ -186,6 +186,185 @@ struct GraphTrackingCancellationTests {
 
   }
 
+  /// Cancels a group's root subscription from that group's rerun handler.
+  ///
+  /// The admitted invocation continues after `cancel()` returns. The same subscription
+  /// must not attempt to reacquire its nonrecursive execution gate during cancellation.
+  @Test
+  func groupScopeSelfCancellationReturns() async {
+    let invalidationTrigger = Stored(wrappedValue: 0)
+    let rootSubscription = OSAllocatedUnfairLock<AnyCancellable?>(uncheckedState: nil)
+
+    await withCheckedContinuation { continuation in
+      let subscription = withGraphTracking {
+        withGraphTrackingGroup(
+          {
+            guard invalidationTrigger.wrappedValue == 1 else { return }
+
+            rootSubscription.withLockUnchecked { $0 }?.cancel()
+            continuation.resume()
+          },
+          isolation: nil
+        )
+      }
+
+      rootSubscription.withLockUnchecked { $0 = subscription }
+      invalidationTrigger.wrappedValue = 1
+    }
+  }
+
+  /// Allows an admitted map pipeline to finish after its applier cancels the scope.
+  @Test
+  func mapPipelineFinishesAfterSelfCancellation() async {
+    let invalidationTrigger = Stored(wrappedValue: 0)
+    let rootSubscription = OSAllocatedUnfairLock<AnyCancellable?>(uncheckedState: nil)
+
+    await withCheckedContinuation { continuation in
+      let subscription = withGraphTracking {
+        withGraphTrackingMap(
+          {
+            let value = invalidationTrigger.wrappedValue
+            if value == 1 {
+              rootSubscription.withLockUnchecked { $0 }?.cancel()
+            }
+            return value
+          },
+          onChange: { value in
+            guard value == 1 else { return }
+            continuation.resume()
+          },
+          isolation: nil
+        )
+      }
+
+      rootSubscription.withLockUnchecked { $0 = subscription }
+      invalidationTrigger.wrappedValue = 1
+    }
+  }
+
+  /// Does not treat `cancel()` as a barrier for an invocation that already started.
+  @Test
+  func cancellationReturnsBeforeAdmittedHandlerFinishes() async {
+    let invalidationTrigger = Stored(wrappedValue: 0)
+    let handlerStarted = TestSignal()
+    let resumeHandler = DispatchSemaphore(value: 0)
+    let handlerFinished = TestSignal()
+    let cancellationReturned = TestSignal()
+    let rootSubscription = OSAllocatedUnfairLock<AnyCancellable?>(uncheckedState: nil)
+
+    let subscription = withGraphTracking {
+      withGraphTrackingGroup(
+        {
+          guard invalidationTrigger.wrappedValue == 1 else { return }
+
+          handlerStarted.signal()
+          resumeHandler.wait()
+          handlerFinished.signal()
+        },
+        isolation: nil
+      )
+    }
+    rootSubscription.withLockUnchecked { $0 = subscription }
+    defer {
+      resumeHandler.signal()
+      subscription.cancel()
+    }
+
+    invalidationTrigger.wrappedValue = 1
+    #expect(await handlerStarted.wait(for: .seconds(5)))
+
+    DispatchQueue.global().async {
+      rootSubscription.withLockUnchecked { $0 }?.cancel()
+      cancellationReturned.signal()
+    }
+
+    #expect(await cancellationReturned.wait(for: .seconds(5)))
+    resumeHandler.signal()
+    #expect(await handlerFinished.wait(for: .seconds(5)))
+  }
+
+  /// Rejects a nested handler created after its current parent was cancelled.
+  @Test
+  func nestedHandlerCreatedAfterCancellationDoesNotStart() async {
+    let invalidationTrigger = Stored(wrappedValue: 0)
+    let nestedGroupInvocationCount = Counter()
+    let nestedMapInvocationCount = Counter()
+    let rootSubscription = OSAllocatedUnfairLock<AnyCancellable?>(uncheckedState: nil)
+
+    await withCheckedContinuation { continuation in
+      let subscription = withGraphTracking {
+        withGraphTrackingGroup(
+          {
+            guard invalidationTrigger.wrappedValue == 1 else { return }
+
+            rootSubscription.withLockUnchecked { $0 }?.cancel()
+
+            withGraphTrackingGroup {
+              nestedGroupInvocationCount.increment()
+            }
+
+            withGraphTrackingMap(
+              {
+                nestedMapInvocationCount.increment()
+                return 0
+              },
+              onChange: { _ in },
+              isolation: nil
+            )
+
+            continuation.resume()
+          },
+          isolation: nil
+        )
+      }
+
+      rootSubscription.withLockUnchecked { $0 = subscription }
+      invalidationTrigger.wrappedValue = 1
+    }
+
+    #expect(nestedGroupInvocationCount.current == 0)
+    #expect(nestedMapInvocationCount.current == 0)
+  }
+
+  /// Prevents a pass contending for the execution gate from starting after cancellation.
+  @Test
+  func invocationContendingForExecutionGateDoesNotStartAfterCancellation() async {
+    let trackingHandler = GraphTrackingHandler {}
+    let firstInvocationStarted = TestSignal()
+    let releaseFirstInvocation = DispatchSemaphore(value: 0)
+    let firstInvocationFinished = TestSignal()
+    let secondInvocationIsReady = TestSignal()
+    let secondInvocationReturned = TestSignal()
+    let secondInvocationCount = Counter()
+
+    DispatchQueue.global().async {
+      trackingHandler.executeIfActive { _ in
+        firstInvocationStarted.signal()
+        releaseFirstInvocation.wait()
+      }
+      firstInvocationFinished.signal()
+    }
+    defer { releaseFirstInvocation.signal() }
+
+    #expect(await firstInvocationStarted.wait(for: .seconds(5)))
+
+    DispatchQueue.global().async {
+      secondInvocationIsReady.signal()
+      trackingHandler.executeIfActive { _ in
+        secondInvocationCount.increment()
+      }
+      secondInvocationReturned.signal()
+    }
+
+    #expect(await secondInvocationIsReady.wait(for: .seconds(5)))
+    trackingHandler.cancel()
+    releaseFirstInvocation.signal()
+
+    #expect(await firstInvocationFinished.wait(for: .seconds(5)))
+    #expect(await secondInvocationReturned.wait(for: .seconds(5)))
+    #expect(secondInvocationCount.current == 0)
+  }
+
   @Test
   func cancellationCallbackCanCancelTheSameCancellable() {
     let holder = OSAllocatedUnfairLock<GraphTrackingCancellable?>(initialState: nil)


### PR DESCRIPTION
## What changed

- Separate handler lifetime/cancellation state from the execution gate.
- Make cancellation cooperative: an admitted group/map pass may finish, while later passes are skipped.
- Register nested tracking scopes before their initial invocation so cancelled parents reject new child handlers.
- Serialize the complete map pipeline, including child cleanup, projection, filtering, and `onChange`.
- Add regression tests for self-cancellation, non-waiting cancellation, nested cancellation, and gate contention.

## Why

The previous implementation invoked user code while holding the handler's non-recursive `OSAllocatedUnfairLock`. Cancelling the same tracking scope from that handler recursively acquired the lock and could abort on Darwin with a recursive `os_unfair_lock` error.

## Validation

- `xcrun swift test --filter GraphTrackingCancellationTests` — 12 tests passed.
- Full test suite was previously verified on this commit family: XCTest 24 and Swift Testing 185 passed.
- `git show --check HEAD` passed.