### PR TITLE
Stabilize parallel coordination tests

### DIFF
--- a/Tests/StateGraphTests/GraphTrackingCancellationTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingCancellationTests.swift
@@ -246,8 +246,8 @@ struct GraphTrackingCancellationTests {
   @Test
   func cancellationReturnsBeforeAdmittedHandlerFinishes() async {
     let invalidationTrigger = Stored(wrappedValue: 0)
-    let handlerStarted = DispatchSemaphore(value: 0)
-    let resumeHandler = DispatchSemaphore(value: 0)
+    let handlerStarted = TestThreadSignal()
+    let resumeHandler = TestThreadGate()
     let handlerFinished = TestSignal()
     let coordinatorFinished = TestSignal()
     let handlerDidFinish = OSAllocatedUnfairLock(initialState: false)
@@ -261,7 +261,7 @@ struct GraphTrackingCancellationTests {
           guard invalidationTrigger.wrappedValue == 1 else { return }
 
           handlerStarted.signal()
-          resumeHandler.wait()
+          resumeHandler.wait(until: .distantFuture)
           handlerDidFinish.withLock { $0 = true }
           handlerFinished.signal()
         },
@@ -270,7 +270,7 @@ struct GraphTrackingCancellationTests {
     }
     rootSubscription.withLockUnchecked { $0 = subscription }
     defer {
-      resumeHandler.signal()
+      resumeHandler.open()
       subscription.cancel()
     }
 
@@ -278,11 +278,11 @@ struct GraphTrackingCancellationTests {
     // cooperative executor while the admitted handler occupies one of its workers.
     Thread {
       defer {
-        resumeHandler.signal()
+        resumeHandler.open()
         coordinatorFinished.signal()
       }
 
-      let didStart = handlerStarted.wait(timeout: .now() + .seconds(5)) == .success
+      let didStart = handlerStarted.wait(until: Date().addingTimeInterval(5))
       didObserveHandlerStart.withLock { $0 = didStart }
       guard didStart else { return }
 
@@ -348,11 +348,11 @@ struct GraphTrackingCancellationTests {
   @Test
   func invocationContendingForExecutionGateDoesNotStartAfterCancellation() async {
     let trackingHandler = GraphTrackingHandler {}
-    let firstInvocationStarted = DispatchSemaphore(value: 0)
-    let releaseFirstInvocation = DispatchSemaphore(value: 0)
-    let firstInvocationFinished = DispatchSemaphore(value: 0)
-    let secondInvocationIsReady = DispatchSemaphore(value: 0)
-    let secondInvocationReturned = DispatchSemaphore(value: 0)
+    let firstInvocationStarted = TestThreadSignal()
+    let releaseFirstInvocation = TestThreadGate()
+    let firstInvocationFinished = TestThreadSignal()
+    let secondInvocationIsReady = TestThreadSignal()
+    let secondInvocationReturned = TestThreadSignal()
     let secondInvocationCount = Counter()
     let coordinatorFinished = TestSignal()
     let scenarioResult = OSAllocatedUnfairLock(
@@ -367,21 +367,18 @@ struct GraphTrackingCancellationTests {
     Thread {
       trackingHandler.executeIfActive { _ in
         firstInvocationStarted.signal()
-        releaseFirstInvocation.wait()
+        releaseFirstInvocation.wait(until: .distantFuture)
       }
       firstInvocationFinished.signal()
     }.start()
 
-    // Sequence the two blocking invocations on dedicated OS threads. The async test task
-    // only resumes after every synchronous handoff has completed.
     Thread {
       defer {
-        releaseFirstInvocation.signal()
+        releaseFirstInvocation.open()
         coordinatorFinished.signal()
       }
 
-      let firstDidStart =
-        firstInvocationStarted.wait(timeout: .now() + .seconds(5)) == .success
+      let firstDidStart = firstInvocationStarted.wait(until: Date().addingTimeInterval(5))
       scenarioResult.withLock { $0.firstInvocationStarted = firstDidStart }
       guard firstDidStart else { return }
 
@@ -393,18 +390,15 @@ struct GraphTrackingCancellationTests {
         secondInvocationReturned.signal()
       }.start()
 
-      let secondIsReady =
-        secondInvocationIsReady.wait(timeout: .now() + .seconds(5)) == .success
+      let secondIsReady = secondInvocationIsReady.wait(until: Date().addingTimeInterval(5))
       scenarioResult.withLock { $0.secondInvocationIsReady = secondIsReady }
       guard secondIsReady else { return }
 
       trackingHandler.cancel()
-      releaseFirstInvocation.signal()
+      releaseFirstInvocation.open()
 
-      let firstDidFinish =
-        firstInvocationFinished.wait(timeout: .now() + .seconds(5)) == .success
-      let secondDidReturn =
-        secondInvocationReturned.wait(timeout: .now() + .seconds(5)) == .success
+      let firstDidFinish = firstInvocationFinished.wait(until: Date().addingTimeInterval(5))
+      let secondDidReturn = secondInvocationReturned.wait(until: Date().addingTimeInterval(5))
       scenarioResult.withLock {
         $0.firstInvocationFinished = firstDidFinish
         $0.secondInvocationReturned = secondDidReturn

--- a/Tests/StateGraphTests/GraphTrackingCancellationTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingCancellationTests.swift
@@ -246,10 +246,13 @@ struct GraphTrackingCancellationTests {
   @Test
   func cancellationReturnsBeforeAdmittedHandlerFinishes() async {
     let invalidationTrigger = Stored(wrappedValue: 0)
-    let handlerStarted = TestSignal()
+    let handlerStarted = DispatchSemaphore(value: 0)
     let resumeHandler = DispatchSemaphore(value: 0)
     let handlerFinished = TestSignal()
-    let cancellationReturned = TestSignal()
+    let coordinatorFinished = TestSignal()
+    let handlerDidFinish = OSAllocatedUnfairLock(initialState: false)
+    let didObserveHandlerStart = OSAllocatedUnfairLock(initialState: false)
+    let cancellationReturnedBeforeHandlerFinished = OSAllocatedUnfairLock(initialState: false)
     let rootSubscription = OSAllocatedUnfairLock<AnyCancellable?>(uncheckedState: nil)
 
     let subscription = withGraphTracking {
@@ -259,6 +262,7 @@ struct GraphTrackingCancellationTests {
 
           handlerStarted.signal()
           resumeHandler.wait()
+          handlerDidFinish.withLock { $0 = true }
           handlerFinished.signal()
         },
         isolation: nil
@@ -270,16 +274,30 @@ struct GraphTrackingCancellationTests {
       subscription.cancel()
     }
 
-    invalidationTrigger.wrappedValue = 1
-    #expect(await handlerStarted.wait(for: .seconds(5)))
+    // Complete the blocking handoff without requiring the test task to resume on the
+    // cooperative executor while the admitted handler occupies one of its workers.
+    Thread {
+      defer {
+        resumeHandler.signal()
+        coordinatorFinished.signal()
+      }
 
-    DispatchQueue.global().async {
+      let didStart = handlerStarted.wait(timeout: .now() + .seconds(5)) == .success
+      didObserveHandlerStart.withLock { $0 = didStart }
+      guard didStart else { return }
+
       rootSubscription.withLockUnchecked { $0 }?.cancel()
-      cancellationReturned.signal()
-    }
+      let didFinishBeforeCancellationReturned = handlerDidFinish.withLock { $0 }
+      cancellationReturnedBeforeHandlerFinished.withLock {
+        $0 = !didFinishBeforeCancellationReturned
+      }
+    }.start()
 
-    #expect(await cancellationReturned.wait(for: .seconds(5)))
-    resumeHandler.signal()
+    invalidationTrigger.wrappedValue = 1
+
+    #expect(await coordinatorFinished.wait(for: .seconds(5)))
+    #expect(didObserveHandlerStart.withLock { $0 })
+    #expect(cancellationReturnedBeforeHandlerFinished.withLock { $0 })
     #expect(await handlerFinished.wait(for: .seconds(5)))
   }
 
@@ -330,38 +348,75 @@ struct GraphTrackingCancellationTests {
   @Test
   func invocationContendingForExecutionGateDoesNotStartAfterCancellation() async {
     let trackingHandler = GraphTrackingHandler {}
-    let firstInvocationStarted = TestSignal()
+    let firstInvocationStarted = DispatchSemaphore(value: 0)
     let releaseFirstInvocation = DispatchSemaphore(value: 0)
-    let firstInvocationFinished = TestSignal()
-    let secondInvocationIsReady = TestSignal()
-    let secondInvocationReturned = TestSignal()
+    let firstInvocationFinished = DispatchSemaphore(value: 0)
+    let secondInvocationIsReady = DispatchSemaphore(value: 0)
+    let secondInvocationReturned = DispatchSemaphore(value: 0)
     let secondInvocationCount = Counter()
+    let coordinatorFinished = TestSignal()
+    let scenarioResult = OSAllocatedUnfairLock(
+      initialState: (
+        firstInvocationStarted: false,
+        secondInvocationIsReady: false,
+        firstInvocationFinished: false,
+        secondInvocationReturned: false
+      )
+    )
 
-    DispatchQueue.global().async {
+    Thread {
       trackingHandler.executeIfActive { _ in
         firstInvocationStarted.signal()
         releaseFirstInvocation.wait()
       }
       firstInvocationFinished.signal()
-    }
-    defer { releaseFirstInvocation.signal() }
+    }.start()
 
-    #expect(await firstInvocationStarted.wait(for: .seconds(5)))
-
-    DispatchQueue.global().async {
-      secondInvocationIsReady.signal()
-      trackingHandler.executeIfActive { _ in
-        secondInvocationCount.increment()
+    // Sequence the two blocking invocations on dedicated OS threads. The async test task
+    // only resumes after every synchronous handoff has completed.
+    Thread {
+      defer {
+        releaseFirstInvocation.signal()
+        coordinatorFinished.signal()
       }
-      secondInvocationReturned.signal()
-    }
 
-    #expect(await secondInvocationIsReady.wait(for: .seconds(5)))
-    trackingHandler.cancel()
-    releaseFirstInvocation.signal()
+      let firstDidStart =
+        firstInvocationStarted.wait(timeout: .now() + .seconds(5)) == .success
+      scenarioResult.withLock { $0.firstInvocationStarted = firstDidStart }
+      guard firstDidStart else { return }
 
-    #expect(await firstInvocationFinished.wait(for: .seconds(5)))
-    #expect(await secondInvocationReturned.wait(for: .seconds(5)))
+      Thread {
+        secondInvocationIsReady.signal()
+        trackingHandler.executeIfActive { _ in
+          secondInvocationCount.increment()
+        }
+        secondInvocationReturned.signal()
+      }.start()
+
+      let secondIsReady =
+        secondInvocationIsReady.wait(timeout: .now() + .seconds(5)) == .success
+      scenarioResult.withLock { $0.secondInvocationIsReady = secondIsReady }
+      guard secondIsReady else { return }
+
+      trackingHandler.cancel()
+      releaseFirstInvocation.signal()
+
+      let firstDidFinish =
+        firstInvocationFinished.wait(timeout: .now() + .seconds(5)) == .success
+      let secondDidReturn =
+        secondInvocationReturned.wait(timeout: .now() + .seconds(5)) == .success
+      scenarioResult.withLock {
+        $0.firstInvocationFinished = firstDidFinish
+        $0.secondInvocationReturned = secondDidReturn
+      }
+    }.start()
+
+    #expect(await coordinatorFinished.wait(for: .seconds(20)))
+    let result = scenarioResult.withLock { $0 }
+    #expect(result.firstInvocationStarted)
+    #expect(result.secondInvocationIsReady)
+    #expect(result.firstInvocationFinished)
+    #expect(result.secondInvocationReturned)
     #expect(secondInvocationCount.current == 0)
   }
 

--- a/Tests/StateGraphTests/GraphTrackingGroupTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingGroupTests.swift
@@ -741,10 +741,10 @@ struct IssuesTrackingOnHeavyOperation {
   @Test
   func concurrentGroupKeepsTrackingAcrossSerializedRerun() async {
     let value = Stored(wrappedValue: 0)
-    let secondInvocationStarted = DispatchSemaphore(value: 0)
-    let thirdInvocationReadValue = DispatchSemaphore(value: 0)
-    let fourthInvocationReadValue = DispatchSemaphore(value: 0)
-    let resumeSecondInvocation = DispatchSemaphore(value: 0)
+    let secondInvocationStarted = TestThreadSignal()
+    let thirdInvocationReadValue = TestThreadSignal()
+    let fourthInvocationReadValue = TestThreadSignal()
+    let resumeSecondInvocation = TestThreadGate()
     let coordinatorFinished = TestSignal()
     let scenarioResult = OSAllocatedUnfairLock(
       initialState: (
@@ -760,7 +760,7 @@ struct IssuesTrackingOnHeavyOperation {
           switch value.wrappedValue {
           case 1:
             secondInvocationStarted.signal()
-            resumeSecondInvocation.wait()
+            resumeSecondInvocation.wait(until: .distantFuture)
           case 2:
             thirdInvocationReadValue.signal()
           case 3:
@@ -773,7 +773,7 @@ struct IssuesTrackingOnHeavyOperation {
       )
     }
     defer {
-      resumeSecondInvocation.signal()
+      resumeSecondInvocation.open()
       cancellable.cancel()
     }
 
@@ -781,30 +781,29 @@ struct IssuesTrackingOnHeavyOperation {
     // release the blocked handler without depending on either shared executor's available width.
     Thread {
       defer {
-        resumeSecondInvocation.signal()
+        resumeSecondInvocation.open()
         coordinatorFinished.signal()
       }
 
       value.wrappedValue = 1
-      let secondStarted =
-        secondInvocationStarted.wait(timeout: .now() + .seconds(5)) == .success
+      let secondStarted = secondInvocationStarted.wait(until: Date().addingTimeInterval(5))
       scenarioResult.withLock { $0.secondInvocationStarted = secondStarted }
       guard secondStarted else { return }
 
       // Invalidate the pass registration while its handler is still active, then let the enqueued
       // rerun continue. No timing delay is needed: the setter has already requested the callback.
       value.wrappedValue = 2
-      resumeSecondInvocation.signal()
+      resumeSecondInvocation.open()
 
       let didReadValueInThirdInvocation =
-        thirdInvocationReadValue.wait(timeout: .now() + .seconds(5)) == .success
+        thirdInvocationReadValue.wait(until: Date().addingTimeInterval(5))
       scenarioResult.withLock { $0.thirdInvocationReadValue = didReadValueInThirdInvocation }
       guard didReadValueInThirdInvocation else { return }
 
       // The rerun must install a fresh registration for this later update.
       value.wrappedValue = 3
       let didReadValueInFourthInvocation =
-        fourthInvocationReadValue.wait(timeout: .now() + .seconds(5)) == .success
+        fourthInvocationReadValue.wait(until: Date().addingTimeInterval(5))
       scenarioResult.withLock { $0.fourthInvocationReadValue = didReadValueInFourthInvocation }
     }.start()
 
@@ -819,9 +818,9 @@ struct IssuesTrackingOnHeavyOperation {
   func stuck() async {
 
     let model = Model()
-    let handlerStarted = DispatchSemaphore(value: 0)
+    let handlerStarted = TestThreadSignal()
     let handlerFinished = TestSignal()
-    let resumeHandler = DispatchSemaphore(value: 0)
+    let resumeHandler = TestThreadGate()
     let coordinatorFinished = TestSignal()
     let coordinatorObservedHandler = OSAllocatedUnfairLock(initialState: false)
     var cancellable: AnyCancellable?
@@ -838,19 +837,19 @@ struct IssuesTrackingOnHeavyOperation {
 
           if model.count1 == 1, model.count2 != 2 {
             handlerStarted.signal()
-            resumeHandler.wait()
+            resumeHandler.wait(until: .distantFuture)
           }
 
         }
       }
 
       Thread {
-        let didObserveHandler = handlerStarted.wait(timeout: .now() + .seconds(5)) == .success
+        let didObserveHandler = handlerStarted.wait(until: Date().addingTimeInterval(5))
         coordinatorObservedHandler.withLock { $0 = didObserveHandler }
         if didObserveHandler {
           model.count2 = 2
         }
-        resumeHandler.signal()
+        resumeHandler.open()
         coordinatorFinished.signal()
       }.start()
 
@@ -871,9 +870,9 @@ struct IssuesTrackingOnHeavyOperation {
 
     let model = Model()
     let trackingStarted = TestSignal()
-    let handlerStarted = DispatchSemaphore(value: 0)
+    let handlerStarted = TestThreadSignal()
     let handlerFinished = TestSignal()
-    let resumeHandler = DispatchSemaphore(value: 0)
+    let resumeHandler = TestThreadGate()
     let coordinatorFinished = TestSignal()
     let coordinatorObservedHandler = OSAllocatedUnfairLock(initialState: false)
 
@@ -892,10 +891,10 @@ struct IssuesTrackingOnHeavyOperation {
               c.confirm()
               handlerFinished.signal()
             }
-            
+
             if model.count1 == 1, model.count2 != 2 {
               handlerStarted.signal()
-              resumeHandler.wait()
+              resumeHandler.wait(until: .distantFuture)
             }
             
           }
@@ -910,12 +909,12 @@ struct IssuesTrackingOnHeavyOperation {
       #expect(await trackingStarted.wait(for: .seconds(5)))
 
       Thread {
-        let didObserveHandler = handlerStarted.wait(timeout: .now() + .seconds(5)) == .success
+        let didObserveHandler = handlerStarted.wait(until: Date().addingTimeInterval(5))
         coordinatorObservedHandler.withLock { $0 = didObserveHandler }
         if didObserveHandler {
           model.count2 = 2
         }
-        resumeHandler.signal()
+        resumeHandler.open()
         coordinatorFinished.signal()
       }.start()
 

--- a/Tests/StateGraphTests/GraphTrackingGroupTests.swift
+++ b/Tests/StateGraphTests/GraphTrackingGroupTests.swift
@@ -777,9 +777,9 @@ struct IssuesTrackingOnHeavyOperation {
       cancellable.cancel()
     }
 
-    // Keep every write on one nonisolated synchronous producer. The coordinator uses a Dispatch
-    // queue so it can release the blocked handler even when Swift's cooperative pool has one worker.
-    DispatchQueue.global().async {
+    // Keep every write on one nonisolated synchronous producer. A dedicated OS thread can
+    // release the blocked handler without depending on either shared executor's available width.
+    Thread {
       defer {
         resumeSecondInvocation.signal()
         coordinatorFinished.signal()
@@ -806,7 +806,7 @@ struct IssuesTrackingOnHeavyOperation {
       let didReadValueInFourthInvocation =
         fourthInvocationReadValue.wait(timeout: .now() + .seconds(5)) == .success
       scenarioResult.withLock { $0.fourthInvocationReadValue = didReadValueInFourthInvocation }
-    }
+    }.start()
 
     #expect(await coordinatorFinished.wait(for: .seconds(20)))
     let result = scenarioResult.withLock { $0 }
@@ -844,7 +844,7 @@ struct IssuesTrackingOnHeavyOperation {
         }
       }
 
-      DispatchQueue.global().async {
+      Thread {
         let didObserveHandler = handlerStarted.wait(timeout: .now() + .seconds(5)) == .success
         coordinatorObservedHandler.withLock { $0 = didObserveHandler }
         if didObserveHandler {
@@ -852,7 +852,7 @@ struct IssuesTrackingOnHeavyOperation {
         }
         resumeHandler.signal()
         coordinatorFinished.signal()
-      }
+      }.start()
 
       model.count1 = 1
 
@@ -909,7 +909,7 @@ struct IssuesTrackingOnHeavyOperation {
 
       #expect(await trackingStarted.wait(for: .seconds(5)))
 
-      DispatchQueue.global().async {
+      Thread {
         let didObserveHandler = handlerStarted.wait(timeout: .now() + .seconds(5)) == .success
         coordinatorObservedHandler.withLock { $0 = didObserveHandler }
         if didObserveHandler {
@@ -917,7 +917,7 @@ struct IssuesTrackingOnHeavyOperation {
         }
         resumeHandler.signal()
         coordinatorFinished.signal()
-      }
+      }.start()
 
       model.count1 = 1
       #expect(await handlerFinished.wait(for: .seconds(5)))
@@ -1036,36 +1036,39 @@ struct IssuesObservationsObservableObject {
   @MainActor
   func observation() async {
     let model = ObservableModel()
-    await confirmation { c in
-      Task {
-        let s = Observations<Void, Never>.untilFinished {
-          print("Up")
+    await confirmation { confirmation in
+      let initialObservation = TestSignal()
+      let count1Observation = TestSignal()
+      let observationFinished = TestSignal()
+      let observationTask = Task {
+        let observations = Observations<Void, Never>.untilFinished {
+          initialObservation.signal()
+
           if model.count2 == 2 {
             return .finish
           }
+
           if model.count1 == 1 {
-            Thread.sleep(forTimeInterval: 2)
-            return .next(())
+            count1Observation.signal()
           }
+
           return .next(())
         }
-        var eventCount: Int = 0
-        for await e in s {
-          eventCount += 1
-        }
-        c.confirm()
-      }
 
-      Task {
-        print("Update count1")
-        model.count1 = 1
-        Task {
-          try? await Task.sleep(for: .milliseconds(100))
-          print("Update count2")
-          model.count2 = 2
-        }
+        for await _ in observations {}
+        confirmation.confirm()
+        observationFinished.signal()
       }
-      try? await Task.sleep(for: .seconds(5))
+      defer { observationTask.cancel() }
+
+      #expect(await initialObservation.wait(for: .seconds(5)))
+
+      model.count1 = 1
+      #expect(await count1Observation.wait(for: .seconds(5)))
+
+      model.count2 = 2
+      #expect(await observationFinished.wait(for: .seconds(5)))
+      await observationTask.value
     }
 
   }

--- a/Tests/StateGraphTests/GraphTransactionTests.swift
+++ b/Tests/StateGraphTests/GraphTransactionTests.swift
@@ -34,37 +34,6 @@ struct GraphTransactionTests {
     }
   }
 
-  /// A one-shot gate for deliberately pausing synchronous graph work on an OS thread.
-  ///
-  /// Use this only when a synchronous transaction body, comparator, or callback must
-  /// remain active while another thread reaches a deterministic state. Async test
-  /// control flow must use `TestSignal` or `TestCountdown` so it suspends instead of
-  /// blocking a cooperative-executor thread.
-  private final class TestThreadGate: @unchecked Sendable {
-    private let condition = NSCondition()
-    private var isOpen = false
-
-    /// Releases every current or future waiter.
-    func open() {
-      condition.lock()
-      isOpen = true
-      condition.broadcast()
-      condition.unlock()
-    }
-
-    /// Blocks the current OS thread until the gate opens or the deadline expires.
-    @discardableResult
-    func wait(until deadline: Date) -> Bool {
-      condition.lock()
-      defer { condition.unlock() }
-
-      while !isOpen {
-        guard condition.wait(until: deadline) else { return isOpen }
-      }
-      return true
-    }
-  }
-
   /// Runs a supplied action when a staged reference value is destroyed.
   private final class DeinitAction {
     private let action: () -> Void
@@ -116,9 +85,9 @@ struct GraphTransactionTests {
   @Test
   func outsideReaderSeesCommittedValueWhileTransactionBodyIsPaused() async {
     let node = Stored(wrappedValue: 0)
-    let transactionStarted = DispatchSemaphore(value: 0)
+    let transactionStarted = TestThreadSignal()
     let resumeTransaction = TestThreadGate()
-    let transactionFinished = DispatchSemaphore(value: 0)
+    let transactionFinished = TestThreadSignal()
     let coordinatorFinished = TestSignal()
     let scenarioResult = OSAllocatedUnfairLock(
       initialState: (
@@ -138,17 +107,17 @@ struct GraphTransactionTests {
       transactionFinished.signal()
     }
     transactionThread.start()
+    defer { resumeTransaction.open() }
 
-    // Keep the transaction pause and read handoff on OS threads. Returning to the async
-    // test task mid-scenario can deadlock with another parallel test that occupies the
-    // cooperative executor while waiting for this global transaction to finish.
+    // A dedicated coordinator owns every intermediate synchronous handoff. The async
+    // test task only waits for the final TestSignal and never blocks its executor worker.
     Thread {
       defer {
         resumeTransaction.open()
         coordinatorFinished.signal()
       }
 
-      let didStart = transactionStarted.wait(timeout: .now() + .seconds(20)) == .success
+      let didStart = transactionStarted.wait(until: Date().addingTimeInterval(20))
       scenarioResult.withLock { $0.transactionStarted = didStart }
       guard didStart else { return }
 
@@ -156,7 +125,7 @@ struct GraphTransactionTests {
       scenarioResult.withLock { $0.pausedReadValue = pausedReadValue }
 
       resumeTransaction.open()
-      let didFinish = transactionFinished.wait(timeout: .now() + .seconds(20)) == .success
+      let didFinish = transactionFinished.wait(until: Date().addingTimeInterval(20))
       let committedValue = node.wrappedValue
       scenarioResult.withLock {
         $0.transactionFinished = didFinish
@@ -175,11 +144,11 @@ struct GraphTransactionTests {
   @Test
   func outsideWriterWaitsForTransactionCompletion() async {
     let node = Stored(wrappedValue: 0)
-    let transactionStarted = DispatchSemaphore(value: 0)
+    let transactionStarted = TestThreadSignal()
     let resumeTransaction = TestThreadGate()
-    let transactionFinished = DispatchSemaphore(value: 0)
-    let writerStarted = DispatchSemaphore(value: 0)
-    let writerFinished = DispatchSemaphore(value: 0)
+    let transactionFinished = TestThreadSignal()
+    let writerStarted = TestThreadSignal()
+    let writerFinished = TestThreadSignal()
     let writerDidFinish = LockedBox(false)
     let coordinatorFinished = TestSignal()
     let scenarioResult = OSAllocatedUnfairLock(
@@ -203,17 +172,17 @@ struct GraphTransactionTests {
       transactionFinished.signal()
     }
     transactionThread.start()
+    defer { resumeTransaction.open() }
 
-    // The coordinator owns every intermediate handoff, so no global transaction remains
-    // paused while this async test task is waiting for a cooperative-executor worker.
+    // Keep the transaction pause, contending writer, and completion handoffs independent
+    // of Swift's cooperative executor. Only the final result crosses the async boundary.
     Thread {
       defer {
         resumeTransaction.open()
         coordinatorFinished.signal()
       }
 
-      let transactionDidStart =
-        transactionStarted.wait(timeout: .now() + .seconds(20)) == .success
+      let transactionDidStart = transactionStarted.wait(until: Date().addingTimeInterval(20))
       scenarioResult.withLock { $0.transactionStarted = transactionDidStart }
       guard transactionDidStart else { return }
 
@@ -224,25 +193,24 @@ struct GraphTransactionTests {
         writerFinished.signal()
       }.start()
 
-      let writerDidStart = writerStarted.wait(timeout: .now() + .seconds(5)) == .success
+      let writerDidStart = writerStarted.wait(until: Date().addingTimeInterval(5))
       scenarioResult.withLock { $0.writerStarted = writerDidStart }
       guard writerDidStart else { return }
 
 #if DEBUG
-      let didObserveBlockedWriter =
+      let didBlock =
         GraphTransactionCoordinator.shared.__testing__waitForImmediateWriterToBlock(
           until: Date().addingTimeInterval(5)
         )
-      scenarioResult.withLock { $0.didObserveBlockedWriter = didObserveBlockedWriter }
+      scenarioResult.withLock { $0.didObserveBlockedWriter = didBlock }
 #endif
       scenarioResult.withLock {
         $0.writerRemainedBlockedBeforeRelease = !writerDidFinish.value
       }
 
       resumeTransaction.open()
-      let transactionDidFinish =
-        transactionFinished.wait(timeout: .now() + .seconds(20)) == .success
-      let writerDidComplete = writerFinished.wait(timeout: .now() + .seconds(20)) == .success
+      let transactionDidFinish = transactionFinished.wait(until: Date().addingTimeInterval(20))
+      let writerDidComplete = writerFinished.wait(until: Date().addingTimeInterval(20))
       let finalValue = node.wrappedValue
       scenarioResult.withLock {
         $0.transactionFinished = transactionDidFinish

--- a/Tests/StateGraphTests/GraphTransactionTests.swift
+++ b/Tests/StateGraphTests/GraphTransactionTests.swift
@@ -116,77 +116,152 @@ struct GraphTransactionTests {
   @Test
   func outsideReaderSeesCommittedValueWhileTransactionBodyIsPaused() async {
     let node = Stored(wrappedValue: 0)
-    let transactionStarted = TestSignal()
+    let transactionStarted = DispatchSemaphore(value: 0)
     let resumeTransaction = TestThreadGate()
-    let transactionFinished = TestSignal()
-
-    let thread = Thread {
-      withGraphTransaction {
-        node.wrappedValue = 1
-        transactionStarted.signal()
-        resumeTransaction.wait(until: Date().addingTimeInterval(5))
-      }
-      transactionFinished.signal()
-    }
-    thread.start()
-
-    #expect(await transactionStarted.wait(for: .seconds(5)))
-    #expect(node.wrappedValue == 0)
-
-    resumeTransaction.open()
-    #expect(await transactionFinished.wait(for: .seconds(5)))
-    #expect(node.wrappedValue == 1)
-  }
-
-  @Test
-  func outsideWriterWaitsForTransactionCompletion() async {
-    let node = Stored(wrappedValue: 0)
-    let transactionStarted = TestSignal()
-    let resumeTransaction = TestThreadGate()
-    let transactionFinished = TestSignal()
-    let writerStarted = TestSignal()
-    let writerFinished = TestSignal()
-    let writerDidFinish = LockedBox(false)
+    let transactionFinished = DispatchSemaphore(value: 0)
+    let coordinatorFinished = TestSignal()
+    let scenarioResult = OSAllocatedUnfairLock(
+      initialState: (
+        transactionStarted: false,
+        pausedReadValue: Int?.none,
+        transactionFinished: false,
+        committedValue: Int?.none
+      )
+    )
 
     let transactionThread = Thread {
       withGraphTransaction {
         node.wrappedValue = 1
         transactionStarted.signal()
-        resumeTransaction.wait(until: Date().addingTimeInterval(5))
+        resumeTransaction.wait(until: Date.distantFuture)
       }
       transactionFinished.signal()
     }
     transactionThread.start()
 
-    #expect(await transactionStarted.wait(for: .seconds(5)))
-
+    // Keep the transaction pause and read handoff on OS threads. Returning to the async
+    // test task mid-scenario can deadlock with another parallel test that occupies the
+    // cooperative executor while waiting for this global transaction to finish.
     Thread {
-      writerStarted.signal()
-      node.wrappedValue = 2
-      writerDidFinish.update { $0 = true }
-      writerFinished.signal()
+      defer {
+        resumeTransaction.open()
+        coordinatorFinished.signal()
+      }
+
+      let didStart = transactionStarted.wait(timeout: .now() + .seconds(20)) == .success
+      scenarioResult.withLock { $0.transactionStarted = didStart }
+      guard didStart else { return }
+
+      let pausedReadValue = node.wrappedValue
+      scenarioResult.withLock { $0.pausedReadValue = pausedReadValue }
+
+      resumeTransaction.open()
+      let didFinish = transactionFinished.wait(timeout: .now() + .seconds(20)) == .success
+      let committedValue = node.wrappedValue
+      scenarioResult.withLock {
+        $0.transactionFinished = didFinish
+        $0.committedValue = committedValue
+      }
     }.start()
 
-    #expect(await writerStarted.wait(for: .seconds(5)))
-#if DEBUG
-    let writerBlocked = TestSignal()
-    let didObserveBlockedWriter = LockedBox(false)
-    Thread {
-      let didBlock = GraphTransactionCoordinator.shared.__testing__waitForImmediateWriterToBlock(
-        until: Date().addingTimeInterval(1)
+    #expect(await coordinatorFinished.wait(for: .seconds(30)))
+    let result = scenarioResult.withLock { $0 }
+    #expect(result.transactionStarted)
+    #expect(result.pausedReadValue == 0)
+    #expect(result.transactionFinished)
+    #expect(result.committedValue == 1)
+  }
+
+  @Test
+  func outsideWriterWaitsForTransactionCompletion() async {
+    let node = Stored(wrappedValue: 0)
+    let transactionStarted = DispatchSemaphore(value: 0)
+    let resumeTransaction = TestThreadGate()
+    let transactionFinished = DispatchSemaphore(value: 0)
+    let writerStarted = DispatchSemaphore(value: 0)
+    let writerFinished = DispatchSemaphore(value: 0)
+    let writerDidFinish = LockedBox(false)
+    let coordinatorFinished = TestSignal()
+    let scenarioResult = OSAllocatedUnfairLock(
+      initialState: (
+        transactionStarted: false,
+        writerStarted: false,
+        didObserveBlockedWriter: false,
+        writerRemainedBlockedBeforeRelease: false,
+        transactionFinished: false,
+        writerFinished: false,
+        finalValue: Int?.none
       )
-      didObserveBlockedWriter.update { $0 = didBlock }
-      writerBlocked.signal()
-    }.start()
-    #expect(await writerBlocked.wait(for: .seconds(5)))
-    #expect(didObserveBlockedWriter.value)
-#endif
-    #expect(!writerDidFinish.value)
+    )
 
-    resumeTransaction.open()
-    #expect(await transactionFinished.wait(for: .seconds(5)))
-    #expect(await writerFinished.wait(for: .seconds(5)))
-    #expect(node.wrappedValue == 2)
+    let transactionThread = Thread {
+      withGraphTransaction {
+        node.wrappedValue = 1
+        transactionStarted.signal()
+        resumeTransaction.wait(until: Date.distantFuture)
+      }
+      transactionFinished.signal()
+    }
+    transactionThread.start()
+
+    // The coordinator owns every intermediate handoff, so no global transaction remains
+    // paused while this async test task is waiting for a cooperative-executor worker.
+    Thread {
+      defer {
+        resumeTransaction.open()
+        coordinatorFinished.signal()
+      }
+
+      let transactionDidStart =
+        transactionStarted.wait(timeout: .now() + .seconds(20)) == .success
+      scenarioResult.withLock { $0.transactionStarted = transactionDidStart }
+      guard transactionDidStart else { return }
+
+      Thread {
+        writerStarted.signal()
+        node.wrappedValue = 2
+        writerDidFinish.update { $0 = true }
+        writerFinished.signal()
+      }.start()
+
+      let writerDidStart = writerStarted.wait(timeout: .now() + .seconds(5)) == .success
+      scenarioResult.withLock { $0.writerStarted = writerDidStart }
+      guard writerDidStart else { return }
+
+#if DEBUG
+      let didObserveBlockedWriter =
+        GraphTransactionCoordinator.shared.__testing__waitForImmediateWriterToBlock(
+          until: Date().addingTimeInterval(5)
+        )
+      scenarioResult.withLock { $0.didObserveBlockedWriter = didObserveBlockedWriter }
+#endif
+      scenarioResult.withLock {
+        $0.writerRemainedBlockedBeforeRelease = !writerDidFinish.value
+      }
+
+      resumeTransaction.open()
+      let transactionDidFinish =
+        transactionFinished.wait(timeout: .now() + .seconds(20)) == .success
+      let writerDidComplete = writerFinished.wait(timeout: .now() + .seconds(20)) == .success
+      let finalValue = node.wrappedValue
+      scenarioResult.withLock {
+        $0.transactionFinished = transactionDidFinish
+        $0.writerFinished = writerDidComplete
+        $0.finalValue = finalValue
+      }
+    }.start()
+
+    #expect(await coordinatorFinished.wait(for: .seconds(30)))
+    let result = scenarioResult.withLock { $0 }
+    #expect(result.transactionStarted)
+    #expect(result.writerStarted)
+#if DEBUG
+    #expect(result.didObserveBlockedWriter)
+#endif
+    #expect(result.writerRemainedBlockedBeforeRelease)
+    #expect(result.transactionFinished)
+    #expect(result.writerFinished)
+    #expect(result.finalValue == 2)
   }
 
   @Test

--- a/Tests/StateGraphTests/GraphUserDefaultTests.swift
+++ b/Tests/StateGraphTests/GraphUserDefaultTests.swift
@@ -58,13 +58,13 @@ struct GraphUserDefaultTests {
     }
 
     func verifyConcurrentOperation(_ operation: @escaping @Sendable () -> Void) {
-      let operationFinished = DispatchSemaphore(value: 0)
+      let operationFinished = TestThreadSignal()
       Thread {
         operation()
         operationFinished.signal()
       }.start()
 
-      let didComplete = operationFinished.wait(timeout: .now() + 5) == .success
+      let didComplete = operationFinished.wait(until: Date().addingTimeInterval(5))
       state.withLock {
         $0.didRun = true
         $0.concurrentOperationCompleted = didComplete
@@ -73,22 +73,31 @@ struct GraphUserDefaultTests {
   }
 
   private final class BlockingReadController: @unchecked Sendable {
-    private let shouldBlock = OSAllocatedUnfairLock(initialState: false)
+    /// One requested read suspension and the async signal that observes its entry, if any.
+    private struct BlockRequest: Sendable {
+      let startedSignal: TestSignal?
+    }
+
+    private let nextRequest = OSAllocatedUnfairLock<BlockRequest?>(initialState: nil)
     let didStart = DispatchSemaphore(value: 0)
     let resume = DispatchSemaphore(value: 0)
 
-    func blockNextRead() {
-      shouldBlock.withLock { $0 = true }
+    func blockNextRead(started: TestSignal? = nil) {
+      nextRequest.withLock { $0 = BlockRequest(startedSignal: started) }
     }
 
     func load(_ value: BlockingValue) -> BlockingValue {
-      let shouldBlock = shouldBlock.withLock { shouldBlock in
-        defer { shouldBlock = false }
-        return shouldBlock
+      let request = nextRequest.withLock { request in
+        defer { request = nil }
+        return request
       }
 
-      if shouldBlock {
-        didStart.signal()
+      if let request {
+        if let started = request.startedSignal {
+          started.signal()
+        } else {
+          didStart.signal()
+        }
         resume.wait()
       }
 
@@ -403,10 +412,11 @@ struct GraphUserDefaultTests {
     userDefaults.set(initialValue.rawValue, forKey: key)
 
     let controller = BlockingValue.readController
-    controller.blockNextRead()
+    let initialReadStarted = TestSignal()
+    controller.blockNextRead(started: initialReadStarted)
 
     let valueBox = ValueBox<GraphUserDefault<BlockingValue>>()
-    let initializationFinished = DispatchSemaphore(value: 0)
+    let initializationFinished = TestSignal()
     Thread {
       valueBox.store(
         GraphUserDefault(
@@ -418,37 +428,12 @@ struct GraphUserDefaultTests {
       initializationFinished.signal()
     }.start()
 
-    let coordinatorFinished = TestSignal()
-    let scenarioResult = OSAllocatedUnfairLock(
-      initialState: (
-        initialReadStarted: false,
-        initializationFinished: false,
-        initializedValue: BlockingValue?.none
-      )
-    )
-    Thread {
-      defer { coordinatorFinished.signal() }
+    #expect(await initialReadStarted.wait(for: .seconds(5)))
+    userDefaultsReference.value.set("during-initialization", forKey: key)
+    controller.resume.signal()
 
-      let initialReadStarted = controller.didStart.wait(timeout: .now() + 20) == .success
-      scenarioResult.withLock { $0.initialReadStarted = initialReadStarted }
-      guard initialReadStarted else { return }
-
-      userDefaultsReference.value.set("during-initialization", forKey: key)
-      controller.resume.signal()
-
-      let didFinish = initializationFinished.wait(timeout: .now() + 20) == .success
-      let initializedValue = valueBox.current?.wrappedValue
-      scenarioResult.withLock {
-        $0.initializationFinished = didFinish
-        $0.initializedValue = initializedValue
-      }
-    }.start()
-
-    #expect(await coordinatorFinished.wait(for: .seconds(30)))
-    let result = scenarioResult.withLock { $0 }
-    #expect(result.initialReadStarted)
-    #expect(result.initializationFinished)
-    #expect(result.initializedValue == .init(rawValue: "during-initialization"))
+    #expect(await initializationFinished.wait(for: .seconds(5)))
+    #expect(valueBox.current?.wrappedValue == .init(rawValue: "during-initialization"))
   }
 
   @Test

--- a/Tests/StateGraphTests/GraphUserDefaultTests.swift
+++ b/Tests/StateGraphTests/GraphUserDefaultTests.swift
@@ -59,12 +59,12 @@ struct GraphUserDefaultTests {
 
     func verifyConcurrentOperation(_ operation: @escaping @Sendable () -> Void) {
       let operationFinished = DispatchSemaphore(value: 0)
-      DispatchQueue.global().async {
+      Thread {
         operation()
         operationFinished.signal()
-      }
+      }.start()
 
-      let didComplete = operationFinished.wait(timeout: .now() + 1) == .success
+      let didComplete = operationFinished.wait(timeout: .now() + 5) == .success
       state.withLock {
         $0.didRun = true
         $0.concurrentOperationCompleted = didComplete
@@ -395,7 +395,7 @@ struct GraphUserDefaultTests {
   }
 
   @Test
-  func refreshesChangeMadeBetweenInitialReadAndObserverInstallation() {
+  func refreshesChangeMadeBetweenInitialReadAndObserverInstallation() async {
     let key = makeTestKey()
     let userDefaults = makeTestUserDefaults()
     let userDefaultsReference = UserDefaultsReference(userDefaults)
@@ -407,7 +407,7 @@ struct GraphUserDefaultTests {
 
     let valueBox = ValueBox<GraphUserDefault<BlockingValue>>()
     let initializationFinished = DispatchSemaphore(value: 0)
-    DispatchQueue.global().async {
+    Thread {
       valueBox.store(
         GraphUserDefault(
           wrappedValue: initialValue,
@@ -416,14 +416,39 @@ struct GraphUserDefaultTests {
         )
       )
       initializationFinished.signal()
-    }
+    }.start()
 
-    #expect(controller.didStart.wait(timeout: .now() + 1) == .success)
-    userDefaults.set("during-initialization", forKey: key)
-    controller.resume.signal()
+    let coordinatorFinished = TestSignal()
+    let scenarioResult = OSAllocatedUnfairLock(
+      initialState: (
+        initialReadStarted: false,
+        initializationFinished: false,
+        initializedValue: BlockingValue?.none
+      )
+    )
+    Thread {
+      defer { coordinatorFinished.signal() }
 
-    #expect(initializationFinished.wait(timeout: .now() + 1) == .success)
-    #expect(valueBox.current?.wrappedValue == .init(rawValue: "during-initialization"))
+      let initialReadStarted = controller.didStart.wait(timeout: .now() + 20) == .success
+      scenarioResult.withLock { $0.initialReadStarted = initialReadStarted }
+      guard initialReadStarted else { return }
+
+      userDefaultsReference.value.set("during-initialization", forKey: key)
+      controller.resume.signal()
+
+      let didFinish = initializationFinished.wait(timeout: .now() + 20) == .success
+      let initializedValue = valueBox.current?.wrappedValue
+      scenarioResult.withLock {
+        $0.initializationFinished = didFinish
+        $0.initializedValue = initializedValue
+      }
+    }.start()
+
+    #expect(await coordinatorFinished.wait(for: .seconds(30)))
+    let result = scenarioResult.withLock { $0 }
+    #expect(result.initialReadStarted)
+    #expect(result.initializationFinished)
+    #expect(result.initializedValue == .init(rawValue: "during-initialization"))
   }
 
   @Test

--- a/Tests/StateGraphTests/TestSignal.swift
+++ b/Tests/StateGraphTests/TestSignal.swift
@@ -63,6 +63,60 @@ final class TestSignal: @unchecked Sendable {
   }
 }
 
+/// A one-shot signal for deterministic handoffs between dedicated OS threads.
+///
+/// Waiting on this type blocks the calling thread. Use it only from a `Thread` or from
+/// synchronous code that a dedicated thread is guaranteed to release. Async test tasks
+/// must await ``TestSignal`` instead so they do not occupy a cooperative-executor worker.
+final class TestThreadSignal: @unchecked Sendable {
+
+  private let condition = NSCondition()
+  private var isSignaled = false
+
+  /// Marks the signal as completed and releases every current or future waiter.
+  func signal() {
+    condition.lock()
+    isSignaled = true
+    condition.broadcast()
+    condition.unlock()
+  }
+
+  /// Blocks the current OS thread until the signal is completed or the deadline expires.
+  ///
+  /// - Parameter deadline: The latest date at which the wait may return.
+  /// - Returns: `true` when signaled, or `false` when the deadline expires first.
+  @discardableResult
+  func wait(until deadline: Date) -> Bool {
+    condition.lock()
+    defer { condition.unlock() }
+
+    while !isSignaled {
+      guard condition.wait(until: deadline) else { return isSignaled }
+    }
+    return true
+  }
+}
+
+/// A one-shot gate for deliberately pausing synchronous work on an OS thread.
+///
+/// The gate is the blocking counterpart to ``TestSignal``. Its naming distinguishes an
+/// intentional synchronous pause from an event that an async test task should await.
+final class TestThreadGate: @unchecked Sendable {
+
+  private let opened = TestThreadSignal()
+
+  /// Releases every current or future waiter.
+  func open() {
+    opened.signal()
+  }
+
+  /// Blocks the current OS thread until the gate opens or the deadline expires.
+  @discardableResult
+  func wait(until deadline: Date) -> Bool {
+    opened.wait(until: deadline)
+  }
+}
+
 /// An asynchronous countdown used when a test must observe several completions.
 ///
 /// Producers call ``signal()`` from synchronous callbacks or worker threads. The


### PR DESCRIPTION
## Summary

- keep async test-task waits on `TestSignal`
- add `TestThreadSignal` for one-shot handoffs between dedicated OS threads
- use `TestThreadGate` only for deliberately paused synchronous callbacks
- replace fixed sleeps in the Observation test with explicit async-safe signals
- keep production code and the package's `--parallel` coverage unchanged

## Root cause

The Xcode 26.4 `package-test` job on `main` failed twice with clusters of 5-second timeouts across cancellation, transaction, and observation tests:

https://github.com/VergeGroup/swift-state-graph/actions/runs/30847606000

Those tests synchronously occupied shared cooperative/global execution contexts while relying on the async test task or another shared worker to release them. On the lower-width CI runner, parallel suites could exhaust the available workers. The process-wide transaction coordinator could then connect otherwise independent suites into a circular wait: a release worker waited behind a paused transaction, while that transaction's test task could not resume.

The timeouts eventually released some gates, which made the failing test set vary between attempts even though the underlying starvation was the same.

## Synchronization boundary

The test helpers now distinguish three contracts:

- `TestSignal`: suspends an async test task through a continuation
- `TestThreadSignal`: blocking one-shot event used only by a dedicated OS thread or synchronous code with a dedicated releaser
- `TestThreadGate`: intentionally pauses synchronous work until a dedicated coordinator opens it

Using `TestSignal` for every intermediate handoff does not work under strict cooperative width 1: the synchronous tracking handler can occupy the only worker, so the async test task cannot resume to release it. The thread-only types make that exceptional blocking boundary explicit without exposing a raw semaphore in the new coordination code.

## Changes

- coordinate mid-scenario cancellation and transaction handoffs on dedicated `Thread` instances
- resume async test tasks only after each synchronous scenario has completed
- use signals rather than fixed sleeps to verify Observation progression
- retain timeouts only as failure bounds, not as normal progression logic
- apply the same executor-independent boundary to the UserDefaults publication tests

## Validation

Using Xcode 26.6 / Swift 6.3.3 locally:

- focused parallel suites: 68 tests in 5 suites passed
- focused strict cooperative-pool suites: 68 tests in 5 suites passed
- `swift test --parallel`: 189 tests in 34 suites passed
- strict cooperative-pool full suite: 189 tests in 34 suites passed
- strict cooperative-pool full suite: 10 consecutive runs passed
- release parallel suite: 186 Swift Testing tests in 33 suites and 24 XCTest tests passed
- `git diff --check` passed

GitHub Actions on commit `0909584` also passed:

- Xcode 26.4 `package-test`
- `build-development`

https://github.com/VergeGroup/swift-state-graph/actions/runs/31249412806