### PR TITLE
Distribute StateGraph as dynamic libraries

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,6 +30,8 @@ jobs:
 
   build-development:
     runs-on: macos-26
+    env:
+      DERIVED_DATA_PATH: ${{ runner.temp }}/StateGraphDerivedData
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1.1
@@ -49,4 +51,15 @@ jobs:
             -project Development.xcodeproj \
             -scheme Development \
             -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$DERIVED_DATA_PATH" \
             CODE_SIGNING_ALLOWED=NO build
+      - name: Verify dynamic package products
+        run: |
+          APP_PATH="$DERIVED_DATA_PATH/Build/Products/Debug-iphonesimulator/Development.app"
+          STATE_GRAPH_BINARY="$APP_PATH/Frameworks/StateGraph.framework/StateGraph"
+          NORMALIZATION_BINARY="$APP_PATH/Frameworks/StateGraphNormalization.framework/StateGraphNormalization"
+
+          otool -hv "$STATE_GRAPH_BINARY" | grep DYLIB
+          otool -hv "$NORMALIZATION_BINARY" | grep DYLIB
+          test "$(find "$APP_PATH" -type d -name 'StateGraph.framework' | wc -l | tr -d '[:space:]')" = "1"
+          test "$(find "$APP_PATH" -type d -name 'StateGraphNormalization.framework' | wc -l | tr -d '[:space:]')" = "1"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,8 +30,6 @@ jobs:
 
   build-development:
     runs-on: macos-26
-    env:
-      DERIVED_DATA_PATH: ${{ runner.temp }}/StateGraphDerivedData
 
     steps:
       - uses: maxim-lobanov/setup-xcode@v1.1
@@ -51,11 +49,11 @@ jobs:
             -project Development.xcodeproj \
             -scheme Development \
             -destination 'generic/platform=iOS Simulator' \
-            -derivedDataPath "$DERIVED_DATA_PATH" \
+            -derivedDataPath "$RUNNER_TEMP/StateGraphDerivedData" \
             CODE_SIGNING_ALLOWED=NO build
       - name: Verify dynamic package products
         run: |
-          APP_PATH="$DERIVED_DATA_PATH/Build/Products/Debug-iphonesimulator/Development.app"
+          APP_PATH="$RUNNER_TEMP/StateGraphDerivedData/Build/Products/Debug-iphonesimulator/Development.app"
           STATE_GRAPH_BINARY="$APP_PATH/Frameworks/StateGraph.framework/StateGraph"
           NORMALIZATION_BINARY="$APP_PATH/Frameworks/StateGraphNormalization.framework/StateGraphNormalization"
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6d7c8e54695577563b80ed7c666951119e648335c5283fb7b0fe27b281bc4f85",
+  "originHash" : "c6d0cbab48d80eb9a3a9207f79f65ea93af7b04d70cc7343c1074ec7d500a1e8",
   "pins" : [
     {
       "identity" : "swift-custom-dump",

--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,18 @@ let package = Package(
     .watchOS(.v10),
   ],
   products: [
-    // Products define the executables and libraries a package produces, making them visible to other packages.
+    // StateGraph owns process-wide runtime state, so separate framework consumers
+    // must resolve one shared binary instead of embedding independent copies.
     .library(
       name: "StateGraph",
+      type: .dynamic,
       targets: ["StateGraph"]
     ),
+    // Normalization is an independent module. Keeping it dynamic preserves its
+    // public Swift type identity when several frameworks consume it.
     .library(
       name: "StateGraphNormalization",
+      type: .dynamic,
       targets: ["StateGraphNormalization"]
     )
   ],
@@ -54,7 +59,6 @@ let package = Package(
     .target(
       name: "StateGraphNormalization",
       dependencies: [
-        "StateGraph",
         "StateGraphNormalizationMacro",
         .product(name: "TypedIdentifier", package: "swift-typed-identifier")
       ]

--- a/Project.swift
+++ b/Project.swift
@@ -36,8 +36,9 @@ let developmentTarget: Target = .target(
   ]),
   buildableFolders: ["Development"],
   dependencies: [
-    .package(product: "StateGraph"),
-    .package(product: "StateGraphNormalization"),
+    // The app is the single owner that embeds each dynamic package runtime.
+    .package(product: "StateGraph", type: .runtimeEmbedded),
+    .package(product: "StateGraphNormalization", type: .runtimeEmbedded),
     .package(product: "StorybookKit"),
   ],
   settings: .settings(

--- a/README.md
+++ b/README.md
@@ -122,6 +122,39 @@ dependencies: [
 )
 ```
 
+### Dynamic Linking
+
+`StateGraph` and `StateGraphNormalization` are distributed as dynamic library
+products. StateGraph owns process-wide tracking and transaction context, so one
+process must load one shared StateGraph runtime. Dynamic products ensure that
+multiple frameworks link to shared binaries instead of embedding independent
+static copies.
+
+The application target should embed the produced frameworks. Dependent dynamic
+frameworks should link them without embedding additional copies.
+
+With Tuist's native Swift Package integration, use the default `.runtime`
+dependency from each feature framework and `.runtimeEmbedded` once from the
+final application target:
+
+```swift
+// Feature framework
+.package(product: "StateGraph")
+
+// Application
+.package(product: "StateGraph", type: .runtimeEmbedded)
+.package(product: "StateGraphNormalization", type: .runtimeEmbedded)
+```
+
+`StateGraphNormalization` does not re-export `StateGraph`. Targets using graph
+nodes together with normalization must depend on and import both products
+explicitly:
+
+```swift
+import StateGraph
+import StateGraphNormalization
+```
+
 ## Core Concepts
 
 ### Stored Nodes (`@GraphStored`)

--- a/Sources/StateGraph/Documentation.docc/Data-Normalization.md
+++ b/Sources/StateGraph/Documentation.docc/Data-Normalization.md
@@ -23,6 +23,7 @@ Data normalization involves storing entities in separate collections while maint
 `EntityStore` is a generic container for managing collections of entities with unique identifiers:
 
 ```swift
+import StateGraph
 import StateGraphNormalization
 
 // Creating entity stores for different types

--- a/Sources/StateGraphNormalization/StateGraphNormalization.swift
+++ b/Sources/StateGraphNormalization/StateGraphNormalization.swift
@@ -1,4 +1,3 @@
-@_exported import StateGraph
 @_exported import TypedIdentifier
 
 import TypedIdentifier
@@ -7,7 +6,7 @@ import TypedIdentifier
 ///
 /// `EntityStore` deliberately contains only entity storage. It does not
 /// coordinate concurrent access or publish graph updates by itself. Store it in
-/// a ``Stored`` node, usually through ``GraphStored``, when reads and
+/// a `Stored` node, usually through `GraphStored`, when reads and
 /// mutations should participate in a state graph.
 ///
 /// Like other Swift value types, copying an entity store creates an independent


### PR DESCRIPTION
## Summary

- Declare `StateGraph` and `StateGraphNormalization` as dynamic Swift package products so one process resolves one runtime/type-metadata owner.
- Decouple `StateGraphNormalization` from the `StateGraph` target. This avoids Xcode folding `StateGraph` statically into the normalization product while also building the dynamic product.
- Configure the Tuist Development app to embed each dynamic product once, document the Tuist dependency topology, and add a CI linkage check.

## Migration

`StateGraphNormalization` no longer re-exports `StateGraph`. A target that uses both products must declare both dependencies and import both modules explicitly.

For Tuist native Swift package dependencies, feature frameworks should use the default `.runtime` dependency. The final application target must depend on each used dynamic product with `.runtimeEmbedded` so the framework is copied into the app bundle once.

## Verification

- `swift package dump-package` reports both public libraries as dynamic.
- `swift test --parallel --xunit-output .tmp/TestResults-dynamic-products-final.xml` passed: 23 XCTest/macro tests, 191 StateGraph tests, and 10 normalization tests.
- Tuist 4.202.6 generated and built the repository Development app for the iOS Simulator; both embedded binaries report `MH_DYLIB`, with one copy of each framework in the app bundle.
- An isolated Tuist app with dynamic FeatureA and FeatureB frameworks was built and archived for generic iOS. Both feature binaries link `@rpath/StateGraph.framework/StateGraph`, their StateGraph implementation symbols remain undefined, and the archive contains exactly one dynamic `StateGraph.framework`.

Tuist 4.202.6 still emits a static-side-effects warning for the two feature `.runtime` edges. The generated Xcode product and Mach-O inspection confirm that the package product remains dynamic.
