### PR TITLE
Add savepoints for nested graph transactions

### DIFF
--- a/Documentation/Design-Notes/Stored-Mutation.md
+++ b/Documentation/Design-Notes/Stored-Mutation.md
@@ -95,6 +95,24 @@ transaction prevents competing writers from losing updates, but it still uses
 the current getter/writeback materialization and therefore does not solve the
 copy optimization described above.
 
+Each nested `withGraphTransaction` call creates a savepoint. Successful inner
+work merges into the parent's staged values; a throwing inner call restores the
+values visible at its entry, even when its parent catches the error. Publication
+occurs only when the outermost call succeeds. An error escaping the outermost
+call also rolls back successful inner work. Assignment observers such as
+`onDidSet` still run immediately, and their external side effects cannot be
+rolled back.
+
+Savepoint storage preserves each `Stored` node's concrete value type. Transaction
+scopes coordinate weak participants rather than collecting values in a shared
+type-erased container. A savepoint merges or restores every affected node before
+releasing displaced values outside node locks, with the parent context active.
+Synchronous `Stored` assignments from those values' `deinit` therefore join the
+parent. The outer transaction retains writer ownership throughout inner
+finalization, so this cleanup must not synchronously wait for another thread to
+complete a graph write. Outermost rollback continues to detach staged values
+before releasing writer ownership and then destroys those values afterward.
+
 This issue concerns in-memory `Stored` mutation. It does not require
 `EntityStore` to have reference semantics, and it is not a database transaction
 or rollback mechanism for external side effects.

--- a/Sources/StateGraph/Documentation.docc/Core-Concepts.md
+++ b/Sources/StateGraph/Documentation.docc/Core-Concepts.md
@@ -122,10 +122,48 @@ Each `Stored` value uses its existing comparator and graph notification pipeline
 once at commit, comparing the committed old value with the final staged value.
 
 The API is synchronous and thread-local; it does not cross `await`, task
-creation, or executor hops. Nested calls join the outer transaction rather than
-creating savepoints. An inner error that the outer body catches leaves its staged
-assignments in place; only an error that escapes the outermost call rolls all
-staged `Stored` assignments back.
+creation, or executor hops. Each nested call creates a savepoint. A successful
+inner call merges its staged assignments into its parent. A throwing inner call
+restores the values visible before that call began, so its parent can catch the
+error and continue. Only the outermost call publishes values; an error escaping
+that call also discards changes from successful inner calls.
+
+```swift
+enum UpdateError: Error {
+  case rejected
+}
+
+let count = Stored(wrappedValue: 0)
+
+withGraphTransaction {
+  count.wrappedValue = 1
+
+  do {
+    try withGraphTransaction {
+      count.wrappedValue = 2
+      throw UpdateError.rejected
+    }
+  } catch {
+    // The inner savepoint has restored the parent's staged value.
+    assert(count.wrappedValue == 1)
+  }
+}
+
+assert(count.wrappedValue == 1)
+```
+
+This changes the behavior of code that catches an inner transaction's error.
+Previously, the failed inner call's assignments remained staged, and the example
+above committed `2`. The savepoint now discards those assignments and commits `1`.
+The public API signature is unchanged. Nested calls no longer emit a diagnostic;
+`StateGraphDiagnostics.isNestedTransactionWarningEnabled` is deprecated and has
+no effect.
+
+When a savepoint finishes, every affected node is merged or restored before
+replaced values are destroyed outside node locks. The parent transaction is
+active during that destruction, so synchronous `Stored` assignments made by a
+value's `deinit` join the parent transaction. Other threads' graph writes remain
+suspended; this cleanup must not wait synchronously for such a write.
 
 Transaction-time `Computed` reads are evaluated from the staged `Stored` values
 without updating the committed cache or dependency edges. A mutation made by a

--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -268,7 +268,17 @@ protocol GraphTransactionParticipant: AnyObject {
 /// This context intentionally retains only weak, type-erased participants. Each
 /// `Stored` node owns its typed staged value directly, which keeps transaction
 /// values out of a shared `[ObjectIdentifier: Any]` container.
-final class GraphTransactionContext {
+///
+/// Equality represents scope identity, not the contents of the participant list.
+/// Node-local staging retains this concrete context until merge, commit, or rollback
+/// removes it. The temporary strong participant snapshot is cleared after delivery
+/// or cleanup, breaking the corresponding node-to-context ownership cycle.
+final class GraphTransactionContext: Equatable {
+
+  /// Returns whether both references identify the same transaction scope.
+  static func == (lhs: GraphTransactionContext, rhs: GraphTransactionContext) -> Bool {
+    lhs === rhs
+  }
 
   private struct WeakParticipant {
     weak var value: (any GraphTransactionParticipant)?
@@ -295,7 +305,7 @@ final class GraphTransactionContext {
   /// Nodes retain their typed undo history and register with the parent only if
   /// that scope had not already staged them.
   func prepareMerge(into parent: GraphTransactionContext) {
-    precondition(self.parent === parent)
+    precondition(self.parent == parent)
     frozenParticipants = participants.compactMap(\.value)
     for participant in frozenParticipants {
       participant.prepareTransactionMerge(self, into: parent)

--- a/Sources/StateGraph/GraphTransaction.swift
+++ b/Sources/StateGraph/GraphTransaction.swift
@@ -24,10 +24,17 @@ import Foundation
 /// the batch is published before this function returns. Every batch uses each
 /// `Stored` node's ordinary comparator and graph notification pipeline.
 ///
-/// Nested calls join the active transaction. They do not create a savepoint or an
-/// independent commit or rollback boundary: if an inner error is caught by `body`,
-/// its staged assignments remain part of the outer transaction. Only an error that
-/// leaves the outermost call rolls all staged assignments back.
+/// Each nested call creates a savepoint. A successful nested call merges its staged
+/// assignments into its parent without publishing them. A throwing nested call
+/// restores the values visible when it began, even if its parent catches the error.
+/// An error that leaves the outermost call rolls all staged assignments back,
+/// including changes from successful nested calls.
+///
+/// Savepoint completion restores the parent scope and finishes merging or restoring
+/// every affected node before releasing discarded values outside node locks. A
+/// synchronous `Stored` assignment from their `deinit` joins the parent scope. As
+/// with other synchronous callbacks, that cleanup must not wait for another thread
+/// to finish a graph write while the outer transaction still owns writer admission.
 ///
 /// This API is synchronous and nonescaping. Its dynamic context is thread-local;
 /// do not assume it is preserved across `await`, task creation, or executor hops.
@@ -70,8 +77,8 @@ import Foundation
 /// - Returns: The value returned by `body`. The outermost call returns after every
 ///   staged Observation-handler batch commits. A nested call returns to the active
 ///   outer body without committing.
-/// - Throws: The error thrown by `body`. An error escaping the outermost call
-///   discards every staged assignment before it is rethrown.
+/// - Throws: The error thrown by `body`, after rolling back this call's assignments
+///   and those of its nested calls. The parent may catch the error and continue.
 @discardableResult
 public func withGraphTransaction<Result, Failure: Error>(
   _ file: StaticString = #fileID,
@@ -81,9 +88,26 @@ public func withGraphTransaction<Result, Failure: Error>(
 ) throws(Failure) -> Result {
   assertGraphMutationAllowed("withGraphTransaction")
 
-  if ThreadLocal.graphTransaction.value != nil {
-    Log.logNestedGraphTransaction(file, line, column)
-    return try body()
+  if let parent = ThreadLocal.graphTransaction.value {
+    let context = GraphTransactionContext(parent: parent)
+    ThreadLocal.graphTransaction.replaceValue(context)
+    var didMerge = false
+
+    defer {
+      // Restore every node before arbitrary value destruction can reenter the graph.
+      // Writer admission continues to belong to the outermost transaction.
+      ThreadLocal.graphTransaction.replaceValue(parent)
+      if !didMerge {
+        context.prepareRollback()
+      }
+      context.finishCleanup()
+    }
+
+    let result = try body()
+    ThreadLocal.graphTransaction.replaceValue(parent)
+    context.prepareMerge(into: parent)
+    didMerge = true
+    return result
   }
 
   precondition(
@@ -109,7 +133,7 @@ public func withGraphTransaction<Result, Failure: Error>(
       ThreadLocal.graphTransaction.replaceValue(previousContext)
       context.prepareRollback()
       coordinator.finishTransaction(context)
-      context.finishRollback()
+      context.finishCleanup()
     }
   }
 
@@ -202,6 +226,13 @@ private func commitTransactionBatches(
 /// remain in the concrete `Stored` node that owns their static type.
 protocol GraphTransactionParticipant: AnyObject {
 
+  /// Transfers a successful savepoint's staged value and undo state to its parent.
+  /// Discarded parent values remain node-local until every participant has merged.
+  func prepareTransactionMerge(
+    _ transaction: GraphTransactionContext,
+    into parent: GraphTransactionContext
+  )
+
   /// Moves the staged value into node-local commit work.
   func prepareTransactionCommit()
 
@@ -228,11 +259,11 @@ protocol GraphTransactionParticipant: AnyObject {
   /// Detaches the staged value while the transaction still excludes other writers.
   func prepareTransactionRollback(_ transaction: GraphTransactionContext)
 
-  /// Destroys the detached value after releasing the transaction writer slot.
-  func finishTransactionRollback(_ transaction: GraphTransactionContext)
+  /// Destroys values detached by rollback or merge, outside node locks.
+  func finishTransactionCleanup(_ transaction: GraphTransactionContext)
 }
 
-/// The thread-local command list for one graph transaction commit batch.
+/// The thread-local command list for one commit batch or nested savepoint.
 ///
 /// This context intentionally retains only weak, type-erased participants. Each
 /// `Stored` node owns its typed staged value directly, which keeps transaction
@@ -247,8 +278,28 @@ final class GraphTransactionContext {
   private var frozenParticipants: [any GraphTransactionParticipant] = []
   private(set) var recordsDependencies = false
 
+  /// The enclosing savepoint or commit batch. Only nested calls have a parent;
+  /// Observation-generated batches are separate roots under the same writer owner.
+  let parent: GraphTransactionContext?
+
+  init(parent: GraphTransactionContext? = nil) {
+    self.parent = parent
+    recordsDependencies = parent?.recordsDependencies ?? false
+  }
+
   func register(_ participant: any GraphTransactionParticipant) {
     participants.append(.init(value: participant))
+  }
+
+  /// Merges every surviving participant before releasing superseded parent values.
+  /// Nodes retain their typed undo history and register with the parent only if
+  /// that scope had not already staged them.
+  func prepareMerge(into parent: GraphTransactionContext) {
+    precondition(self.parent === parent)
+    frozenParticipants = participants.compactMap(\.value)
+    for participant in frozenParticipants {
+      participant.prepareTransactionMerge(self, into: parent)
+    }
   }
 
   /// Freezes one strong participant snapshot for every phase of this batch.
@@ -312,10 +363,11 @@ final class GraphTransactionContext {
     recordsDependencies = true
   }
 
-  /// Detaches every staged value while this transaction still owns the writer slot.
+  /// Detaches this scope's staged values while the outer call owns writer admission.
   ///
   /// The strong snapshot prevents a participant from disappearing between detach
-  /// and destruction. Values remain in their concrete nodes throughout both phases.
+  /// and destruction. Savepoints restore their preceding staging during this phase;
+  /// detached values remain in their concrete nodes until cleanup.
   func prepareRollback() {
     frozenParticipants = participants.compactMap(\.value)
     for participant in frozenParticipants {
@@ -323,16 +375,17 @@ final class GraphTransactionContext {
     }
   }
 
-  /// Destroys detached staged values after another writer can safely reenter.
+  /// Destroys detached values after the whole scope has merged or rolled back.
   ///
   /// Releasing an arbitrary `Value` may synchronously run user-defined `deinit`
-  /// work. Keeping that destruction outside node locks and the coordinator's writer
-  /// slot prevents reentrant graph mutations from waiting on their own rollback.
-  func finishRollback() {
+  /// work. An outer rollback releases writer admission first. A savepoint instead
+  /// restores its parent context first, so reentrant assignments join the parent
+  /// while the outer transaction continues excluding competing writers.
+  func finishCleanup() {
     defer { frozenParticipants.removeAll() }
 
     for participant in frozenParticipants {
-      participant.finishTransactionRollback(self)
+      participant.finishTransactionCleanup(self)
     }
   }
 }

--- a/Sources/StateGraph/GraphTransactionCoordinator.swift
+++ b/Sources/StateGraph/GraphTransactionCoordinator.swift
@@ -188,7 +188,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     condition.lock()
     defer { condition.unlock() }
 
-    precondition(activeTransaction === transaction)
+    precondition(activeTransaction == transaction)
     precondition(!isPublishing)
 
     // Close admission before draining. Existing readers can now only finish, so the
@@ -220,7 +220,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     condition.lock()
     defer { condition.unlock() }
 
-    precondition(activeTransaction === transaction)
+    precondition(activeTransaction == transaction)
     precondition(!isPublishing)
 
     activeTransaction = nil
@@ -236,7 +236,7 @@ final class GraphTransactionCoordinator: @unchecked Sendable {
     condition.lock()
     defer { condition.unlock() }
 
-    precondition(activeTransaction === transaction)
+    precondition(activeTransaction == transaction)
     precondition(isPublishing)
     isPublishing = false
 

--- a/Sources/StateGraph/Logger.swift
+++ b/Sources/StateGraph/Logger.swift
@@ -29,11 +29,12 @@ public enum StateGraphDiagnostics {
     }
   }
 
-  /// Controls the DEBUG diagnostic emitted when a nested graph transaction joins
-  /// an active outer transaction.
+  /// Retains the former nested-transaction diagnostic preference for source compatibility.
   ///
-  /// Nested calls always join the outer transaction regardless of this setting.
-  /// The default is `true`. Logging remains disabled in non-DEBUG builds.
+  /// Nested graph transactions now create savepoints and emit no nesting warning.
+  /// Reading and writing this preference remains supported, with a default of `true`,
+  /// but its value has no effect on transaction behavior or diagnostics.
+  @available(*, deprecated, message: "Nested graph transactions now support savepoints; this setting has no effect.")
   public static var isNestedTransactionWarningEnabled: Bool {
     get {
       state.withLock { $0.isNestedTransactionWarningEnabled }
@@ -49,9 +50,6 @@ enum Log {
 #if DEBUG
   @TaskLocal
   static var selfInvalidationWarningObserver: (@Sendable () -> Void)?
-
-  @TaskLocal
-  static var nestedTransactionWarningObserver: (@Sendable () -> Void)?
 #endif
 
   static let generic = Logger(OSLog.makeOSLogInDebug { OSLog.init(subsystem: "state-graph", category: "generic") })
@@ -67,22 +65,6 @@ enum Log {
     tracking.warning(
       "A tracking handler invalidated its own active registration. The mutation was applied and peer registrations were notified, but this registration was not restored to the invalidated node."
     )
-  }
-
-  static func logNestedGraphTransaction(
-    _ file: StaticString,
-    _ line: UInt,
-    _ column: UInt
-  ) {
-#if DEBUG
-    guard StateGraphDiagnostics.isNestedTransactionWarningEnabled else { return }
-    nestedTransactionWarningObserver?()
-
-    let sourceLocation = "\(file):\(line):\(column)"
-    generic.debug(
-      "A nested graph transaction at \(sourceLocation, privacy: .public) joined the active transaction. It has no independent commit or rollback boundary."
-    )
-#endif
   }
 }
 

--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -25,10 +25,10 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   /// but keeping the wrapper noncopyable makes its single owner explicit and lets commit
   /// consume the staged storage before publishing.
   private struct TransactionBuffer<Element>: ~Copyable {
-    var context: ObjectIdentifier
+    var context: GraphTransactionContext
     var value: Element
 
-    init(_ value: consuming Element, context: ObjectIdentifier) {
+    init(_ value: consuming Element, context: GraphTransactionContext) {
       self.context = context
       self.value = value
     }
@@ -75,7 +75,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   /// to any ancestor because intermediate scopes need not have touched this node.
   private enum TransactionStagingState {
     case unstaged
-    case staged(context: ObjectIdentifier, value: Value)
+    case staged(context: GraphTransactionContext, value: Value)
   }
 
   /// Typed undo state for a savepoint that has written this node.
@@ -84,7 +84,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   /// undo state to a previously untouched parent; rollback restores it directly,
   /// without invoking assignment observers or graph notifications.
   private struct TransactionSavepoint {
-    let context: ObjectIdentifier
+    let context: GraphTransactionContext
     let precedingState: TransactionStagingState
   }
 
@@ -94,10 +94,11 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   /// A typed value detached by rollback or superseded by a savepoint merge.
   ///
   /// Multiple cleanup operations may overlap after their writer slots are released,
-  /// so context identity keeps their node-local values distinct without moving them
-  /// into the type-erased transaction context.
+  /// so retaining each context keeps its node-local values distinct without moving
+  /// them into the type-erased transaction context. Cleanup removes this reference
+  /// before the scope releases its temporary strong participant snapshot.
   private struct TransactionDiscardedValue {
-    let context: ObjectIdentifier
+    let context: GraphTransactionContext
     let value: Value
   }
 
@@ -246,8 +247,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
       oldValue = value
     }
 
-    let context = ObjectIdentifier(transaction)
-    let needsRegistration = transactionBuffer == nil || transactionBuffer!.context != context
+    let needsRegistration = transactionBuffer == nil || transactionBuffer!.context != transaction
     var discardedBuffer = transactionBuffer.take()
 
     if needsRegistration, transaction.parent != nil {
@@ -262,11 +262,11 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
         precedingState = .unstaged
       }
       transactionSavepoints.append(
-        .init(context: context, precedingState: precedingState)
+        .init(context: transaction, precedingState: precedingState)
       )
     }
 
-    transactionBuffer = .init(newValue, context: context)
+    transactionBuffer = .init(newValue, context: transaction)
     let didSetHandler = self.didSetHandler
     lock.unlock()
 
@@ -366,28 +366,25 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
     _ transaction: GraphTransactionContext,
     into parent: GraphTransactionContext
   ) {
-    let context = ObjectIdentifier(transaction)
-    let parentContext = ObjectIdentifier(parent)
-
     lock.lock()
-    precondition(transactionBuffer != nil && transactionBuffer!.context == context)
+    precondition(transactionBuffer != nil && transactionBuffer!.context == transaction)
     let savepoint = transactionSavepoints.removeLast()
-    precondition(savepoint.context == context)
+    precondition(savepoint.context == transaction)
 
     // Keep the child's final value as the parent's staged value. Merging is not an
     // assignment and must not repeat onDidSet or publish a graph notification.
-    transactionBuffer!.context = parentContext
+    transactionBuffer!.context = parent
 
     let needsParentRegistration: Bool
     switch savepoint.precedingState {
     case .unstaged:
       needsParentRegistration = true
     case .staged(let precedingContext, let precedingValue):
-      if precedingContext == parentContext {
+      if precedingContext == parent {
         needsParentRegistration = false
         // Retain the superseded parent value until every node has merged. Its deinit
         // must see the whole parent snapshot and must never execute under this lock.
-        transactionDiscardedValues.append(.init(context: context, value: precedingValue))
+        transactionDiscardedValues.append(.init(context: transaction, value: precedingValue))
       } else {
         needsParentRegistration = true
       }
@@ -398,7 +395,7 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
         // The parent had not written this node. It inherits the child's undo state,
         // including a value staged by an ancestor beyond the immediate parent.
         transactionSavepoints.append(
-          .init(context: parentContext, precedingState: savepoint.precedingState)
+          .init(context: parent, precedingState: savepoint.precedingState)
         )
       } else {
         guard case .unstaged = savepoint.precedingState else {
@@ -557,18 +554,17 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
       lock.unlock()
       return
     }
-    let context = ObjectIdentifier(transaction)
-    precondition(transactionBuffer.context == context)
+    precondition(transactionBuffer.context == transaction)
     transactionDiscardedValues.append(
       .init(
-        context: context,
+        context: transaction,
         value: transactionBuffer.takeValue()
       )
     )
 
     if transaction.parent != nil {
       let savepoint = transactionSavepoints.removeLast()
-      precondition(savepoint.context == context)
+      precondition(savepoint.context == transaction)
       switch savepoint.precedingState {
       case .unstaged:
         break
@@ -582,12 +578,10 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   }
 
   func finishTransactionCleanup(_ transaction: GraphTransactionContext) {
-    let context = ObjectIdentifier(transaction)
-
     lock.lock()
     guard
       let index = transactionDiscardedValues.lastIndex(
-        where: { $0.context == context }
+        where: { $0.context == transaction }
       )
     else {
       lock.unlock()

--- a/Sources/StateGraph/Primitives/Stored.swift
+++ b/Sources/StateGraph/Primitives/Stored.swift
@@ -19,15 +19,17 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   nonisolated(unsafe)
   private var value: Value
 
-  /// A typed staged value owned directly by this node during an outer graph transaction.
+  /// The latest typed value staged by one transaction scope, owned by this node.
   ///
   /// The wrapper is deliberately not a reference box. `Stored` values are copyable today,
   /// but keeping the wrapper noncopyable makes its single owner explicit and lets commit
   /// consume the staged storage before publishing.
   private struct TransactionBuffer<Element>: ~Copyable {
+    var context: ObjectIdentifier
     var value: Element
 
-    init(_ value: consuming Element) {
+    init(_ value: consuming Element, context: ObjectIdentifier) {
+      self.context = context
       self.value = value
     }
 
@@ -67,19 +69,42 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
   nonisolated(unsafe)
   private var transactionBuffer: TransactionBuffer<Value>?
 
-  /// A typed value detached from a particular transaction during rollback.
+  /// The staging state preceding a savepoint's first assignment to this node.
+  ///
+  /// `unstaged` is distinct from a staged optional `nil`. A saved value may belong
+  /// to any ancestor because intermediate scopes need not have touched this node.
+  private enum TransactionStagingState {
+    case unstaged
+    case staged(context: ObjectIdentifier, value: Value)
+  }
+
+  /// Typed undo state for a savepoint that has written this node.
+  ///
+  /// Read-only scopes allocate no node history. Successful scopes transfer their
+  /// undo state to a previously untouched parent; rollback restores it directly,
+  /// without invoking assignment observers or graph notifications.
+  private struct TransactionSavepoint {
+    let context: ObjectIdentifier
+    let precedingState: TransactionStagingState
+  }
+
+  nonisolated(unsafe)
+  private var transactionSavepoints: [TransactionSavepoint] = []
+
+  /// A typed value detached by rollback or superseded by a savepoint merge.
   ///
   /// Multiple cleanup operations may overlap after their writer slots are released,
   /// so context identity keeps their node-local values distinct without moving them
   /// into the type-erased transaction context.
-  private struct TransactionRollbackValue {
+  private struct TransactionDiscardedValue {
     let context: ObjectIdentifier
     let value: Value
   }
 
-  /// Rolled-back values waiting to be destroyed outside writer coordination.
+  /// Values waiting for the entire scope to finish restoring or merging its nodes.
+  /// Outer rollback also releases writer admission before destroying these values.
   nonisolated(unsafe)
-  private var transactionRollbackValues: [TransactionRollbackValue] = []
+  private var transactionDiscardedValues: [TransactionDiscardedValue] = []
 
   nonisolated(unsafe)
   private var transactionCommitWork: TransactionCommitWork?
@@ -221,9 +246,27 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
       oldValue = value
     }
 
-    let needsRegistration = transactionBuffer == nil
-    let discardedBuffer = transactionBuffer.take()
-    transactionBuffer = .init(newValue)
+    let context = ObjectIdentifier(transaction)
+    let needsRegistration = transactionBuffer == nil || transactionBuffer!.context != context
+    var discardedBuffer = transactionBuffer.take()
+
+    if needsRegistration, transaction.parent != nil {
+      let precedingState: TransactionStagingState
+      if let precedingBuffer = discardedBuffer.take() {
+        let precedingContext = precedingBuffer.context
+        precedingState = .staged(
+          context: precedingContext,
+          value: precedingBuffer.takeValue()
+        )
+      } else {
+        precedingState = .unstaged
+      }
+      transactionSavepoints.append(
+        .init(context: context, precedingState: precedingState)
+      )
+    }
+
+    transactionBuffer = .init(newValue, context: context)
     let didSetHandler = self.didSetHandler
     lock.unlock()
 
@@ -319,8 +362,60 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
 #endif
   }
 
+  func prepareTransactionMerge(
+    _ transaction: GraphTransactionContext,
+    into parent: GraphTransactionContext
+  ) {
+    let context = ObjectIdentifier(transaction)
+    let parentContext = ObjectIdentifier(parent)
+
+    lock.lock()
+    precondition(transactionBuffer != nil && transactionBuffer!.context == context)
+    let savepoint = transactionSavepoints.removeLast()
+    precondition(savepoint.context == context)
+
+    // Keep the child's final value as the parent's staged value. Merging is not an
+    // assignment and must not repeat onDidSet or publish a graph notification.
+    transactionBuffer!.context = parentContext
+
+    let needsParentRegistration: Bool
+    switch savepoint.precedingState {
+    case .unstaged:
+      needsParentRegistration = true
+    case .staged(let precedingContext, let precedingValue):
+      if precedingContext == parentContext {
+        needsParentRegistration = false
+        // Retain the superseded parent value until every node has merged. Its deinit
+        // must see the whole parent snapshot and must never execute under this lock.
+        transactionDiscardedValues.append(.init(context: context, value: precedingValue))
+      } else {
+        needsParentRegistration = true
+      }
+    }
+
+    if needsParentRegistration {
+      if parent.parent != nil {
+        // The parent had not written this node. It inherits the child's undo state,
+        // including a value staged by an ancestor beyond the immediate parent.
+        transactionSavepoints.append(
+          .init(context: parentContext, precedingState: savepoint.precedingState)
+        )
+      } else {
+        guard case .unstaged = savepoint.precedingState else {
+          preconditionFailure("A root transaction cannot inherit another scope's staged value.")
+        }
+      }
+    }
+    lock.unlock()
+
+    if needsParentRegistration {
+      parent.register(self)
+    }
+  }
+
   func prepareTransactionCommit() {
     lock.lock()
+    precondition(transactionSavepoints.isEmpty)
     guard let transactionBuffer = self.transactionBuffer.take() else {
       lock.unlock()
       return
@@ -462,34 +557,49 @@ public final class Stored<Value: SendableMetatype>: Node, Observable, CustomDebu
       lock.unlock()
       return
     }
-    transactionRollbackValues.append(
+    let context = ObjectIdentifier(transaction)
+    precondition(transactionBuffer.context == context)
+    transactionDiscardedValues.append(
       .init(
-        context: ObjectIdentifier(transaction),
+        context: context,
         value: transactionBuffer.takeValue()
       )
     )
+
+    if transaction.parent != nil {
+      let savepoint = transactionSavepoints.removeLast()
+      precondition(savepoint.context == context)
+      switch savepoint.precedingState {
+      case .unstaged:
+        break
+      case .staged(let precedingContext, let precedingValue):
+        self.transactionBuffer = .init(precedingValue, context: precedingContext)
+      }
+    } else {
+      precondition(transactionSavepoints.isEmpty)
+    }
     lock.unlock()
   }
 
-  func finishTransactionRollback(_ transaction: GraphTransactionContext) {
+  func finishTransactionCleanup(_ transaction: GraphTransactionContext) {
     let context = ObjectIdentifier(transaction)
 
     lock.lock()
     guard
-      let index = transactionRollbackValues.lastIndex(
+      let index = transactionDiscardedValues.lastIndex(
         where: { $0.context == context }
       )
     else {
       lock.unlock()
       return
     }
-    let rollbackValue = transactionRollbackValues.remove(at: index)
+    let discardedValue = transactionDiscardedValues.remove(at: index)
     lock.unlock()
 
-    Self.discardTransactionValue(rollbackValue.value)
+    Self.discardTransactionValue(discardedValue.value)
   }
 
-  /// Ends a rolled-back value's lifetime outside node and coordinator locks.
+  /// Ends a discarded value's lifetime after the whole scope is coherent, outside locks.
   private static func discardTransactionValue(_ value: consuming Value) {
     _ = consume value
   }

--- a/Tests/StateGraphTests/GraphStoredDidSetTests.swift
+++ b/Tests/StateGraphTests/GraphStoredDidSetTests.swift
@@ -118,6 +118,68 @@ struct GraphStoredDidSetTests {
     #expect(nodeObserverEvents == model.propertyObserverEvents)
   }
 
+  @Test func nested_rollback_restores_observer_mutations_without_replaying_observers() {
+    /// A source and derived value whose assignment history is an external side effect.
+    final class Model {
+      @GraphStored
+      var source: Int = 0 {
+        didSet {
+          derived += source - oldValue
+          propertyObserverEvents.append("\(oldValue)->\(source)")
+        }
+      }
+
+      @GraphStored
+      var derived: Int = 0
+
+      @GraphStored
+      var nodeDerived: Int = 0
+
+      var propertyObserverEvents: [String] = []
+    }
+
+    /// Requests rollback of the inner assignment while allowing its parent to continue.
+    enum TestError: Error {
+      case rollback
+    }
+
+    let model = Model()
+    var nodeObserverEvents: [String] = []
+    model.$source.onDidSet { [weak model] oldValue, newValue in
+      nodeObserverEvents.append("\(oldValue)->\(newValue)")
+      if let model {
+        model.nodeDerived += newValue - oldValue
+      }
+    }
+
+    withGraphTransaction {
+      model.source = 1
+
+      #expect(throws: TestError.self) {
+        try withGraphTransaction { () throws(TestError) -> Void in
+          model.source = 2
+          #expect(model.derived == 2)
+          #expect(model.nodeDerived == 2)
+          throw .rollback
+        }
+      }
+
+      #expect(model.source == 1)
+      #expect(model.derived == 1)
+      #expect(model.nodeDerived == 1)
+      #expect(model.propertyObserverEvents == ["0->1", "1->2"])
+      #expect(nodeObserverEvents == model.propertyObserverEvents)
+
+      model.source = 3
+    }
+
+    #expect(model.source == 3)
+    #expect(model.derived == 3)
+    #expect(model.nodeDerived == 3)
+    #expect(model.propertyObserverEvents == ["0->1", "1->2", "1->3"])
+    #expect(nodeObserverEvents == model.propertyObserverEvents)
+  }
+
   @Test func didSet_runs_with_graphUserDefault() {
     let key = "GraphStoredDidSetTests.username"
     UserDefaults.standard.removeObject(forKey: key)

--- a/Tests/StateGraphTests/GraphTransactionTests.swift
+++ b/Tests/StateGraphTests/GraphTransactionTests.swift
@@ -47,6 +47,21 @@ struct GraphTransactionTests {
     }
   }
 
+  /// Observes a transaction context's lifetime without extending it beyond its scope.
+  private final class WeakTransactionContext {
+    weak var value: GraphTransactionContext?
+  }
+
+  @Test
+  func transactionContextEqualityUsesIdentity() {
+    let context = GraphTransactionContext()
+    let alias = context
+    let otherContext = GraphTransactionContext()
+
+    #expect(context == alias)
+    #expect(context != otherContext)
+  }
+
   @Test
   func commitsMultipleStoredValuesAndReadsStagedMutations() {
     let first = Stored(wrappedValue: 0)
@@ -969,6 +984,7 @@ struct GraphTransactionTests {
   @MainActor
   func nestedTransactionOutcomesMatchSnapshotsAtEveryScope(rollsBack: [Bool]) {
     let scopeCount = rollsBack.count
+    let contexts = (0..<scopeCount).map { _ in WeakTransactionContext() }
     let initialValues = Array(repeating: 0, count: scopeCount + 1)
     let comparisonCounts = LockedBox(initialValues)
     let notificationCounts = LockedBox(initialValues)
@@ -1012,6 +1028,8 @@ struct GraphTransactionTests {
       let precedingValues = expectedValues
       do {
         try withGraphTransaction { () throws(TransactionError) -> Void in
+          contexts[level - 1].value = ThreadLocal.graphTransaction.value
+          #expect(contexts[level - 1].value != nil)
           expectSnapshot()
 
           // Every scope overwrites the shared node and introduces its own node.
@@ -1071,12 +1089,20 @@ struct GraphTransactionTests {
     } else {
       #expect(computedNotificationCount.value == 1)
     }
+
+    // Live nodes must release the strong contexts in their staging and cleanup storage.
+    withExtendedLifetime(nodes) {
+      for context in contexts {
+        #expect(context.value == nil)
+      }
+    }
   }
 
   @Test
   @MainActor
   func uncaughtInnermostErrorRollsBackAllEightScopesWithoutPublication() {
     let scopeCount = 8
+    let contexts = (0..<scopeCount).map { _ in WeakTransactionContext() }
     let comparisonCount = LockedBox(0)
     let notificationCount = LockedBox(0)
     let nodes = (0..<scopeCount).map { _ in
@@ -1098,6 +1124,8 @@ struct GraphTransactionTests {
 
     func enterScope(_ index: Int) throws(TransactionError) {
       try withGraphTransaction { () throws(TransactionError) -> Void in
+        contexts[index].value = ThreadLocal.graphTransaction.value
+        #expect(contexts[index].value != nil)
         nodes[index].wrappedValue = index + 1
         if index + 1 < scopeCount {
           try enterScope(index + 1)
@@ -1113,6 +1141,12 @@ struct GraphTransactionTests {
     #expect(nodes.map { $0.wrappedValue } == Array(repeating: 0, count: scopeCount))
     #expect(comparisonCount.value == 0)
     #expect(notificationCount.value == 0)
+
+    withExtendedLifetime(nodes) {
+      for context in contexts {
+        #expect(context.value == nil)
+      }
+    }
   }
 
   @Test
@@ -1274,6 +1308,13 @@ struct GraphTransactionTests {
     let fourth = Stored(wrappedValue: 0)
     let secondChangeCount = LockedBox(0)
     let thirdChangeCount = LockedBox(0)
+    let contexts = LockedBox(
+      (
+        parent: WeakTransactionContext(),
+        failedChild: WeakTransactionContext(),
+        successfulChild: WeakTransactionContext()
+      )
+    )
 
     withObservationTracking {
       _ = third.wrappedValue
@@ -1292,10 +1333,14 @@ struct GraphTransactionTests {
     withObservationTracking {
       _ = first.wrappedValue
     } onChange: {
+      contexts.update { $0.parent.value = ThreadLocal.graphTransaction.value }
+      #expect(contexts.value.parent.value != nil)
       second.wrappedValue = 10
 
       #expect(throws: TransactionError.self) {
         try withGraphTransaction { () throws(TransactionError) -> Void in
+          contexts.update { $0.failedChild.value = ThreadLocal.graphTransaction.value }
+          #expect(contexts.value.failedChild.value != nil)
           first.wrappedValue = 9
           second.wrappedValue = 20
           third.wrappedValue = 30
@@ -1309,6 +1354,8 @@ struct GraphTransactionTests {
       #expect(third.wrappedValue == 0)
 
       withGraphTransaction {
+        contexts.update { $0.successfulChild.value = ThreadLocal.graphTransaction.value }
+        #expect(contexts.value.successfulChild.value != nil)
         second.wrappedValue = 12
       }
 
@@ -1326,6 +1373,13 @@ struct GraphTransactionTests {
     #expect(fourth.wrappedValue == 4)
     #expect(secondChangeCount.value == 1)
     #expect(thirdChangeCount.value == 0)
+
+    withExtendedLifetime((first, second, third, fourth)) {
+      let capturedContexts = contexts.value
+      #expect(capturedContexts.parent.value == nil)
+      #expect(capturedContexts.failedChild.value == nil)
+      #expect(capturedContexts.successfulChild.value == nil)
+    }
 
     third.wrappedValue = 3
     #expect(thirdChangeCount.value == 1)

--- a/Tests/StateGraphTests/GraphTransactionTests.swift
+++ b/Tests/StateGraphTests/GraphTransactionTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite("Graph transactions", .serialized)
 struct GraphTransactionTests {
 
-  /// The typed failure used to verify outer transaction rollback.
+  /// The typed failure used to verify transaction and savepoint rollback.
   private enum TransactionError: Error {
     case rollback
   }
@@ -83,7 +83,7 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func outsideReaderSeesCommittedValueWhileTransactionBodyIsPaused() async {
+  func outsideReaderSeesCommittedValueAfterNestedTransactionReturns() async {
     let node = Stored(wrappedValue: 0)
     let transactionStarted = TestThreadSignal()
     let resumeTransaction = TestThreadGate()
@@ -101,6 +101,9 @@ struct GraphTransactionTests {
     let transactionThread = Thread {
       withGraphTransaction {
         node.wrappedValue = 1
+        withGraphTransaction {
+          node.wrappedValue = 2
+        }
         transactionStarted.signal()
         resumeTransaction.wait(until: Date.distantFuture)
       }
@@ -138,11 +141,11 @@ struct GraphTransactionTests {
     #expect(result.transactionStarted)
     #expect(result.pausedReadValue == 0)
     #expect(result.transactionFinished)
-    #expect(result.committedValue == 1)
+    #expect(result.committedValue == 2)
   }
 
   @Test
-  func outsideWriterWaitsForTransactionCompletion() async {
+  func outsideWriterWaitsForOuterTransactionAfterNestedTransactionReturns() async {
     let node = Stored(wrappedValue: 0)
     let transactionStarted = TestThreadSignal()
     let resumeTransaction = TestThreadGate()
@@ -166,6 +169,9 @@ struct GraphTransactionTests {
     let transactionThread = Thread {
       withGraphTransaction {
         node.wrappedValue = 1
+        withGraphTransaction {
+          node.wrappedValue = 2
+        }
         transactionStarted.signal()
         resumeTransaction.wait(until: Date.distantFuture)
       }
@@ -188,7 +194,7 @@ struct GraphTransactionTests {
 
       Thread {
         writerStarted.signal()
-        node.wrappedValue = 2
+        node.wrappedValue = 3
         writerDidFinish.update { $0 = true }
         writerFinished.signal()
       }.start()
@@ -229,7 +235,7 @@ struct GraphTransactionTests {
     #expect(result.writerRemainedBlockedBeforeRelease)
     #expect(result.transactionFinished)
     #expect(result.writerFinished)
-    #expect(result.finalValue == 2)
+    #expect(result.finalValue == 3)
   }
 
   @Test
@@ -311,6 +317,89 @@ struct GraphTransactionTests {
 
     #expect(source.wrappedValue === committedValue)
     #expect(sideEffect.wrappedValue == 1)
+  }
+
+  @Test
+  func nestedRollbackRestoresEveryParentValueBeforeDestroyingStagedReferences() {
+    let committedValue = DeinitAction()
+    let parentValue = DeinitAction()
+    let source = Stored(wrappedValue: committedValue)
+    let second = Stored(wrappedValue: 0)
+    let sideEffect = Stored(wrappedValue: 0)
+    let cleanupObservedParentSnapshot = LockedBox(false)
+
+    #expect(throws: TransactionError.self) {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        source.wrappedValue = parentValue
+        second.wrappedValue = 1
+
+        var didRollBackNestedTransaction = false
+        do {
+          try withGraphTransaction { () throws(TransactionError) -> Void in
+            source.wrappedValue = DeinitAction {
+              cleanupObservedParentSnapshot.update {
+                $0 = source.wrappedValue === parentValue && second.wrappedValue == 1
+              }
+              // Cleanup runs after the child scope is detached and joins its parent.
+              sideEffect.wrappedValue = 3
+            }
+            second.wrappedValue = 2
+            throw .rollback
+          }
+        } catch {
+          didRollBackNestedTransaction = true
+        }
+
+        #expect(didRollBackNestedTransaction)
+        #expect(cleanupObservedParentSnapshot.value)
+        #expect(source.wrappedValue === parentValue)
+        #expect(second.wrappedValue == 1)
+        #expect(sideEffect.wrappedValue == 3)
+        throw .rollback
+      }
+    }
+
+    #expect(source.wrappedValue === committedValue)
+    #expect(second.wrappedValue == 0)
+    #expect(sideEffect.wrappedValue == 0)
+  }
+
+  @Test
+  func nestedMergeTransfersEveryValueBeforeDestroyingReplacedParentValues() {
+    let committedValue = DeinitAction()
+    let childValue = DeinitAction()
+    let source = Stored(wrappedValue: committedValue)
+    let second = Stored(wrappedValue: 0)
+    let sideEffect = Stored(wrappedValue: 0)
+    let cleanupObservedMergedSnapshot = LockedBox(false)
+
+    #expect(throws: TransactionError.self) {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        source.wrappedValue = DeinitAction {
+          cleanupObservedMergedSnapshot.update {
+            $0 = source.wrappedValue === childValue && second.wrappedValue == 2
+          }
+          sideEffect.wrappedValue = 3
+        }
+        second.wrappedValue = 1
+
+        withGraphTransaction {
+          source.wrappedValue = childValue
+          second.wrappedValue = 2
+          #expect(!cleanupObservedMergedSnapshot.value)
+        }
+
+        #expect(cleanupObservedMergedSnapshot.value)
+        #expect(source.wrappedValue === childValue)
+        #expect(second.wrappedValue == 2)
+        #expect(sideEffect.wrappedValue == 3)
+        throw .rollback
+      }
+    }
+
+    #expect(source.wrappedValue === committedValue)
+    #expect(second.wrappedValue == 0)
+    #expect(sideEffect.wrappedValue == 0)
   }
 
   @Test
@@ -664,7 +753,7 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func nestedTransactionHasNoSavepointAndCaughtErrorKeepsItsStagedValue() {
+  func caughtNestedTransactionErrorRestoresTheParentStagedValue() {
     let node = Stored(wrappedValue: 0)
 
     withGraphTransaction {
@@ -680,10 +769,350 @@ struct GraphTransactionTests {
         Issue.record("Unexpected nested transaction error: \(error)")
       }
 
-      #expect(node.wrappedValue == 2)
+      #expect(node.wrappedValue == 1)
     }
 
-    #expect(node.wrappedValue == 2)
+    #expect(node.wrappedValue == 1)
+  }
+
+  @Test
+  @MainActor
+  func successfulNestedTransactionDefersPublicationUntilTheOuterCommit() {
+    let comparisons = LockedBox<[(Int, Int)]>([])
+    let first = Stored(
+      wrappedValue: 0,
+      shouldNotify: { oldValue, newValue in
+        comparisons.update { $0.append((oldValue, newValue)) }
+        return oldValue != newValue
+      }
+    )
+    let second = Stored(wrappedValue: 0)
+    let notificationCount = LockedBox(0)
+
+    withObservationTracking {
+      _ = first.wrappedValue
+      _ = second.wrappedValue
+    } onChange: {
+      notificationCount.update { $0 += 1 }
+    }
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+
+      let result = withGraphTransaction {
+        #expect(first.wrappedValue == 1)
+        first.wrappedValue = 2
+        second.wrappedValue = 3
+        return "merged"
+      }
+
+      #expect(result == "merged")
+      #expect(first.wrappedValue == 2)
+      #expect(second.wrappedValue == 3)
+      #expect(comparisons.value.isEmpty)
+      #expect(notificationCount.value == 0)
+    }
+
+    #expect(first.wrappedValue == 2)
+    #expect(second.wrappedValue == 3)
+    #expect(notificationCount.value == 1)
+    #expect(comparisons.value.count == 1)
+    #expect(comparisons.value.first?.0 == 0)
+    #expect(comparisons.value.first?.1 == 2)
+  }
+
+  @Test
+  func successfulNestedTransactionRollsBackWhenTheOuterBodyThrows() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+
+    #expect(throws: TransactionError.self) {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        first.wrappedValue = 1
+
+        withGraphTransaction {
+          first.wrappedValue = 2
+          second.wrappedValue = 3
+        }
+
+        #expect(first.wrappedValue == 2)
+        #expect(second.wrappedValue == 3)
+        throw .rollback
+      }
+    }
+
+    #expect(first.wrappedValue == 0)
+    #expect(second.wrappedValue == 0)
+  }
+
+  @Test
+  @MainActor
+  func nestedRollbackRestoresOptionalNilAndRemovesItsNewParticipants() {
+    let optional = Stored<Int?>(wrappedValue: 1)
+    let comparisonCount = LockedBox(0)
+    let innerOnly = Stored(
+      wrappedValue: 0,
+      shouldNotify: { oldValue, newValue in
+        comparisonCount.update { $0 += 1 }
+        return oldValue != newValue
+      }
+    )
+    let notificationCount = LockedBox(0)
+
+    withObservationTracking {
+      _ = innerOnly.wrappedValue
+    } onChange: {
+      notificationCount.update { $0 += 1 }
+    }
+
+    withGraphTransaction {
+      optional.wrappedValue = nil
+
+      #expect(throws: TransactionError.self) {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          #expect(optional.wrappedValue == nil)
+          optional.wrappedValue = 2
+          innerOnly.wrappedValue = 3
+          throw .rollback
+        }
+      }
+
+      #expect(optional.wrappedValue == nil)
+      #expect(innerOnly.wrappedValue == 0)
+    }
+
+    #expect(optional.wrappedValue == nil)
+    #expect(innerOnly.wrappedValue == 0)
+    #expect(comparisonCount.value == 0)
+    #expect(notificationCount.value == 0)
+
+    // A rolled-back participant must retain its existing observation registration.
+    innerOnly.wrappedValue = 4
+    #expect(comparisonCount.value == 1)
+    #expect(notificationCount.value == 1)
+  }
+
+  @Test
+  func nestedRollbackDiscardsSuccessfulGrandchildrenAndAllowsAnotherSavepoint() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+      second.wrappedValue = 10
+
+      #expect(throws: TransactionError.self) {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          first.wrappedValue = 2
+
+          withGraphTransaction {
+            #expect(first.wrappedValue == 2)
+            // The middle scope has not staged this node; reads reach the grandparent.
+            #expect(second.wrappedValue == 10)
+            first.wrappedValue = 3
+            second.wrappedValue = 4
+          }
+
+          #expect(first.wrappedValue == 3)
+          #expect(second.wrappedValue == 4)
+          throw .rollback
+        }
+      }
+
+      #expect(first.wrappedValue == 1)
+      #expect(second.wrappedValue == 10)
+
+      withGraphTransaction {
+        first.wrappedValue = 5
+
+        #expect(throws: TransactionError.self) {
+          try withGraphTransaction { () throws(TransactionError) -> Void in
+            #expect(second.wrappedValue == 10)
+            second.wrappedValue = 6
+            throw .rollback
+          }
+        }
+
+        #expect(second.wrappedValue == 10)
+      }
+    }
+
+    #expect(first.wrappedValue == 5)
+    #expect(second.wrappedValue == 10)
+  }
+
+  /// Rollback decisions ordered from the outermost scope to the innermost scope.
+  ///
+  /// Two and three scopes cover every outcome combination. Eight scopes cover
+  /// all-success, each individual rollback boundary, and all-rollback without
+  /// multiplying the same deep traversal into every possible combination.
+  private static let nestedTransactionRollbackPatterns: [[Bool]] = {
+    var patterns: [[Bool]] = []
+    for scopeCount in [2, 3] {
+      for mask in 0..<(1 << scopeCount) {
+        patterns.append((0..<scopeCount).map { mask & (1 << $0) != 0 })
+      }
+    }
+
+    let deepScopeCount = 8
+    patterns.append(Array(repeating: false, count: deepScopeCount))
+    for rollbackIndex in 0..<deepScopeCount {
+      var pattern = Array(repeating: false, count: deepScopeCount)
+      pattern[rollbackIndex] = true
+      patterns.append(pattern)
+    }
+    patterns.append(Array(repeating: true, count: deepScopeCount))
+    return patterns
+  }()
+
+  @Test(arguments: nestedTransactionRollbackPatterns)
+  @MainActor
+  func nestedTransactionOutcomesMatchSnapshotsAtEveryScope(rollsBack: [Bool]) {
+    let scopeCount = rollsBack.count
+    let initialValues = Array(repeating: 0, count: scopeCount + 1)
+    let comparisonCounts = LockedBox(initialValues)
+    let notificationCounts = LockedBox(initialValues)
+    let computedNotificationCount = LockedBox(0)
+    let nodes = initialValues.indices.map { index in
+      Stored(
+        wrappedValue: 0,
+        shouldNotify: { oldValue, newValue in
+          comparisonCounts.update { $0[index] += 1 }
+          return oldValue != newValue
+        }
+      )
+    }
+    let computed = Computed { _ in
+      nodes.map { $0.wrappedValue }
+    }
+
+    for (index, node) in nodes.enumerated() {
+      withObservationTracking {
+        _ = node.wrappedValue
+      } onChange: {
+        notificationCounts.update { $0[index] += 1 }
+      }
+    }
+    withObservationTracking {
+      _ = computed.wrappedValue
+    } onChange: {
+      computedNotificationCount.update { $0 += 1 }
+    }
+
+    // A plain value-semantic snapshot is an independent reference for savepoints;
+    // it does not inspect the graph's participant lists or node-local undo history.
+    var expectedValues = initialValues
+
+    func expectSnapshot() {
+      #expect(nodes.map { $0.wrappedValue } == expectedValues)
+      #expect(computed.wrappedValue == expectedValues)
+    }
+
+    func enterScope(_ level: Int) throws(TransactionError) {
+      let precedingValues = expectedValues
+      do {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          expectSnapshot()
+
+          // Every scope overwrites the shared node and introduces its own node.
+          // Successful children therefore exercise both replacement and transfer
+          // into parents that have never written the scope-specific nodes.
+          nodes[0].wrappedValue = level
+          nodes[level].wrappedValue = level
+          expectedValues[0] = level
+          expectedValues[level] = level
+          expectSnapshot()
+
+          if level < scopeCount {
+            do {
+              try enterScope(level + 1)
+            } catch {
+              #expect(rollsBack[level])
+            }
+            // Check immediately on return so a parent's later write cannot hide
+            // an incorrect merge or a rollback to the wrong ancestor.
+            expectSnapshot()
+          }
+
+          #expect(comparisonCounts.value == initialValues)
+          #expect(notificationCounts.value == initialValues)
+          #expect(computedNotificationCount.value == 0)
+          if rollsBack[level - 1] {
+            throw .rollback
+          }
+        }
+      } catch {
+        expectedValues = precedingValues
+        expectSnapshot()
+        throw error
+      }
+    }
+
+    var didRollBackOutermostScope = false
+    do {
+      try enterScope(1)
+    } catch {
+      didRollBackOutermostScope = true
+    }
+
+    #expect(didRollBackOutermostScope == rollsBack[0])
+    expectSnapshot()
+    for (index, value) in expectedValues.enumerated() {
+      if value == 0 {
+        #expect(comparisonCounts.value[index] == 0)
+        #expect(notificationCounts.value[index] == 0)
+      } else {
+        #expect(comparisonCounts.value[index] == 1)
+        #expect(notificationCounts.value[index] == 1)
+      }
+    }
+    if rollsBack[0] {
+      #expect(computedNotificationCount.value == 0)
+    } else {
+      #expect(computedNotificationCount.value == 1)
+    }
+  }
+
+  @Test
+  @MainActor
+  func uncaughtInnermostErrorRollsBackAllEightScopesWithoutPublication() {
+    let scopeCount = 8
+    let comparisonCount = LockedBox(0)
+    let notificationCount = LockedBox(0)
+    let nodes = (0..<scopeCount).map { _ in
+      Stored(
+        wrappedValue: 0,
+        shouldNotify: { oldValue, newValue in
+          comparisonCount.update { $0 += 1 }
+          return oldValue != newValue
+        }
+      )
+    }
+    for node in nodes {
+      withObservationTracking {
+        _ = node.wrappedValue
+      } onChange: {
+        notificationCount.update { $0 += 1 }
+      }
+    }
+
+    func enterScope(_ index: Int) throws(TransactionError) {
+      try withGraphTransaction { () throws(TransactionError) -> Void in
+        nodes[index].wrappedValue = index + 1
+        if index + 1 < scopeCount {
+          try enterScope(index + 1)
+        } else {
+          throw .rollback
+        }
+      }
+    }
+
+    #expect(throws: TransactionError.self) {
+      try enterScope(0)
+    }
+    #expect(nodes.map { $0.wrappedValue } == Array(repeating: 0, count: scopeCount))
+    #expect(comparisonCount.value == 0)
+    #expect(notificationCount.value == 0)
   }
 
   @Test
@@ -714,30 +1143,33 @@ struct GraphTransactionTests {
   }
 
 #if DEBUG
-  @Test
-  func nestedTransactionDiagnosticCanBeDisabled() {
+  @Test(arguments: [true, false])
+  func legacyNestedTransactionDiagnosticSettingDoesNotChangeSavepointBehavior(
+    isEnabled: Bool
+  ) {
     let previousValue = StateGraphDiagnostics.isNestedTransactionWarningEnabled
     defer {
       StateGraphDiagnostics.isNestedTransactionWarningEnabled = previousValue
     }
 
-    let warningCount = LockedBox(0)
+    StateGraphDiagnostics.isNestedTransactionWarningEnabled = isEnabled
+    #expect(StateGraphDiagnostics.isNestedTransactionWarningEnabled == isEnabled)
+    let node = Stored(wrappedValue: 0)
 
-    Log.$nestedTransactionWarningObserver.withValue({
-      warningCount.update { $0 += 1 }
-    }) {
-      StateGraphDiagnostics.isNestedTransactionWarningEnabled = true
-      withGraphTransaction {
-        withGraphTransaction {}
+    withGraphTransaction {
+      node.wrappedValue = 1
+
+      #expect(throws: TransactionError.self) {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          node.wrappedValue = 2
+          throw .rollback
+        }
       }
 
-      StateGraphDiagnostics.isNestedTransactionWarningEnabled = false
-      withGraphTransaction {
-        withGraphTransaction {}
-      }
+      #expect(node.wrappedValue == 1)
     }
 
-    #expect(warningCount.value == 1)
+    #expect(node.wrappedValue == 1)
   }
 #endif
 
@@ -830,6 +1262,101 @@ struct GraphTransactionTests {
     #expect(second.wrappedValue == 2)
     #expect(third.wrappedValue == 3)
     #expect(firstChangeCount.value == 1)
+    #expect(secondChangeCount.value == 1)
+  }
+
+  @Test
+  @MainActor
+  func observationCallbackSavepointRestoresThePendingCommitAndFollowingBatch() {
+    let first = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    let third = Stored(wrappedValue: 0)
+    let fourth = Stored(wrappedValue: 0)
+    let secondChangeCount = LockedBox(0)
+    let thirdChangeCount = LockedBox(0)
+
+    withObservationTracking {
+      _ = third.wrappedValue
+    } onChange: {
+      thirdChangeCount.update { $0 += 1 }
+    }
+
+    withObservationTracking {
+      _ = second.wrappedValue
+    } onChange: {
+      secondChangeCount.update { $0 += 1 }
+      #expect(second.wrappedValue == 12)
+      fourth.wrappedValue = 4
+    }
+
+    withObservationTracking {
+      _ = first.wrappedValue
+    } onChange: {
+      second.wrappedValue = 10
+
+      #expect(throws: TransactionError.self) {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          first.wrappedValue = 9
+          second.wrappedValue = 20
+          third.wrappedValue = 30
+          throw .rollback
+        }
+      }
+
+      // Reads fall back to the pending first commit and the parent callback batch.
+      #expect(first.wrappedValue == 1)
+      #expect(second.wrappedValue == 10)
+      #expect(third.wrappedValue == 0)
+
+      withGraphTransaction {
+        second.wrappedValue = 12
+      }
+
+      #expect(second.wrappedValue == 12)
+      #expect(secondChangeCount.value == 0)
+    }
+
+    withGraphTransaction {
+      first.wrappedValue = 1
+    }
+
+    #expect(first.wrappedValue == 1)
+    #expect(second.wrappedValue == 12)
+    #expect(third.wrappedValue == 0)
+    #expect(fourth.wrappedValue == 4)
+    #expect(secondChangeCount.value == 1)
+    #expect(thirdChangeCount.value == 0)
+
+    third.wrappedValue = 3
+    #expect(thirdChangeCount.value == 1)
+  }
+
+  @Test
+  @MainActor
+  func observationCallbackSavepointPreservesDependencyRegistration() {
+    let source = Stored(wrappedValue: 0)
+    let second = Stored(wrappedValue: 0)
+    let secondChangeCount = LockedBox(0)
+
+    withObservationTracking {
+      _ = source.wrappedValue
+    } onChange: {
+      withGraphTransaction {
+        // A child scope must preserve its callback parent's ability to track reads.
+        withObservationTracking {
+          _ = second.wrappedValue
+        } onChange: {
+          secondChangeCount.update { $0 += 1 }
+        }
+      }
+    }
+
+    withGraphTransaction {
+      source.wrappedValue = 1
+    }
+
+    #expect(secondChangeCount.value == 0)
+    second.wrappedValue = 2
     #expect(secondChangeCount.value == 1)
   }
 
@@ -1087,14 +1614,66 @@ struct GraphTransactionTests {
   }
 
   @Test
-  func deallocatedParticipantIsSkippedAtCommit() {
+  func computedReadsReturnToParentDependenciesAfterNestedRollback() {
+    let toggle = Stored(wrappedValue: false)
+    let first = Stored(wrappedValue: 1)
+    let second = Stored(wrappedValue: 2)
+    let computeCount = LockedBox(0)
+    let selected = Computed { _ in
+      computeCount.update { $0 += 1 }
+      if toggle.wrappedValue {
+        return second.wrappedValue
+      }
+      return first.wrappedValue
+    }
+
+    #expect(selected.wrappedValue == 1)
+
+    withGraphTransaction {
+      first.wrappedValue = 10
+      #expect(selected.wrappedValue == 10)
+
+      #expect(throws: TransactionError.self) {
+        try withGraphTransaction { () throws(TransactionError) -> Void in
+          toggle.wrappedValue = true
+          second.wrappedValue = 3
+          #expect(selected.wrappedValue == 3)
+          throw .rollback
+        }
+      }
+
+      #expect(selected.wrappedValue == 10)
+      #expect(second.wrappedValue == 2)
+      first.wrappedValue = 11
+    }
+
+    #expect(selected.wrappedValue == 11)
+    let countAfterCommit = computeCount.value
+
+    // The failed child must not leave a dependency on the alternate branch.
+    second.wrappedValue = 4
+    #expect(selected.wrappedValue == 11)
+    #expect(computeCount.value == countAfterCommit)
+
+    first.wrappedValue = 12
+    #expect(selected.wrappedValue == 12)
+    #expect(computeCount.value == countAfterCommit + 1)
+  }
+
+  @Test
+  func deallocatedNestedParticipantIsSkippedAtMergeAndCommit() {
     weak var weakNode: Stored<Int>?
 
     withGraphTransaction {
-      var node: Stored<Int>? = Stored(wrappedValue: 0)
-      weakNode = node
-      node?.wrappedValue = 1
-      node = nil
+      withGraphTransaction {
+        var node: Stored<Int>? = Stored(wrappedValue: 0)
+        weakNode = node
+        node?.wrappedValue = 1
+        node = nil
+        #expect(weakNode == nil)
+      }
+
+      #expect(weakNode == nil)
     }
 
     #expect(weakNode == nil)


### PR DESCRIPTION
Nested `withGraphTransaction` calls now create savepoints. A successful inner call merges into its parent; a throwing inner call restores its entry snapshot. Only the outermost call publishes, and its rollback also discards successful inner work.

This changes caught-error behavior: setting a value to `1` in the outer scope, then to `2` in an inner scope that throws, now leaves `1` after the outer scope catches the error. Previously it left `2`.

Typed undo history stays inside each `Stored` node. Every affected node is restored or merged before discarded values are destroyed outside node locks; synchronous `deinit` mutations join the parent. Assignment observers remain immediate, and external side effects remain outside rollback. The API signature is unchanged; the obsolete nesting-warning setting is deprecated and has no effect.

`GraphTransactionContext` conforms to `Equatable` using reference identity (`lhs === rhs`). Node-local staging and undo records retain the concrete context directly; completion clears those references and temporary strong participant snapshots.

Coverage includes Observation callback batches, dependency registration, `Computed`, property observers, value lifetime, competing readers/writers, and 23 deep-nesting scenarios: all outcomes at two and three scopes, representative eight-scope outcomes, and an uncaught error unwinding all eight scopes.

Weak-reference assertions verify that transaction contexts are released while their nodes remain alive after each nested outcome and after Observation callback batches with successful and failing child scopes.

Validation on macOS after rebasing onto current `main`:

- `swift test --parallel` — passed (204 StateGraph tests and 10 normalization tests).
- `swift test -c release --filter 'GraphTransactionTests|GraphStoredDidSetTests'` — passed (59 tests, including all 23 deep-nesting scenarios).
- `git diff --check origin/main...HEAD` — passed.
